### PR TITLE
Remove verified redundancies across video-recap skill

### DIFF
--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -16,7 +16,7 @@ description: >
 | 何时读 | 文档 |
 |---|---|
 | **写 narration.json 之前必读** | `references/agent-mode-workflow.md` |
-| 撰写解说词时（风格 / 反幻觉 / 字数公式） | `references/prompt-templates.md` |
+| 撰写解说词时（风格 / 反幻觉 / 字数公式） | `references/agent-mode-workflow.md` |
 | 读写中间 JSON | `references/data-schema.md` |
 | 改 CLI 参数或环境变量 | `references/parameters.md` |
 | 中断恢复 / 局部重跑 | `references/pipeline-resume.md` |
@@ -72,7 +72,7 @@ python3 scripts/video_recap.py <video> --resume work_dir
 python3 scripts/video_recap.py <video> --resume work_dir --burn-subtitles
 ```
 
-⚠️ 改完 narration.json 后如需重配音，删 `tts_segments/`、`.step_tts.done`、`.step_assemble.done` 和 `tts_meta.json`。cut 模式下 CLI 会自动检测 `clip_plan.json` / `narration.json` 是否比剪辑产物更新，并重建映射。
+⚠️ 改完 narration.json 后如需重配音，按 `references/pipeline-resume.md` 清理 TTS/组装缓存再续跑。cut 模式下 CLI 会自动检测 `clip_plan.json` / `narration.json` 是否比剪辑产物更新并重建映射。
 
 ## 自检
 

--- a/skills/video-recap/references/agent-mode-workflow.md
+++ b/skills/video-recap/references/agent-mode-workflow.md
@@ -142,9 +142,4 @@ Verdict: APPROVE | REVISE
 python3 scripts/video_recap.py <video> --resume work_dir
 ```
 
-如果改过已经配音的 `narration.json`，先清理旧 TTS 缓存：
-
-```bash
-rm -rf work_dir/tts_segments/ work_dir/.step_tts.done \
-  work_dir/.step_assemble.done work_dir/tts_meta.json
-```
+如果改过已经配音的 `narration.json`，先清理旧 TTS 缓存再续跑，清理命令见 `references/pipeline-resume.md`（「改解说词后重新配音」一节）。

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -67,9 +67,11 @@
 
 ```json
 [
-  {"start": 2.0, "end": 8.5}
+  {"start": 2.0, "end": 8.5, "duration": 6.5, "has_speech": false}
 ]
 ```
+
+`has_speech` 标记该窗口是否与检测到的 ASR 语音重叠；下游（pipeline / narration）只把 `has_speech=false` 的窗口当作可放解说的安静窗口。
 
 ## timeline_fusion.json
 

--- a/skills/video-recap/scripts/assemble.py
+++ b/skills/video-recap/scripts/assemble.py
@@ -101,10 +101,6 @@ def _wrap_subtitle_text(text, max_chars=20, line_break="\n"):
     return line_break.join(lines)
 
 
-def _wrap_srt_text(text, max_chars=20):
-    return _wrap_subtitle_text(text, max_chars=max_chars, line_break="\n")
-
-
 def _subtitle_entries(narration):
     """Collect subtitle entries from final TTS segment placement."""
     entries = []
@@ -134,7 +130,7 @@ def _generate_srt(narration, work_dir):
         end_ts = _seconds_to_srt_time(entry["end"])
         srt_lines.append(str(idx))
         srt_lines.append(f"{start_ts} --> {end_ts}")
-        srt_lines.append(_wrap_srt_text(entry["text"], max_chars=max_chars))
+        srt_lines.append(_wrap_subtitle_text(entry["text"], max_chars=max_chars))
         srt_lines.append("")
     srt_path = work_dir / "subtitles.srt"
     srt_path.write_text("\n".join(srt_lines), encoding="utf-8")
@@ -458,7 +454,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
 
     for seg in tts_segments:
         wav_path = seg["audio_path"]
-        seg_pause_ms = seg.get("pause_after_ms", CONFIG.get("breath_ms", 600))
+        seg_pause_ms = seg.get("pause_after_ms", CONFIG.get("breath_ms", 250))
 
         if not os.path.exists(wav_path):
             seg["actual_place_start"] = seg["start"]
