### PR TITLE
Release prep v0.1.0: tighten READMEs, lift 剪映 demo, CI on all PRs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "video-recap-skills",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Turn any video into a Chinese-narration recap on ffmpeg + one Xiaomi MiMo API key: understanding (ASR + VLM) -> narration -> cut -> voiceover -> assemble. A bundle of independent skills + a thin orchestrator. Runs on macOS, Linux, and Windows.",
   "author": "PiteChen"
 }

--- a/.github/workflows/skill-validate.yml
+++ b/.github/workflows/skill-validate.yml
@@ -1,11 +1,8 @@
 name: Skill Validate
 on:
+  # Run on every PR so the required status checks always report — a path filter
+  # here would let docs-only PRs stall forever under branch protection.
   pull_request:
-    paths:
-      - 'skills/**'
-      - 'tests/**'
-      - '.claude-plugin/**'
-      - 'scripts/**'
 
 jobs:
   validate:

--- a/README.en.md
+++ b/README.en.md
@@ -8,37 +8,89 @@
 
 [中文](README.md) · English
 
-A Claude Code plugin that turns a video into a Chinese-narration recap. One pipeline runs background research, ASR + VLM scene understanding, agent-written narration, TTS voiceover, subtitles, and audio mixing, built from a set of small, independent skills. All it needs to run is ffmpeg and one Xiaomi MiMo API key.
+**Turn any video into a Chinese-narration recap — from one sentence inside Claude Code.** All it needs locally is `ffmpeg` and one Xiaomi MiMo API key. No GPU, no model downloads.
 
 ## Demo
 
 https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff
 
+Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand — original clips, narration, BGM, and subtitles each on their own track, with the ducking as editable volume keyframes:
+
+![Exported 剪映 draft: original clips, narration, BGM, and subtitles, each independently editable](docs/jianying-export.png)
+
 ## What is it?
 
