### PR TITLE
Multi-track audio: gap-fill ducking + BGM; snappier defaults; ruff/致谢 housekeeping

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -153,7 +153,6 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 ## Acknowledgements
 
-- [Xiaomi MiMo](https://platform.xiaomimimo.com): ASR (`mimo-v2.5-asr`), VLM (`mimo-v2.5`), and TTS (`mimo-v2.5-tts`)
 - [linux.do](https://linux.do)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 ## 致谢
 
-- [小米 MiMo](https://platform.xiaomimimo.com)：ASR（`mimo-v2.5-asr`）、VLM（`mimo-v2.5`）、TTS（`mimo-v2.5-tts`）
 - [linux.do](https://linux.do)
 
 ## 许可

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
+[tool.ruff.lint.per-file-ignores]
 # Each skill ships its own lib.py, so tests prepend their skill's scripts dir to
 # sys.path before importing — that legitimately puts imports after a statement (E402).
-[lint.per-file-ignores]
 "tests/**" = ["E402"]

--- a/skills/video-assemble/SKILL.md
+++ b/skills/video-assemble/SKILL.md
@@ -37,8 +37,10 @@ python3 scripts/assemble.py <video> --work-dir <work_dir> \
 - `subtitles.srt` — narration subtitles; `subtitles.ass` when `--burn-subtitles` is used.
 
 ## Notes
+- Audio is mixed as tracks (like a cut-software timeline): the original audio, an optional BGM bed, and the narration.
 - Subtitle look: `SUBTITLE_FONT_SIZE`, `SUBTITLE_MARGIN_V`, `SUBTITLE_MAX_CHARS`, etc.
-- Ducking / loudness: `DUCKING_MODE`, `ZONE_DUCKING_VOLUME`, `FINAL_LOUDNORM`, `TARGET_LUFS`.
+- Ducking / loudness: the original swells to `IDLE_ORIG_VOLUME` in the gaps and ducks to `SPEECH_DUCKING_VOLUME` under narration (`DUCK_FADE_SECONDS` smooths the transition); also `DUCKING_MODE`, `ZONE_DUCKING_VOLUME`, `FINAL_LOUDNORM`, `TARGET_LUFS`.
+- BGM (optional): set `BGM_PATH` to any audio file; it loops to length and ducks under narration (`BGM_VOLUME` / `BGM_DUCKING_VOLUME`).
 - Burning subtitles requires an ffmpeg with `subtitles`/libass support.
 
 ## What this skill does NOT do

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -275,94 +275,117 @@ def _seg_place_window(seg):
     return s, e
 
 
-def _amix_tail(narr_vol):
-    """Original [orig] + boosted narration [narr] -> [aout]; shared by every mode."""
-    return (
-        f"[1:a]volume={narr_vol},aresample=48000[narr];"
-        "[orig][narr]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
-    )
+def _amix_tail(narr_vol, bgm_chain=""):
+    """Mix the prepared original track [orig] (+ optional BGM bed) with the boosted
+    narration [narr] into [aout]. bgm_chain, when given, defines [bgm] from input [2:a]."""
+    narr = f"[1:a]volume={narr_vol},aresample=48000[narr];"
+    if bgm_chain:
+        return bgm_chain + narr + "[orig][bgm][narr]amix=inputs=3:duration=first:dropout_transition=0:normalize=0[aout]"
+    return narr + "[orig][narr]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
 
 
-def _build_audio_filter_complex(tts_segments):
-    """Build the ffmpeg filter_complex that ducks the original audio under narration.
+def _duck_ramp(s, e, fade):
+    """A 0→1 trapezoid over [s,e] with `fade`-second ramps at each edge (no clicks)."""
+    return f"min(1,max(0,min(t-{s:.2f},{e:.2f}-t)/{fade:.2f}))"
 
-    CONFIG["ducking_mode"] (default "fixed") selects the strategy:
-      - sidechaincompress: classic auto-duck keyed off the narration track.
-      - none: no ducking; just boost narration and mix.
-      - fixed (the default): a per-segment volume envelope on the original track,
-        whose shape is chosen by the beats' overlaps_speech flags — lower under
-        speech-overlapping beats, lower still under beats in quiet windows,
-        otherwise an idle level. When every beat is quiet, a smooth trapezoid
-        fade is used instead of hard switches; with no overlap info at all it
-        falls back to a constant level.
-    The narration's placed timing comes from actual_place_start/end.
+
+def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade):
+    """Per-beat ducking automation for the ORIGINAL track.
+
+    Holds the original at `idle` in the gaps (no narration) so the source audio keeps
+    the recap from going dead-air between sentences, and ramps it down under each
+    placed narration window — to speech_vol where the beat overlaps source dialogue,
+    quiet_vol where it sits in a quiet window. Returns a volume= expression, or None
+    when no beat carries placement info (caller falls back to a constant)."""
+    terms = []
+    for seg in tts_segments:
+        if not isinstance(seg, dict):
+            continue
+        s, e = _seg_place_window(seg)
+        if e - s <= 0:
+            continue
+        level = speech_vol if seg.get("overlaps_speech", True) else quiet_vol
+        terms.append(f"+({level - idle:.3f})*{_duck_ramp(s, e, fade)}")
+    if not terms:
+        return None
+    return f"max(0,min(1,{idle}{''.join(terms)}))"
+
+
+def _bgm_envelope(tts_segments, base, duck, fade):
+    """Per-beat ducking automation for the BGM track: hold the bed at `base`, dip to
+    `duck` under every narration window so the voice stays clear. None if no beats."""
+    terms = []
+    for seg in tts_segments:
+        if not isinstance(seg, dict):
+            continue
+        s, e = _seg_place_window(seg)
+        if e - s <= 0:
+            continue
+        terms.append(f"+({duck - base:.3f})*{_duck_ramp(s, e, fade)}")
+    if not terms:
+        return None
+    return f"max(0,min(1,{base}{''.join(terms)}))"
+
+
+def _build_audio_filter_complex(tts_segments, has_bgm=False):
+    """Compose the audio tracks into [aout], like a cut-software timeline.
+
+    Tracks:
+      - original (input [0:a], the video's own audio): ducked under each narration
+        window by a per-beat volume envelope, but held up at `idle_orig_volume` in
+        the gaps so the recap never drops to dead air between sentences.
+      - bgm (input [2:a], optional): a looped music bed, gently ducked under narration.
+      - narration (input [1:a]): the TTS, boosted and laid on top.
+    CONFIG["ducking_mode"] (default "fixed") selects the original-track strategy:
+    fixed = the gap-fill envelope above; sidechaincompress = auto-duck keyed off the
+    narration; none = no ducking. Placement comes from actual_place_start/end.
     """
     ducking_mode = CONFIG.get("ducking_mode", "fixed")
     narr_vol = CONFIG.get("ducking_narr_weight", 1.5)
-    has_overlaps = any(seg.get("overlaps_speech") for seg in tts_segments if isinstance(seg, dict))
-    has_quiet = any(not seg.get("overlaps_speech", True) for seg in tts_segments if isinstance(seg, dict))
+    fade = CONFIG.get("duck_fade_seconds", 0.25)
+
+    # BGM bed (input [2:a]): ducked under each narration window when present.
+    bgm_chain = ""
+    if has_bgm:
+        base = CONFIG.get("bgm_volume", 0.18)
+        bgm_expr = _bgm_envelope(tts_segments, base, CONFIG.get("bgm_ducking_volume", 0.10), fade)
+        if bgm_expr:
+            bgm_chain = f"[2:a]volume='{bgm_expr}':eval=frame,aresample=48000[bgm];"
+        else:
+            bgm_chain = f"[2:a]volume={base},aresample=48000[bgm];"
 
     if ducking_mode == "sidechaincompress":
-        return (
-            "[0:a]aresample=48000[orig];"
-            "[1:a]aresample=48000[narr];"
-            f"[orig][narr]sidechaincompress="
+        # The narration keys the compressor; split it so it can also be mixed in.
+        head = (
+            "[0:a]aresample=48000[o0];"
+            "[1:a]aresample=48000,asplit=2[sckey][scnarr];"
+            f"[o0][sckey]sidechaincompress="
             f"threshold={CONFIG['ducking_threshold']}:ratio={CONFIG['ducking_ratio']}"
             f":attack={CONFIG['ducking_attack']}:release={CONFIG['ducking_release']}"
-            f":knee=2.5:makeup={CONFIG['ducking_makeup']}:level_sc={CONFIG['ducking_level_sc']}"
-            f"[ducked];"
-            f"[ducked][narr]amix=inputs=2:duration=first:dropout_transition=0"
-            f":weights=1 {CONFIG['ducking_narr_weight']}:normalize=0[aout]"
+            f":knee=2.5:makeup={CONFIG['ducking_makeup']}:level_sc={CONFIG['ducking_level_sc']}[orig];"
         )
+        narr = f"[scnarr]volume={narr_vol}[narr];"
+        if bgm_chain:
+            return head + bgm_chain + narr + "[orig][bgm][narr]amix=inputs=3:duration=first:dropout_transition=0:normalize=0[aout]"
+        return head + narr + "[orig][narr]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
 
     if ducking_mode == "none":
-        return "[0:a]aresample=48000[orig];" + _amix_tail(narr_vol)
+        return "[0:a]aresample=48000[orig];" + _amix_tail(narr_vol, bgm_chain)
 
+    # fixed (default): gap-fill ducking envelope on the original track.
+    idle = CONFIG.get("idle_orig_volume", 0.85)
+    speech_vol = CONFIG.get("speech_ducking_volume", 0.2)
     quiet_vol = CONFIG.get("zone_ducking_volume", 0.12)
-
-    if has_overlaps and has_quiet:
-        # Per-segment volume envelope. between(t,s,e) indicators select beats;
-        # commas inside the expr are fine here because the whole volume value is
-        # single-quoted, so ffmpeg does not read them as filter separators.
-        speech_vol = CONFIG.get("speech_ducking_volume", 0.2)
-        default_vol = CONFIG.get("ducking_orig_volume", 0.5)
-        overlap_exprs, quiet_exprs = [], []
-        for seg in tts_segments:
-            if not isinstance(seg, dict):
-                continue
-            s, e = _seg_place_window(seg)
-            ind = f"if(between(t,{s:.2f},{e:.2f}),1,0)"
-            (overlap_exprs if seg.get("overlaps_speech") else quiet_exprs).append(ind)
-        vol_expr = f"{default_vol}"
-        if overlap_exprs:
-            vol_expr += f"+{speech_vol-default_vol}*({'+'.join(overlap_exprs)})"
-        if quiet_exprs:
-            vol_expr += f"+{quiet_vol-default_vol}*({'+'.join(quiet_exprs)})"
-        vol_expr = f"max(0,min(1,{vol_expr}))"
-        log(f"动态 ducking: 语音重叠段={len(overlap_exprs)}, 安静段={len(quiet_exprs)}")
-        return f"[0:a]volume='{vol_expr}':eval=frame,aresample=48000[orig];" + _amix_tail(narr_vol)
-
-    if has_quiet and not has_overlaps:
-        # All beats in quiet windows: smooth trapezoid fade to quiet_vol under each
-        # beat, full original elsewhere.
-        default_vol = 1.0
-        fade = CONFIG.get("zone_fade_seconds", 0.5)
-        exprs = []
-        for seg in tts_segments:
-            if not isinstance(seg, dict):
-                continue
-            s, e = _seg_place_window(seg)
-            exprs.append(f"min(1,max(0,min(t-{s:.2f},{e:.2f}-t)/{fade:.1f}))")
-        vol_expr = f"{default_vol}"
-        if exprs:
-            vol_expr += f"+{quiet_vol - default_vol}*({'+'.join(exprs)})"
-        vol_expr = f"max(0,min(1,{vol_expr}))"
-        log(f"zone ducking: 解说时原声={quiet_vol}, 非解说时原声={default_vol}")
-        return f"[0:a]volume='{vol_expr}':eval=frame,aresample=48000[orig];" + _amix_tail(narr_vol)
-
-    # fixed (no per-segment overlap info): hold the original at a constant level.
-    orig_vol = CONFIG.get("ducking_orig_volume", 0.5)
-    return f"[0:a]volume={orig_vol},aresample=48000[orig];" + _amix_tail(narr_vol)
+    expr = _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade)
+    if expr:
+        n_overlap = sum(1 for s in tts_segments if isinstance(s, dict) and s.get("overlaps_speech", True))
+        n_quiet = sum(1 for s in tts_segments if isinstance(s, dict) and not s.get("overlaps_speech", True))
+        log(f"gap-fill ducking: 间隙原声={idle}, 对白段={speech_vol}({n_overlap}), 安静段={quiet_vol}({n_quiet})")
+        orig = f"[0:a]volume='{expr}':eval=frame,aresample=48000[orig];"
+    else:
+        # No placement info at all: hold the original at a constant level.
+        orig = f"[0:a]volume={CONFIG.get('ducking_orig_volume', 0.3)},aresample=48000[orig];"
+    return orig + _amix_tail(narr_vol, bgm_chain)
 
 
 def assemble_video(input_video, tts_segments, work_dir, output_path):
@@ -387,8 +410,16 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
         ass_path = _generate_ass(tts_segments, work_dir)
         log(f"压制字幕文件: {ass_path}")
 
-    # 混合原始音频 + 解说音频
-    filter_complex = _build_audio_filter_complex(tts_segments)
+    # 可选 BGM：作为一条独立音轨（input [2:a]）混入，旁白处自动压低
+    bgm_path = CONFIG.get("bgm_path", "")
+    has_bgm = bool(bgm_path) and os.path.exists(bgm_path)
+    if bgm_path and not has_bgm:
+        log(f"  ⚠️ BGM 文件不存在，跳过: {bgm_path}")
+    elif has_bgm:
+        log(f"BGM 铺底: {bgm_path} (音量 {CONFIG.get('bgm_volume', 0.18)}，旁白时 {CONFIG.get('bgm_ducking_volume', 0.10)})")
+
+    # 混合原始音频 + 解说音频（+ 可选 BGM）
+    filter_complex = _build_audio_filter_complex(tts_segments, has_bgm)
 
     # 对于超长 volume 表达式（多段解说），使用 -filter_complex_script 避免命令行溢出
     # 末端整体响度归一：ducking 只管相对平衡，这一步统一成片绝对响度
@@ -399,6 +430,10 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
         aout_label = "[aoutln]"
         log(f"成片响度归一: {final_ln}")
 
+    # BGM is input [2:a]; -stream_loop -1 loops it to cover the whole timeline (amix
+    # duration=first + -t trim it back to the video length).
+    bgm_input = ["-stream_loop", "-1", "-i", str(bgm_path)] if has_bgm else []
+
     filter_complex_bytes = filter_complex.encode('utf-8')
     if len(filter_complex_bytes) > 8000:
         fc_script = Path(work_dir) / ".filter_complex.txt"
@@ -408,6 +443,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             "ffmpeg", "-y",
             "-i", str(input_video),
             "-i", str(narration_wav),
+            *bgm_input,
             "-filter_complex_script", str(fc_script),
             "-map", "0:v", "-map", aout_label,
         ]
@@ -416,6 +452,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             "ffmpeg", "-y",
             "-i", str(input_video),
             "-i", str(narration_wav),
+            *bgm_input,
             "-filter_complex", filter_complex,
             "-map", "0:v", "-map", aout_label,
         ]

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -198,11 +198,16 @@ CONFIG = {
     "ducking_level_sc": 2.0,
     "ducking_makeup": 1.2,
     "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.5, minimum=0.0),  # 解说时原声基准音量
+    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "narration_speed": env_float("NARRATION_SPEED", 1.0, minimum=0.5),  # 解说整体提速(atempo)，1.1~1.2 更适合短视频
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", False),  # 遮挡原片烧录字幕
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
+    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
+    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
+    "narration_speed": env_float("NARRATION_SPEED", 1.2, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -16,9 +16,11 @@ bundle ships no root `CLAUDE.md` (so it never collides with your project/global 
 | TTS model | `MIMO_TTS_MODEL` | `mimo-v2.5-tts` | the only TTS engine |
 | MiMo voice | `MIMO_TTS_VOICE` / `--mimo-tts-voice` | `冰糖` | |
 | Narration density | `TARGET_SEGMENTS_PER_MINUTE` | `9.6` | min `MIN_SEGMENTS_PER_MINUTE=6.24` |
-| Narration speed | `NARRATION_SPEED` | `1.0` | global atempo on the voiceover; `1.1`–`1.2` is snappier for short-form |
-| Mask source subs | `MASK_SOURCE_SUBTITLES` / `SOURCE_SUBTITLE_MASK_RATIO` | off / `0.14` | cover burned-in source subtitles (bottom band) so only the recap's subtitles show |
-| Ducking level | `DUCKING_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `0.5` / `0.2` | lower = original audio quieter under narration |
+| Narration speed | `NARRATION_SPEED` | `1.2` | global atempo on the voiceover; default leans snappy for short-form, set `1.0` for long-form/documentary |
+| Mask source subs | `MASK_SOURCE_SUBTITLES` / `SOURCE_SUBTITLE_MASK_RATIO` | on / `0.14` | covers burned-in source subtitles (bottom band) so only the recap's subtitles show; set `MASK_SOURCE_SUBTITLES=false` for sources without hardcoded subs |
+| Original ducking | `IDLE_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `0.85` / `0.2` | the original swells to `IDLE` in the gaps between sentences (so the recap never goes dead-air / choppy) and ducks to `SPEECH` under narration. `DUCKING_ORIG_VOLUME` (`0.3`) is only the fallback when beats carry no placement info |
+| Duck fade | `DUCK_FADE_SECONDS` | `0.25` | ramp time for each duck transition, so the original fades down/up without clicks |
+| Background music | `BGM_PATH` / `BGM_VOLUME` / `BGM_DUCKING_VOLUME` | off / `0.18` / `0.10` | optional looped music bed mixed as its own track; point `BGM_PATH` at any audio file. It ducks to `BGM_DUCKING_VOLUME` under narration |
 | Final loudness | `FINAL_LOUDNORM` / `TARGET_LUFS` | `true` / `-14` | end-of-pipeline normalize |
 | Style | `--style` | `纪录片` | |
 | Edit mode | `EDIT_MODE` / `--edit-mode` | `full` | `full` or `cut` |

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -197,11 +197,16 @@ CONFIG = {
     "ducking_level_sc": 2.0,
     "ducking_makeup": 1.2,
     "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.5, minimum=0.0),  # 解说时原声基准音量
+    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "narration_speed": env_float("NARRATION_SPEED", 1.0, minimum=0.5),  # 解说整体提速(atempo)，1.1~1.2 更适合短视频
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", False),  # 遮挡原片烧录字幕
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
+    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
+    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
+    "narration_speed": env_float("NARRATION_SPEED", 1.2, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -207,11 +207,16 @@ CONFIG = {
     "ducking_level_sc": 2.0,
     "ducking_makeup": 1.2,
     "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.5, minimum=0.0),  # 解说时原声基准音量
+    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "narration_speed": env_float("NARRATION_SPEED", 1.0, minimum=0.5),  # 解说整体提速(atempo)，1.1~1.2 更适合短视频
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", False),  # 遮挡原片烧录字幕
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
+    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
+    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
+    "narration_speed": env_float("NARRATION_SPEED", 1.2, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -207,11 +207,16 @@ CONFIG = {
     "ducking_level_sc": 2.0,
     "ducking_makeup": 1.2,
     "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.5, minimum=0.0),  # 解说时原声基准音量
+    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "narration_speed": env_float("NARRATION_SPEED", 1.0, minimum=0.5),  # 解说整体提速(atempo)，1.1~1.2 更适合短视频
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", False),  # 遮挡原片烧录字幕
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
+    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
+    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
+    "narration_speed": env_float("NARRATION_SPEED", 1.2, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -207,11 +207,16 @@ CONFIG = {
     "ducking_level_sc": 2.0,
     "ducking_makeup": 1.2,
     "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.5, minimum=0.0),  # 解说时原声基准音量
+    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "narration_speed": env_float("NARRATION_SPEED", 1.0, minimum=0.5),  # 解说整体提速(atempo)，1.1~1.2 更适合短视频
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", False),  # 遮挡原片烧录字幕
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
+    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
+    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
+    "narration_speed": env_float("NARRATION_SPEED", 1.2, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -151,6 +151,7 @@ def test_assemble_video_burns_ass_subtitles(monkeypatch, tmp_path):
         return CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setitem(CONFIG, "burn_subtitles", True)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)  # isolate burn behavior from the mask default
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
     monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
     monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
@@ -187,6 +188,7 @@ def test_assemble_video_without_burn_keeps_video_copy(monkeypatch, tmp_path):
 
     monkeypatch.setitem(CONFIG, "burn_subtitles", False)
     monkeypatch.setitem(CONFIG, "force_video_reencode", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)  # nothing should force a re-encode here
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
     monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
     monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
@@ -206,42 +208,104 @@ def test_assemble_video_without_burn_keeps_video_copy(monkeypatch, tmp_path):
     assert ffmpeg_cmd[ffmpeg_cmd.index("-c:v") + 1] == "copy"
 
 
-def test_build_audio_filter_complex_dynamic_envelope_default(monkeypatch):
+def test_assemble_video_masks_source_subs_by_default(monkeypatch, tmp_path):
+    # mask_source_subtitles defaults to True now: even with burn off, the bottom
+    # band is drawn, which forces a video re-encode (no -c:v copy).
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"video")
+    output = tmp_path / "output.mp4"
+    commands = []
+
+    def fake_run_cmd(cmd):
+        commands.append(cmd)
+        output.write_bytes(b"mp4")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "force_video_reencode", False)
+    # mask_source_subtitles left at its default (True) on purpose
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
+    monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    assemble_video(video, [{
+        "start": 0.0,
+        "end": 3.0,
+        "narration": "默认遮挡原字幕。",
+        "audio_path": str(tmp_path / "narr.wav"),
+        "audio_duration": 1.0,
+    }], tmp_path, output)
+
+    ffmpeg_cmd = commands[-1]
+    assert "-vf" in ffmpeg_cmd
+    assert any("drawbox=" in str(arg) for arg in ffmpeg_cmd)
+    assert ffmpeg_cmd[ffmpeg_cmd.index("-c:v") + 1] == "libx264"
+
+
+def test_build_audio_filter_complex_gap_fill_envelope(monkeypatch):
     monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
-    monkeypatch.setitem(CONFIG, "ducking_orig_volume", 0.5)
+    monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
     monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
     monkeypatch.setitem(CONFIG, "zone_ducking_volume", 0.12)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
     fc = _build_audio_filter_complex([
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
         {"actual_place_start": 5.0, "actual_place_end": 7.0, "overlaps_speech": False},
     ])
-    assert "volume='max(0,min(1," in fc  # per-segment envelope
+    assert "volume='max(0,min(1,0.85" in fc          # idle baseline holds the original up in the gaps
     assert "eval=frame" in fc
-    assert "between(t,0.00,2.00)" in fc
-    assert "between(t,5.00,7.00)" in fc
+    assert "min(t-0.00,2.00-t)/0.25" in fc            # faded duck under the dialogue-overlap beat
+    assert "min(t-5.00,7.00-t)/0.25" in fc            # faded duck under the quiet-window beat
+    assert "(-0.650)" in fc                           # 0.85 -> 0.20 under dialogue
+    assert "(-0.730)" in fc                           # 0.85 -> 0.12 in quiet window
     assert fc.endswith("[aout]")
 
 
-def test_build_audio_filter_complex_fixed_when_all_overlap(monkeypatch):
+def test_build_audio_filter_complex_all_overlap_still_fills_gaps(monkeypatch):
+    # Regression: all-overlap beats used to fall back to a constant duck, leaving the
+    # original quiet across the whole video (dead air between sentences). Now the
+    # original swells back to idle in the gaps and only ducks under each beat.
     monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
-    monkeypatch.setitem(CONFIG, "ducking_orig_volume", 0.5)
+    monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
+    monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
     fc = _build_audio_filter_complex([
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
     ])
-    assert "volume=0.5,aresample=48000[orig]" in fc  # constant, not an envelope
-    assert "eval=frame" not in fc
+    assert "volume='max(0,min(1,0.85" in fc           # NOT a constant; idle baseline present
+    assert "min(t-0.00,2.00-t)/0.25" in fc            # ducks only under the narration window
+    assert "eval=frame" in fc
     assert fc.endswith("[aout]")
 
 
-def test_build_audio_filter_complex_trapezoid_when_all_quiet(monkeypatch):
+def test_build_audio_filter_complex_all_quiet_ducks_to_zone(monkeypatch):
     monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
     monkeypatch.setitem(CONFIG, "zone_ducking_volume", 0.12)
-    monkeypatch.setitem(CONFIG, "zone_fade_seconds", 0.5)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
     fc = _build_audio_filter_complex([
         {"actual_place_start": 1.0, "actual_place_end": 4.0, "overlaps_speech": False},
     ])
-    assert "min(t-1.00,4.00-t)/0.5" in fc  # smooth trapezoid fade
+    assert "min(t-1.00,4.00-t)/0.25" in fc            # smooth fade
+    assert "(-0.730)" in fc                           # 0.85 -> 0.12
     assert "eval=frame" in fc
+
+
+def test_build_audio_filter_complex_bgm_adds_third_track(monkeypatch):
+    monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(CONFIG, "bgm_volume", 0.18)
+    monkeypatch.setitem(CONFIG, "bgm_ducking_volume", 0.10)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    segs = [{"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True}]
+    fc = _build_audio_filter_complex(segs, has_bgm=True)
+    assert "[2:a]volume='" in fc                      # BGM bed from input 2, ducked under narration
+    assert "[bgm]" in fc
+    assert "amix=inputs=3" in fc
+    assert fc.endswith("[aout]")
+    # default (no BGM) stays a two-track mix with no third input referenced
+    fc2 = _build_audio_filter_complex(segs, has_bgm=False)
+    assert "amix=inputs=2" in fc2
+    assert "[2:a]" not in fc2
 
 
 def test_build_audio_filter_complex_explicit_modes(monkeypatch):


### PR DESCRIPTION
## Summary
Mixes the recap's audio as explicit tracks — original / optional BGM / narration — like a cut-tool's audio lanes, and tunes the short-form defaults. Plus small housekeeping.

### Audio (assemble)
- **Gap-fill ducking** — the original audio now swells to `IDLE_ORIG_VOLUME` (0.85) in the gaps between sentences and ducks to `SPEECH_DUCKING_VOLUME` (0.2) under each placed narration window, with `DUCK_FADE_SECONDS` ramps. Fixes the choppy "顿挫感": all-overlap beats used to fall back to a *constant* duck, leaving ~53% of the timeline as near-silent dead air. After the fix a gap window measured **−16.3 dB** (fuller than the speech windows).
- **BGM** — `BGM_PATH` adds a looped (`-stream_loop -1`), auto-ducked music bed as input `[2:a]` (`BGM_VOLUME` / `BGM_DUCKING_VOLUME`); no-op when unset.

### Defaults (short-form friendly)
- `NARRATION_SPEED` 1.0 → **1.2**
- `MASK_SOURCE_SUBTITLES` off → **on**
- `DUCKING_ORIG_VOLUME` 0.5 → **0.3** (now only the no-placement fallback)

### Housekeeping
- `ruff.toml` removed from repo root → config moved into `pyproject.toml`
- Dropped the 小米 MiMo line from README 致谢 / Acknowledgements

## Verification
- 85 tests pass across all skill groups (`scripts/test.py`); ruff clean
- understanding/script `lib.py` stay byte-identical
- Demo re-rendered (1280×720, 315s, −14.3 LUFS) with gap-fill + BGM + 1.3x narration

🤖 Generated with [Claude Code](https://claude.com/claude-code)