@@ -494,7 +490,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         tts_rate_offset = seg.get("tts_rate_offset", 0.0)
         tts_dur = seg.get("audio_duration", 0)
 
-        configured_delay = max(0.0, float(CONFIG.get("narration_delay_seconds", 2.0) or 0.0))
+        configured_delay = max(0.0, float(CONFIG.get("narration_delay_seconds", 1.5) or 0.0))
         tail_pad = max(0.0, float(CONFIG.get("narration_tail_pad_seconds", 0.1) or 0.0))
         slot_duration = max(0.0, float(seg["end"]) - float(seg["start"]))
         max_delay = max(0.0, slot_duration - float(tts_dur or 0.0) - tail_pad)
@@ -568,7 +564,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
             actual_start = last_written_end
 
         # fade-in / fade-out（在 overlap 裁剪之后应用，确保正确的音频包络）
-        fade_len = min(int(CONFIG.get("fade_ms", 50) * sample_rate / 1000), write_samples // 4)
+        fade_len = min(int(CONFIG.get("fade_ms", 300) * sample_rate / 1000), write_samples // 4)
         for i in range(fade_len):
             gain = i / fade_len
             s = i * 2

--- a/skills/video-recap/scripts/doctor.py
+++ b/skills/video-recap/scripts/doctor.py
@@ -28,10 +28,6 @@ def _command_path(name: str) -> str | None:
     return shutil.which(name)
 
 
-def _command_exists(name: str) -> bool:
-    return _command_path(name) is not None
-
-
 def _run(cmd: list[str], *, timeout: int = 20) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
 

--- a/skills/video-recap/scripts/edit.py
+++ b/skills/video-recap/scripts/edit.py
@@ -167,11 +167,6 @@ def _clips_for_midpoint(start, end, clips):
     return [clip for clip in clips if clip["source_start"] <= mid <= clip["source_end"]]
 
 
-def _clip_for_midpoint(start, end, clips):
-    matches = _clips_for_midpoint(start, end, clips)
-    return matches[0] if matches else None
-
-
 def map_narration_to_clips(narration, validated_plan, min_duration=0.3):
     """Convert source-time narration segments to edited-output timeline segments."""
     clips = validated_plan["clips"] if isinstance(validated_plan, dict) else validated_plan

--- a/skills/video-recap/scripts/narration.py
+++ b/skills/video-recap/scripts/narration.py
@@ -292,11 +292,11 @@ def _normalise_narration_segment(seg, scenes_analysis=None):
     text = str(seg.get("narration", "")).strip()
     if not text:
         return None
-    pause = seg.get("pause_after_ms", CONFIG.get("breath_ms", 600))
+    pause = seg.get("pause_after_ms", CONFIG.get("breath_ms", 250))
     try:
         pause = int(pause)
     except (TypeError, ValueError):
-        pause = CONFIG.get("breath_ms", 600)
+        pause = CONFIG.get("breath_ms", 250)
     item = {
         "start": round(start, 2),
         "end": round(end, 2),
@@ -402,11 +402,11 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                 errors.append(_lint_issue("error", idx, "invalid_time", "start/end must be numeric"))
                 continue
             text = str(seg.get("narration", "")).strip()
-            pause_raw = seg.get("pause_after_ms", CONFIG.get("breath_ms", 600))
+            pause_raw = seg.get("pause_after_ms", CONFIG.get("breath_ms", 250))
             try:
                 pause = int(pause_raw)
             except (TypeError, ValueError):
-                pause = CONFIG.get("breath_ms", 600)
+                pause = CONFIG.get("breath_ms", 250)
                 warnings.append(_lint_issue(
                     "warning", idx, "invalid_pause",
                     "pause_after_ms is invalid; default will be used",
@@ -550,7 +550,6 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
         "warnings": warnings,
     }
     if work_dir is not None:
-        import json
         Path(work_dir, "narration_lint.json").write_text(
             json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
         )
@@ -697,7 +696,7 @@ def _quiet_overlap_seconds(start, end, quiet_windows):
                 q_end = float(q_end)
         except (TypeError, ValueError):
             continue
-        overlap_seconds += max(0.0, min(float(end), q_end) - max(float(start), q_start))
+        overlap_seconds += _overlap_seconds(start, end, q_start, q_end)
     return overlap_seconds
 
 

--- a/skills/video-recap/scripts/pipeline.py
+++ b/skills/video-recap/scripts/pipeline.py
@@ -771,6 +771,12 @@ def _tail_video_path(video_path, work_dir):
     return video_path
 
 
+def _final_output_path(video_path, work_dir, output_dir):
+    """最终成片路径：指定 output_dir 时放其中，否则放 work_dir 的上级目录。"""
+    base = Path(output_dir) if output_dir else work_dir.parent
+    return base / f"recap_{video_path.stem}.mp4"
+
+
 def _run_cached_tail_step(video_path, work_dir, step, output_dir):
     """Run tts/assemble from existing artifacts without VLM/API prerequisites."""
     if step not in ("tts", "assemble"):
@@ -806,7 +812,7 @@ def _run_cached_tail_step(video_path, work_dir, step, output_dir):
     else:
         _assemble_video_stateful(work_dir, assembly_input, tts_segments, output_path, [tts_meta, assembly_input])
 
-    final_output = Path(output_dir) / f"recap_{video_path.stem}.mp4" if output_dir else work_dir.parent / f"recap_{video_path.stem}.mp4"
+    final_output = _final_output_path(video_path, work_dir, output_dir)
     if final_output != output_path:
         shutil.copy2(str(output_path), str(final_output))
     log(f"步骤 assemble 完成: {final_output}")
@@ -865,14 +871,11 @@ def run_pipeline(video_path, output_dir=None, step=None, style="纪录片",
     log(f"成片模式: {CONFIG.get('edit_mode', 'full')}")
 
     # 如果指定了 step，只执行那一步
+    # 仅含可直接调度的前置步骤；tts/assemble 走 _run_cached_tail_step，script 走 stop_after_script
     steps = {
         "extract": lambda: extract_frames(video_path, work_dir),
         "detect": lambda: detect_scenes(video_path, work_dir, scene_threshold),
         "asr": lambda: transcribe_audio(video_path, work_dir) if not skip_asr else [],
-        "analyze": None,  # 需要前置数据
-        "script": None,   # Agent-authored narration.json / clip_plan.json validation
-        "tts": None,      # 需要前置数据
-        "assemble": None, # 需要前置数据
     }
 
     # 动态 FPS（需要在 step dispatch 之前，--step extract 需要）
@@ -1200,10 +1203,7 @@ def run_pipeline(video_path, output_dir=None, step=None, style="纪录片",
         log(f"[{time.time()-t0:.1f}s] 视频组装完成")
 
     # 复制到输出目录
-    if output_dir:
-        final_output = Path(output_dir) / f"recap_{video_path.stem}.mp4"
-    else:
-        final_output = work_dir.parent / f"recap_{video_path.stem}.mp4"
+    final_output = _final_output_path(video_path, work_dir, output_dir)
     if final_output != output_path:
         shutil.copy2(str(output_path), str(final_output))
 

--- a/skills/video-recap/scripts/tts.py
+++ b/skills/video-recap/scripts/tts.py
@@ -6,7 +6,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from config import CONFIG
-from common import log, mimo_tts_api_call, run_cmd
+from common import log, mimo_tts_api_call, run_cmd, get_video_duration
 from narration import _truncate_at_sentence
 
 SUPPORTED_TTS_ENGINES = {"edge-tts", "mimo-tts"}
@@ -333,16 +333,8 @@ def _tts_edge(text, output_path, rate="+0%", pitch="+0Hz"):
 
 
 def _get_audio_duration(audio_path):
-    """获取音频文件时长"""
-    cmd = ["ffprobe", "-v", "quiet", "-show_entries", "format=duration",
-           "-of", "csv=p=0", str(audio_path)]
-    result = run_cmd(cmd)
-    if result.returncode == 0 and result.stdout.strip():
-        try:
-            return float(result.stdout.strip())
-        except ValueError:
-            pass
-    return 0.0
+    """获取音频文件时长（复用 common.get_video_duration 的 ffprobe 探测）。"""
+    return get_video_duration(audio_path)
 
 
 # ── Step 7: 视频组装 ─────────────────────────────────────────────────

--- a/skills/video-recap/scripts/vlm.py
+++ b/skills/video-recap/scripts/vlm.py
@@ -279,10 +279,15 @@ def _mimo_chunk_prompt(chunk):
     )
 
 
+def _mimo_video_model():
+    """MiMo 视频理解使用的模型：优先 mimo_video_model，回退 mimo_model，再回退 vlm_model。"""
+    return CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG["vlm_model"]
+
+
 def mimo_video_settings_fingerprint():
     """Return non-secret MiMo video-overview settings that affect generated content."""
     return {
-        "model": CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG.get("vlm_model"),
+        "model": _mimo_video_model(),
         "mimo_video_fps": CONFIG.get("mimo_video_fps", 2.0),
         "mimo_media_resolution": CONFIG.get("mimo_media_resolution", "default"),
         "mimo_video_chunk_max_seconds": CONFIG.get("mimo_video_chunk_max_seconds", 20.0),
@@ -346,7 +351,7 @@ def _analyze_mimo_video_chunk(chunk_path, chunk):
         },
         {"type": "text", "text": _mimo_chunk_prompt(chunk)},
     ]
-    model = CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG["vlm_model"]
+    model = _mimo_video_model()
     payload = {
         "model": model,
         "messages": [{"role": "user", "content": content_parts}],
@@ -420,7 +425,7 @@ def analyze_video_overview(video_path, work_dir, scenes=None):
     )
 
     overview = {
-        "model": CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG["vlm_model"],
+        "model": _mimo_video_model(),
         "content": content,
         "chunks": chunk_results,
         "chunk_count": len(chunk_results),


### PR DESCRIPTION
## Summary

Audit-driven cleanup of the `video-recap` skill: a multi-agent scan → adversarial verification pass, then **re-checked against the repo-root `tests/`** (the audit's scoped search had missed them, which caused a false dead-code positive). Only confirmed-safe findings were applied.

**Net −20 lines across 10 files. `make test` 134/134 passing, pyflakes clean.**

## Dead code removed
- `edit._clip_for_midpoint` — no callers (logic inlined in `map_narration_to_clips`)
- `doctor._command_exists` — all sites use `_command_path` directly
- 4 never-indexed `None` entries in the pipeline step-dispatch dict
- redundant local `import json` in `narration.lint_narration`

## Duplicate logic consolidated
- `tts._get_audio_duration` now delegates to `common.get_video_duration` (kept as a thin wrapper so tests that monkeypatch it still work)
- `assemble._wrap_srt_text` inlined into `_generate_srt` (no-op over `_wrap_subtitle_text`)
- new `vlm._mimo_video_model()` — model fallback chain was copy-pasted 3× and inconsistently; now the cache fingerprint and the actual API payload cannot drift
- `_quiet_overlap_seconds` calls `_overlap_seconds` instead of re-inlining the formula
- new `pipeline._final_output_path()` shared by the cached-tail and main paths

## Inconsistent constants unified (to match `config.py`)
`breath_ms` 600→250, `narration_delay_seconds` 2.0→1.5, `fade_ms` 50→300. Inert today (keys always present) but the divergent literals were maintenance traps.

## Docs
- `SKILL.md`: repoint the 风格/反幻觉/字数公式 reference row from `prompt-templates.md` (VLM-only) → `agent-mode-workflow.md`, which actually carries those rules
- `data-schema.md`: document the load-bearing `has_speech` (+`duration`) fields on `silence_periods.json`
- De-duplicate the TTS-cache cleanup recipe — `SKILL.md` and `agent-mode-workflow.md` now point to `pipeline-resume.md`

## Deliberately not changed
- `step_cache_key` — production-unused but a pinned contract in `tests/test_pure.py`
- asr/detect ffmpeg extraction — different error semantics (`raise` vs atomic-move + graceful `return []`); merging would risk a behavior change
- `parameters.md` ↔ `internal-config.md` ~20-key overlap — left as a follow-up (large doc rewrite)
- Intentional back-compat shims (`.step_*.done` markers, assemble-meta legacy fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)