-`video-recap-skills` lets an agent turn an existing video into a short narrated recap. It is five independent skills plus a thin orchestrator: each skill owns one stage, they share no code, and they pass results to each other only as JSON/MP4 files in a shared `work_dir`. The agent writes the narration; the scripts do the deterministic media work (cutting, voicing, mixing).
-
-The whole pipeline runs on ffmpeg and a single [Xiaomi MiMo](https://platform.xiaomimimo.com) API key: speech-to-text, vision understanding, and text-to-speech all go through MiMo. There is no GPU to manage, nothing to download, and no extra service to run, on macOS, Linux, or Windows.
+A Claude Code plugin: five small, independent skills plus a thin orchestrator. Each owns one stage and they pass results only as JSON/MP4 files in a shared `work_dir`. **The scripts do the deterministic media work (cutting, voicing, mixing); the agent writes the narration.**
 
 ```mermaid
-flowchart TD
-    research["Story research<br/>background_research.json"] --> understand
-    video(["Input video"]) --> understand["video-understanding<br/>scenes · ASR · VLM · brief"]
-    understand --> script["video-script<br/>agent writes narration.json"]
-    script --> voiceover["video-voiceover<br/>MiMo TTS"]
-    voiceover --> assemble["video-assemble<br/>mux · duck · subtitles"]
-    assemble --> output(["Recap video"])
-    script -. cut mode .-> cut["video-cut"] -.-> voiceover
-
+flowchart LR
+    research["Story research"] --> understand
+    video(["Video"]) --> understand["Understand<br/>scenes·ASR·VLM"] --> script["Script<br/>agent"] --> voiceover["Voiceover<br/>MiMo TTS"] --> assemble["Assemble<br/>mux·subtitles"] --> output(["Recap"])
+    script -. cut mode .-> cut["Cut"] -.-> voiceover
     classDef io fill:#eef6ff,stroke:#4f86c6,color:#1f2937;
     classDef opt fill:#f3f4f6,stroke:#9ca3af,color:#374151;
     class video,output io;
     class research,cut opt;
 ```
 
+## Why use it?
+
+- **One key, runs anywhere.** ASR, VLM, and TTS all go through [Xiaomi MiMo](https://platform.xiaomimimo.com); the only local dependency is `ffmpeg` — no GPU, no model files, no extra service, on macOS / Linux / Windows.
+- **Research before analysis.** Put the plot and characters into `background_research.json` first, and the VLM names people on screen instead of labelling everyone "黑衣男子".
+- **Original audio survives, dynamic mix.** Narration is mixed over a ducked original; between sentences the original and BGM swell back up so there's no dead air.
+- **Cut and review.** `--edit-mode cut` turns a long video into a shorter narrated edit; an LLM review pass flags hallucinations, weak hooks, and a missing throughline before TTS.
+- **Keep editing in 剪映.** Optionally export a multi-track 剪映 draft; the core render only needs `ffmpeg` and never depends on 剪映.
+
+## Installation
+
+**① Install the plugin** — ask Claude Code:
+
+```text
+Install this plugin: https://github.com/worldwonderer/video-recap-skills
+```
+
+**② Install ffmpeg** (the pipeline needs no `pip install` — just the standard library and `ffmpeg` on `PATH`, Python 3.10+):
+
+```bash
+brew install ffmpeg                        # macOS
+sudo apt install ffmpeg                     # Debian/Ubuntu
+choco install ffmpeg                        # Windows (or scoop / winget install ffmpeg)
+```
+
+**③ Set your MiMo API key** (one key powers ASR / VLM / TTS — keep it in an env var, never in the repo):
+
+```bash
+export MIMO_API_KEY=your-mimo-key
+# tp-* Token-Plan keys auto-connect to a cluster: cn | sgp | ams
+export MIMO_TOKEN_PLAN_CLUSTER=cn
+```
+
+Pay-as-you-go `sk-*` keys default to `https://api.xiaomimimo.com/v1`. Everything else has a default; to change a model, the voice, loudness, subtitles, or set a key/URL per capability, see the
+[config playbook](skills/video-recap/references/config-playbook.md).
+
+## Usage
+
+Point it at a video and give it whatever story context you have:
+
+```text
+Make a recap of /path/to/video.mp4. It's 庆余年 episode 1; the lead is 范闲.
+```
+
+It analyzes the video, writes the narration against that context, and produces `recap_<name>.mp4` with subtitles. Ask for variations the same way:
+
+```text
+Turn /path/to/long.mp4 into a ~10-minute cut-down recap and burn the subtitles in.
+```
+
+Behind the scenes the orchestrator chains the stages, pausing so the agent can write `narration.json`. Before the first run, check your setup:
+
+```bash
+python3 skills/video-recap/scripts/recap.py --doctor
+```
+
 ## Architecture
 
-`video-recap` is the one you drive. It calls each stage skill as a subprocess and stops to let the agent write the narration. The four pure-tool stages are hidden (`user-invocable: false`), so only `video-recap` and `video-script` are exposed.
+`video-recap` is the one you drive: it calls each stage skill as a subprocess and stops to let the agent write the narration. The four pure-tool stages are hidden (`user-invocable: false`), so only `video-recap` and `video-script` are exposed.
 
 | Skill | Does | In → Out (the `work_dir` contract) |
 |---|---|---|
@@ -49,105 +101,16 @@ flowchart TD
 | **video-assemble** | mux · duck original audio · render subtitles · multi-track timeline (optional 剪映 export) | `video + tts_meta` → `recap_<name>.mp4 + subtitles.srt/.ass + timeline.json` |
 | **video-recap** | orchestrator + `--doctor` | `video` → `recap_<name>.mp4` |
 
-Each skill ships its own `lib.py` with its config and helpers. There is no shared code file; the JSON artifacts are the only interface. See each skill's `SKILL.md` for its full options.
-
-## Why use it?
-
-**One key, runs anywhere.** ASR, VLM, and TTS all hit MiMo's OpenAI-compatible API, so the only thing you install locally is ffmpeg. No GPU, no model files.
-
-**Research before analysis.** Put the plot, characters, and relationships into `background_research.json` first; the VLM reads scenes with that knowledge and names people, instead of labelling everyone "黑衣男子".
-
-**It reads the screen and hears the dialogue.** `mimo-v2.5-asr` transcribes speech; `mimo-v2.5` describes each scene and its frame-level actions, lined up with the scene cuts.
-
-**Optional index pass.** `--consolidate` rolls the per-scene VLM into one global character / relationship / plot index; `--consolidate-asr` cleans the transcript without touching timestamps.
-
-**A review pass before TTS.** `review.py` flags problems in the draft (hallucination, weak hook, no throughline, density) as advisory, logged notes. The one that can actually block is `validate.py`.
-
-**The original audio survives.** Narration is mixed in over a ducked original track instead of replacing the dialogue and ambience.
-
-**Multi-track timeline, optional 剪映 export.** Assembly also emits a backend-neutral `timeline.json` (video / original / narration / BGM / subtitle tracks with ducking automation). Add `--export-jianying` to turn it into a 剪映/JianYing draft — original clips, separate audio tracks, and volume keyframes — to keep editing by hand. This is fully optional: the core render only needs `ffmpeg` and never depends on 剪映.
-
-![Exported 剪映 draft: original clips, narration track, BGM, and subtitles, each independently editable](docs/jianying-export.png)
-
-**Re-runs are cheap.** Edit `narration.json` and only the voiceover and assembly re-run; the analysis is reused.
-
-**Cut-style recaps.** `--edit-mode cut` picks source ranges in `clip_plan.json` to turn a long video into a shorter narrated edit.
-
-## Installation
-
-### 1. Install the plugin
-
-Ask Claude Code:
-
-```text
-Install this plugin: https://github.com/worldwonderer/video-recap-skills
-```
-
-### 2. Install ffmpeg
-
-```bash
-# macOS
-brew install ffmpeg
-# Debian/Ubuntu
-sudo apt install ffmpeg
-# Windows (choose one)
-choco install ffmpeg   # or: scoop install ffmpeg   |   winget install ffmpeg
-```
-
-Python 3.10+ is the only other requirement. The scripts use the standard library plus ffmpeg on `PATH`, so the pipeline itself needs no `pip install`.
-
-### 3. Set your MiMo API key
-
-One key powers ASR, VLM, and TTS. Keep it in an environment variable, never in the repo.
-
-```bash
-export MIMO_API_KEY=your-mimo-key
-```
-
-Pay-as-you-go `sk-*` keys default to `https://api.xiaomimimo.com/v1`. Token-Plan `tp-*` keys connect to the Token-Plan cluster (default `cn`):
-
-```bash
-export MIMO_TOKEN_PLAN_CLUSTER=cn   # cn | sgp | ams
-# or pin the base URL: export MIMO_API_URL=https://token-plan-cn.xiaomimimo.com/v1
-```
-
-Everything else has a default. To change a model, the ASR window, the voice, loudness, subtitles, and so on, see
-[`skills/video-recap/references/config-playbook.md`](skills/video-recap/references/config-playbook.md).
-If you want a separate key or URL per capability, use `MIMO_VIDEO_API_KEY` / `MIMO_TTS_API_KEY` / `MIMO_ASR_API_KEY` (and the matching `*_API_URL`); anything unset falls back to `MIMO_API_KEY` / `MIMO_API_URL`.
-
-## Usage
-
-It is a Claude Code skill, so you drive it in plain language. After installing the plugin, point it at a video and give it whatever story context you have:
-
-```text
-Make a recap of /path/to/video.mp4. It's 庆余年 episode 1; the lead is 范闲.
-```
-
-Claude Code analyzes the video, writes the narration against that context, and produces `recap_<name>.mp4` with subtitles. Ask for variations the same way:
-
-```text
-Turn /path/to/long.mp4 into a ~10-minute cut-down recap and burn the subtitles in.
-```
-
-Behind the scenes the orchestrator chains the stages (understand → script → (cut) → voiceover → assemble), pausing so the agent can write `narration.json`; cut mode and burned-in subtitles are just flags it sets. To follow the steps or run one stage yourself, read each `skills/<skill>/SKILL.md`.
-
-Before the first run, check your setup:
-
-```bash
-python3 skills/video-recap/scripts/recap.py --doctor
-```
+Each skill ships its own `lib.py`; there is no shared code file, and the JSON artifacts are the only interface. See each skill's `SKILL.md` for its full options.
 
 ## Output
 
 - `recap_<video>.mp4`: the final recap. `subtitles.srt` (plus `subtitles.ass` with `--burn-subtitles`)
+- `work_dir/narration.json`: the narration script (`narration_lint.json` timing diagnostics, `narration_review.md` review notes)
 - `work_dir/agent_narration_brief.md`: timing and scene brief for the agent
-- `work_dir/narration.json`: the narration script. `work_dir/narration_lint.json`: timing diagnostics
-- `work_dir/narration_review.md`: review notes (optional, advisory)
-- `work_dir/vlm_analysis.json`, `asr_result.json`, `silence_periods.json`, `timeline_fusion.json`: understanding artifacts
-- `work_dir/understanding_index.json` / `asr_clean.json`: `--consolidate` outputs
-- `work_dir/clip_plan.json`, `edited_source.mp4`, `narration_mapped.json`: cut-mode artifacts
-- `work_dir/mimo_video_overview.json`: MiMo scene-chunk understanding (`--mimo-video-overview`, optional)
-- `work_dir/tts_segments/`, `tts_meta.json`: TTS audio and placement
+- `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`: understanding artifacts
+- `work_dir/clip_plan.json` · `edited_source.mp4` · `narration_mapped.json`: cut-mode artifacts
+- `work_dir/timeline.json` · `tts_segments/` · `tts_meta.json`: multi-track timeline and TTS audio
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -8,37 +8,89 @@
 
 中文 · [English](README.en.md)
 
-把视频做成中文解说 recap 的 Claude Code 插件。一条流水线串起背景调研、ASR + VLM 场景理解、Agent 写解说词、TTS 配音、字幕和动态混音，由一组小而独立的 skill 拼起来。跑起来只要 ffmpeg 和一个小米 MiMo 的 API Key。
+**把任何视频做成中文解说 recap——在 Claude Code 里一句话搞定。** 本地只要 `ffmpeg` 和一个小米 MiMo 的 API Key，不要 GPU、不下模型。
 
 ## 演示
 
 https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff
 
+成片之外，还能一键导出**剪映草稿**接着手动精修——原片片段、解说、BGM、字幕各成一轨，连 ducking 都是可调的音量关键帧：
+
+![导出的剪映草稿：原片片段、解说、BGM、字幕，各自独立可编辑](docs/jianying-export.png)
+
 ## 这是什么
 
-`video-recap-skills` 让 Agent 把已有视频做成短篇解说 recap。它由五个独立 skill 加一个编排器组成，每个 skill 各管一段，彼此不共享代码，只靠 `work_dir` 里的 JSON/MP4 文件传结果。解说词交给 Agent 写，剪辑、配音、混音这些确定的活儿交给脚本。
-
-好上手的地方在于：语音转写、画面理解、语音合成全都走 [小米 MiMo](https://platform.xiaomimimo.com)，本地只装一个 `ffmpeg`。不碰 GPU，不下模型，也不用另起服务，macOS、Linux、Windows 都能跑。
+一个 Claude Code 插件：五个小而独立的 skill 加一个编排器，各管一段，只靠 `work_dir` 里的 JSON/MP4 传结果。**确定的活儿（剪辑、配音、混音）交给脚本，解说词交给 Agent 写。**
 
 ```mermaid
-flowchart TD
-    research["背景调研<br/>background_research.json"] --> understand
-    video(["输入视频"]) --> understand["video-understanding<br/>场景 · ASR · VLM · brief"]
-    understand --> script["video-script<br/>Agent 写 narration.json"]
-    script --> voiceover["video-voiceover<br/>MiMo TTS"]
-    voiceover --> assemble["video-assemble<br/>混音 · 压低 · 字幕"]
-    assemble --> output(["Recap 视频"])
-    script -. 剪辑模式 .-> cut["video-cut"] -.-> voiceover
-
+flowchart LR
+    research["背景调研"] --> understand
+    video(["视频"]) --> understand["理解<br/>场景·ASR·VLM"] --> script["写稿<br/>Agent"] --> voiceover["配音<br/>MiMo TTS"] --> assemble["组装<br/>混音·字幕"] --> output(["Recap"])
+    script -. 剪辑模式 .-> cut["剪辑"] -.-> voiceover
     classDef io fill:#eef6ff,stroke:#4f86c6,color:#1f2937;
     classDef opt fill:#f3f4f6,stroke:#9ca3af,color:#374151;
     class video,output io;
     class research,cut opt;
 ```
 
+## 为什么用它
+
+- **一个 key 跑全程。** ASR、VLM、TTS 全走[小米 MiMo](https://platform.xiaomimimo.com)，本地只装 `ffmpeg`——不要 GPU、不下模型、不起服务，三平台都能跑。
+- **先调研再分析。** 先把剧情人物查清楚写进 `background_research.json`，VLM 读画面时能叫出人名，而不是满屏「黑衣男子」。
+- **原声不丢，动态混音。** 解说压低原声后混进去；句子间隙自动让原声和 BGM 顶上来，不留死气。
+- **能剪、能审。** `--edit-mode cut` 把长视频压成更短的解说剪辑；出稿前一道 LLM 评审挑幻觉、钩子、主线的毛病。
+- **接着在剪映里改。** 可选导出多轨剪映草稿；核心渲染只靠 `ffmpeg`，不装剪映也照常出片。
+
+## 安装
+
+**① 装插件**——对 Claude Code 说：
+
+```text
+安装这个插件：https://github.com/worldwonderer/video-recap-skills
+```
+
+**② 装 ffmpeg**（流水线本身不用 `pip install`，脚本都是标准库 + `PATH` 上的 `ffmpeg`，Python 3.10+）：
+
+```bash
+brew install ffmpeg                        # macOS
+sudo apt install ffmpeg                     # Debian/Ubuntu
+choco install ffmpeg                        # Windows（或 scoop / winget install ffmpeg）
+```
+
+**③ 配 MiMo API Key**（一个 key 同时驱动 ASR / VLM / TTS，放环境变量、别写进仓库）：
+
+```bash
+export MIMO_API_KEY=your-mimo-key
+# tp-* 的 Token-Plan key 会自动连集群，可选 cn | sgp | ams：
+export MIMO_TOKEN_PLAN_CLUSTER=cn
+```
+
+按量付费的 `sk-*` key 默认走 `https://api.xiaomimimo.com/v1`。其它都有默认值；想分别配 key/URL 或改模型、音色、响度、字幕等，见
+[配置手册](skills/video-recap/references/config-playbook.md)。
+
+## 怎么用
+
+把视频丢给它，顺手给点剧情背景就行：
+
+```text
+给 /path/to/video.mp4 做个解说。这是《庆余年》第一集，主角是范闲。
+```
+
+它会分析视频、照背景写解说，产出带字幕的 `recap_<名>.mp4`。想要别的花样，照样一句话：
+
+```text
+把 /path/to/long.mp4 剪成十分钟左右的解说短片，字幕压进画面。
+```
+
+背后是编排器把几个阶段串起来跑，中间停下来让 Agent 写 `narration.json`。第一次跑前先自检环境：
+
+```bash
+python3 skills/video-recap/scripts/recap.py --doctor
+```
+
 ## 架构
 
-`video-recap` 是你直接用的编排器。它按子进程依次调起各阶段 skill，轮到写解说词时停下来等 Agent。四个纯工具阶段设了 `user-invocable: false` 藏起来，对外只暴露 `video-recap` 和 `video-script`。
+`video-recap` 是你直接用的编排器，按子进程依次调起各阶段 skill，轮到写解说词时停下等 Agent。四个纯工具阶段设了 `user-invocable: false` 藏起来，对外只暴露 `video-recap` 和 `video-script`。
 
 | Skill | 职责 | 输入 → 输出（`work_dir` 契约） |
 |---|---|---|
@@ -49,105 +101,16 @@ flowchart TD
 | **video-assemble** | 混音 · 压低原声 · 渲染字幕 · 多轨时间线（可选导出剪映） | `视频 + tts_meta` → `recap_<名>.mp4 + subtitles.srt/.ass + timeline.json` |
 | **video-recap** | 编排器 + `--doctor` | `视频` → `recap_<名>.mp4` |
 
-每个 skill 自带一份 `lib.py`（配置和工具都在里面），相互之间没有共享代码文件，JSON 产物就是唯一的接口。各 skill 的完整参数见各自的 `SKILL.md`。
-
-## 为什么用它
-
-一个 key 跑全程。ASR、VLM、TTS 都走小米 MiMo 的 OpenAI 兼容接口，本地只要 `ffmpeg`，不用 GPU 也不用下模型，三个平台都能用。
-
-先调研再分析。把剧情、人物、关系先查清楚写进 `background_research.json`，理解阶段的 VLM 就能照着叫出人名、带着剧情读画面，而不是把人都标成「黑衣男子」。
-
-看得懂画面也听得到对白。`mimo-v2.5-asr` 转写对白，配上场景切分和 `mimo-v2.5` 的画面描述、帧级动作。
-
-可以「整理」成索引。`--consolidate` 把逐场景的 VLM 结果汇总成一份全局的人物 / 关系 / 剧情索引；`--consolidate-asr` 顺手把转写清洗一遍，时间戳不动。
-
-写完先过一道评审。`review.py` 给草稿挑毛病（幻觉、钩子、主线、密度这些），只给建议、留记录；真正卡着不放行的是 `validate.py`。
-
-多轨时间线，可选导出剪映。合成阶段会顺手产出一份后端中立的 `timeline.json`（视频 / 原声 / 解说 / BGM / 字幕 多轨，带 ducking 自动化）。想继续手动精修，就加 `--export-jianying` 把它导成剪映草稿（原片片段 + 各条音轨 + 音量关键帧）。这件事完全可选：核心渲染只靠 `ffmpeg`，不装剪映也照常出片。
-
-![导出的剪映草稿：原片片段、解说音轨、BGM、字幕，各自独立可编辑](docs/jianying-export.png)
-
-原声不丢。解说是把原声压低之后混进去的，不会盖掉对白和环境声。
-
-改稿不用重跑分析。动了 `narration.json`，只重跑配音和组装就行。
-
-能做成剪辑版。`--edit-mode cut` 在 `clip_plan.json` 里挑片段，把长视频压成更短的解说剪辑。
-
-## 安装
-
-### 1. 安装插件
-
-对 Claude Code 说：
-
-```text
-安装这个插件：https://github.com/worldwonderer/video-recap-skills
-```
-
-### 2. 安装 ffmpeg
-
-```bash
-# macOS
-brew install ffmpeg
-# Debian/Ubuntu
-sudo apt install ffmpeg
-# Windows（任选其一）
-choco install ffmpeg   # 或：scoop install ffmpeg   |   winget install ffmpeg
-```
-
-除了 ffmpeg，只要 Python 3.10+。脚本用的都是标准库，加上 `PATH` 上的 `ffmpeg` 就够，流水线本身不用 `pip install`。
-
-### 3. 配置 MiMo API Key
-
-一个 key 同时驱动 ASR、VLM、TTS。只放环境变量，别写进仓库。
-
-```bash
-export MIMO_API_KEY=your-mimo-key
-```
-
-按量付费的 `sk-*` key 默认走 `https://api.xiaomimimo.com/v1`。Token-Plan 的 `tp-*` key 会自动连到 Token-Plan 集群（默认 `cn`）：
-
-```bash
-export MIMO_TOKEN_PLAN_CLUSTER=cn   # cn | sgp | ams
-# 也可以直接写死 base URL：export MIMO_API_URL=https://token-plan-cn.xiaomimimo.com/v1
-```
-
-其它都有默认值，想改的话，所有环境变量（模型、ASR 分段、音色、响度、字幕等等）列在
-[`skills/video-recap/references/config-playbook.md`](skills/video-recap/references/config-playbook.md)。
-如果想给三种能力分别配 key 或 URL，用 `MIMO_VIDEO_API_KEY` / `MIMO_TTS_API_KEY` / `MIMO_ASR_API_KEY`（以及对应的 `*_API_URL`），没设的就回退到 `MIMO_API_KEY` / `MIMO_API_URL`。
-
-## 怎么用
-
-它是个 Claude Code skill，用大白话指挥就行。装好插件后把视频丢给它，顺手给点剧情背景：
-
-```text
-给 /path/to/video.mp4 做个解说。这是《庆余年》第一集，主角是范闲。
-```
-
-Claude Code 会分析视频，照你给的背景写解说，产出带字幕的 `recap_<名>.mp4`。想要别的花样，照样一句话：
-
-```text
-把 /path/to/long.mp4 剪成十分钟左右的解说短片，字幕压进画面。
-```
-
-背后是编排器把几个阶段串起来跑（理解 → 写稿 →（剪辑）→ 配音 → 组装），中间停下来让 Agent 写 `narration.json`；剪辑模式、压字幕这些只是它顺手带上的参数。想看具体环节、或自己单跑某一段，看对应的 `skills/<skill>/SKILL.md`。
-
-第一次跑之前先自检一下环境：
-
-```bash
-python3 skills/video-recap/scripts/recap.py --doctor
-```
+每个 skill 自带一份 `lib.py`，相互之间没有共享代码文件，JSON 产物就是唯一的接口。完整参数见各自的 `SKILL.md`。
 
 ## 输出
 
 - `recap_<video>.mp4`：成片。`subtitles.srt`（加 `--burn-subtitles` 时还有 `subtitles.ass`）
+- `work_dir/narration.json`：解说脚本（`narration_lint.json` 时间诊断、`narration_review.md` 评审意见）
 - `work_dir/agent_narration_brief.md`：给 Agent 的时间和场景 brief
-- `work_dir/narration.json`：解说脚本。`work_dir/narration_lint.json`：时间诊断
-- `work_dir/narration_review.md`：评审意见（可选，只是建议）
-- `work_dir/vlm_analysis.json`、`asr_result.json`、`silence_periods.json`、`timeline_fusion.json`：理解产物
-- `work_dir/understanding_index.json` / `asr_clean.json`：`--consolidate` 的产物
-- `work_dir/clip_plan.json`、`edited_source.mp4`、`narration_mapped.json`：剪辑模式产物
-- `work_dir/mimo_video_overview.json`：MiMo 分片理解（`--mimo-video-overview`，可选）
-- `work_dir/tts_segments/`、`tts_meta.json`：TTS 音频和放置信息
+- `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`：理解产物
+- `work_dir/clip_plan.json` · `edited_source.mp4` · `narration_mapped.json`：剪辑模式产物
+- `work_dir/timeline.json` · `tts_segments/` · `tts_meta.json`：多轨时间线与 TTS 音频
 
 ## 参考文档
 


### PR DESCRIPTION
Makes the README grab a newcomer at a glance.

- **Demo first**: the 剪映 draft screenshot moves up into `## 演示` / `## Demo`, right under the recap video.
- **Horizontal mermaid**: pipeline diagram flipped `TD → LR` — compact and scannable.
- **Less verbose**: 9 "why" paragraphs → 5 bullets; install folded into inline numbered steps; the dense skill table moved below usage. Same info, much less wall-of-text. Mirrored in both zh + en.
- **CI fix**: dropped the `pull_request` path filter so the required checks run on every PR (otherwise a docs-only PR stalls forever under the new branch protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)