### PR TITLE
Curate staleness/provenance hardening: keep masked-failure fixes, drop over-built machinery

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -103,14 +103,16 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 Each skill ships its own `lib.py`; there is no shared code file, and the JSON artifacts are the only interface. See each skill's `SKILL.md` for its full options.
 
+Run tests with `python3 scripts/test.py`. Do not run bare `pytest` at the repository root: skills intentionally keep same-named top-level modules (for example `lib.py`), so the test runner isolates skill groups in separate processes.
+
 ## Output
 
-- `recap_<video>.mp4`: the final recap. `subtitles.srt` (plus `subtitles.ass` with `--burn-subtitles`)
+- `recap_<video>.mp4`: the final recap; a stable output alias overwritten in place on every run, so iterating on the narration refreshes the same file. `subtitles.srt` (plus `subtitles.ass` with `--burn-subtitles`)
 - `work_dir/narration.json`: the narration script (`narration_lint.json` timing diagnostics, `narration_review.md` review notes)
 - `work_dir/agent_narration_brief.md`: timing and scene brief for the agent
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`: understanding artifacts
 - `work_dir/clip_plan.json` · `edited_source.mp4` · `narration_mapped.json`: cut-mode artifacts
-- `work_dir/timeline.json` · `tts_segments/` · `tts_meta.json`: multi-track timeline and TTS audio
+- `work_dir/timeline.json` · `work_dir/assembly_manifest.json` · `tts_segments/` · `tts_meta.json`: multi-track timeline, slim render record, and TTS audio
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -103,14 +103,16 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 每个 skill 自带一份 `lib.py`，相互之间没有共享代码文件，JSON 产物就是唯一的接口。完整参数见各自的 `SKILL.md`。
 
+测试请运行 `python3 scripts/test.py`。不要在仓库根目录直接运行裸 `pytest`：各 skill 故意保留同名顶层模块（如 `lib.py`），需要由测试脚本按 skill 分组隔离进程。
+
 ## 输出
 
-- `recap_<video>.mp4`：成片。`subtitles.srt`（加 `--burn-subtitles` 时还有 `subtitles.ass`）
+- `recap_<video>.mp4`：成片（固定输出名，每次运行原地覆盖，迭代解说时刷新同一文件）。`subtitles.srt`（加 `--burn-subtitles` 时还有 `subtitles.ass`）
 - `work_dir/narration.json`：解说脚本（`narration_lint.json` 时间诊断、`narration_review.md` 评审意见）
 - `work_dir/agent_narration_brief.md`：给 Agent 的时间和场景 brief
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`：理解产物
 - `work_dir/clip_plan.json` · `edited_source.mp4` · `narration_mapped.json`：剪辑模式产物
-- `work_dir/timeline.json` · `tts_segments/` · `tts_meta.json`：多轨时间线与 TTS 音频
+- `work_dir/timeline.json` · `work_dir/assembly_manifest.json` · `tts_segments/` · `tts_meta.json`：多轨时间线、渲染记录与 TTS 音频
 
 ## 参考文档
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,51 @@
+"""Root pytest guard for this self-contained skill bundle.
+
+Each skill intentionally has its own top-level modules (notably `lib.py`). The
+canonical test command runs one isolated pytest process per skill group, so a
+plain root-level `pytest` run would otherwise collect incompatible groups in one
+interpreter and report misleading import collisions.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_CANONICAL_MESSAGE = (
+    "This repository uses isolated per-skill pytest processes. "
+    "Run `python3 scripts/test.py` for the full suite, or target one group such "
+    "as `python3 -m pytest tests/assemble -q`."
+)
+
+
+def _is_help_or_version(args):
+    return any(arg in {"--help", "-h", "--version", "-V"} for arg in args)
+
+
+def _test_group_for_path(root, path):
+    try:
+        rel = path.relative_to(root / "tests")
+    except ValueError:
+        return None
+    if not rel.parts:
+        return ""
+    return rel.parts[0]
+
+
+def pytest_cmdline_main(config):
+    if _is_help_or_version(config.invocation_params.args):
+        return None
+    args = list(getattr(config.option, "file_or_dir", None) or [])
+    if not args:
+        raise pytest.UsageError(_CANONICAL_MESSAGE)
+    root = Path(config.rootpath).resolve()
+    groups = set()
+    for raw in args:
+        path = (root / raw).resolve() if not Path(raw).is_absolute() else Path(raw).resolve()
+        if path == root or path == root / "tests":
+            raise pytest.UsageError(_CANONICAL_MESSAGE)
+        group = _test_group_for_path(root, path)
+        if group:
+            groups.add(group)
+    if len(groups) > 1:
+        raise pytest.UsageError(_CANONICAL_MESSAGE)
+    return None

--- a/skills/video-assemble/SKILL.md
+++ b/skills/video-assemble/SKILL.md
@@ -33,15 +33,16 @@ python3 scripts/assemble.py <video> --work-dir <work_dir> \
 
 ## Output contract
 
-- `recap_<stem>.mp4` — the final recap video (written to `--output-dir` or `work_dir`'s parent).
+- `recap_<stem>.mp4` — the final recap video (written to `--output-dir` or `work_dir`'s parent). It is the stable output alias, overwritten in place on every run so iterating on the narration refreshes the same file.
 - `work_dir/output.mp4` — the in-place render.
 - `subtitles.srt` — narration subtitles; `subtitles.ass` when `--burn-subtitles` is used.
 - `timeline.json` — backend-neutral multi-track model (video / original-audio / narration / BGM / subtitle tracks with ducking automation). Always written.
+- `assembly_manifest.json` — a slim render record: the input/source paths, the cut-mode source fingerprint (proving a stale ambient `SOURCE_VIDEO` did not leak into a full-mode export), the render settings, and the final output path.
 - 剪映 draft folder (`recap_<stem>/draft_content.json` + `draft_info.json` + `draft_meta_info.json`) — only with `--export-jianying`.
 
 ## Notes
 - Audio is mixed as tracks (like a cut-software timeline): the original audio, an optional BGM bed, and the narration.
-- Optional 剪映/JianYing export: `--export-jianying` (or `EXPORT_JIANYING=1`) turns `timeline.json` into an editable 剪映 draft — original clips, separate audio tracks, and volume keyframes for the ducking. Fully decoupled and lazy-imported: the ffmpeg render never depends on it, and 剪映 need not be installed. In cut mode pass `--source-video <orig>` so the draft references the real clips. Point `--jianying-out` at 剪映's drafts root to open it in-app. Media is bundled into the draft folder by default (`--jianying-no-bundle-media` to reference in place) — this is **required on macOS**, where 剪映 is sandboxed and cannot read external paths. Note: the draft references the un-burned original, so the source's hardcoded subtitles are visible there (mask them in 剪映 if needed).
+- Optional 剪映/JianYing export: `--export-jianying` (or `EXPORT_JIANYING=1`) turns `timeline.json` into an editable 剪映 draft — original clips, separate audio tracks, and volume keyframes for the ducking. Fully decoupled and lazy-imported: the ffmpeg render never depends on it, and 剪映 need not be installed. In cut mode pass `--source-video <orig>` so the draft references the real clips. Point `--jianying-out` at 剪映's drafts root to open it in-app. If a draft folder with the same name already has files, export writes a numbered sibling instead of overwriting it. Media is bundled into the draft folder by default (`--jianying-no-bundle-media` to reference in place) — this is **required on macOS**, where 剪映 is sandboxed and cannot read external paths. Note: the draft references the un-burned original, so the source's hardcoded subtitles are visible there (mask them in 剪映 if needed).
 - Subtitle look: `SUBTITLE_FONT_SIZE`, `SUBTITLE_MARGIN_V`, `SUBTITLE_MAX_CHARS`, etc.
 - Ducking / loudness: the original swells to `IDLE_ORIG_VOLUME` in the gaps and ducks to `SPEECH_DUCKING_VOLUME` under narration (`DUCK_FADE_SECONDS` smooths the transition); also `DUCKING_MODE`, `ZONE_DUCKING_VOLUME`, `FINAL_LOUDNORM`, `TARGET_LUFS`.
 - BGM (optional): set `BGM_PATH` to any audio file; it loops to length and ducks under narration (`BGM_VOLUME` / `BGM_DUCKING_VOLUME`).

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -419,7 +419,7 @@ def _escape_subtitle_filter_path(path):
     for raw, escaped in (
         ("\\", "\\\\"),
         (":", "\\:"),
-        ("'", "\\\\\\'"),
+        ("'", "\\'"),
         (",", "\\,"),
         ("[", "\\["),
         ("]", "\\]"),
@@ -430,7 +430,7 @@ def _escape_subtitle_filter_path(path):
 
 def _subtitle_burn_filter(subtitle_path):
     """Build the ffmpeg video filter used for hard-sub rendering."""
-    return f"subtitles=filename={_escape_subtitle_filter_path(subtitle_path)}"
+    return f"subtitles=filename='{_escape_subtitle_filter_path(subtitle_path)}'"
 
 
 def final_loudnorm_filter():

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1,5 +1,6 @@
+import hashlib
+import json
 import os
-import shutil
 import wave
 from pathlib import Path
 
@@ -8,6 +9,95 @@ from lib import log, run_cmd, get_video_duration
 from timeline import build_timeline, save_timeline
 
 SUBTITLE_RENDER_VERSION = 1
+ASSEMBLY_MANIFEST = "assembly_manifest.json"
+
+
+def _stable_json_dumps(value):
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _value_fingerprint(value):
+    return hashlib.md5(_stable_json_dumps(value).encode("utf-8")).hexdigest()
+
+
+def _file_fingerprint(path, chunk_size=1024 * 1024):
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _artifact_fingerprint(path):
+    path = Path(path)
+    return _file_fingerprint(path) if path.exists() else None
+
+
+def _explicit_source_video():
+    """Return the cut-mode source video only when the caller opted in explicitly."""
+    if not CONFIG.get("source_video_explicit", False):
+        return ""
+    return str(CONFIG.get("source_video", "") or "").strip()
+
+
+def _source_video_identity():
+    source_video = _explicit_source_video()
+    if not source_video:
+        return None, None
+    path = Path(source_video)
+    return str(path.resolve()), _artifact_fingerprint(path)
+
+
+def _assembly_manifest_payload(input_video, tts_segments, work_dir, output_path,
+                               tts_meta_path=None, final_output=None):
+    """Slim render record. The orchestrator reads `final_output` to report the result;
+    `source_video` stays None unless cut mode explicitly passed --source-video, proving a
+    stale ambient SOURCE_VIDEO never leaked into a full-mode timeline / 剪映 export."""
+    input_video = Path(input_video)
+    output_path = Path(output_path)
+    source_video, source_video_fingerprint = _source_video_identity()
+    payload = {
+        "schema_version": 2,
+        "input_video": str(input_video.resolve()),
+        "source_video": source_video,
+        "source_video_fingerprint": source_video_fingerprint,
+        "tts_meta": str(Path(tts_meta_path).resolve()) if tts_meta_path else None,
+        "tts_segments": len(tts_segments or []),
+        "assembly_settings": assembly_settings_fingerprint(),
+        "output_path": str(output_path.resolve()),
+    }
+    if final_output is not None:
+        payload["final_output"] = str(Path(final_output).resolve())
+    return payload
+
+
+def _write_assembly_manifest(work_dir, manifest):
+    path = Path(work_dir) / ASSEMBLY_MANIFEST
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def _resolve_final_output(base, stem):
+    """The recap output is the stable human alias recap_<stem>.mp4, overwritten in place
+    on every run so the iterate-on-narration loop always refreshes the same file."""
+    return Path(base) / f"recap_{stem}.mp4"
+
+
+def _load_cut_timeline_plan(work_dir):
+    raw_plan_path = Path(work_dir) / "clip_plan.json"
+    validated_plan_path = Path(work_dir) / "clip_plan_validated.json"
+    if not validated_plan_path.exists():
+        return json.loads(raw_plan_path.read_text(encoding="utf-8")) if raw_plan_path.exists() else None
+    if not raw_plan_path.exists():
+        return json.loads(validated_plan_path.read_text(encoding="utf-8"))
+    raw_plan = json.loads(raw_plan_path.read_text(encoding="utf-8"))
+    validated_plan = json.loads(validated_plan_path.read_text(encoding="utf-8"))
+    if (
+        isinstance(validated_plan, dict)
+        and validated_plan.get("raw_plan_fingerprint") == _value_fingerprint(raw_plan)
+    ):
+        return validated_plan
+    return raw_plan
 
 
 def _probe_canvas(video_path):
@@ -32,6 +122,15 @@ def _probe_canvas(video_path):
     return {"width": width, "height": height, "fps": fps}
 
 
+def _has_audio_stream(video_path):
+    """Return True when the input has an audio stream usable as [0:a]."""
+    result = run_cmd([
+        "ffprobe", "-v", "error", "-select_streams", "a:0",
+        "-show_entries", "stream=index", "-of", "csv=p=0", str(video_path),
+    ])
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
 def _build_video_clips(input_video, work_dir, duration_s):
     """Video-track clips for the timeline.
 
@@ -39,26 +138,36 @@ def _build_video_clips(input_video, work_dir, duration_s):
     becomes a clip referencing the ORIGINAL source range, so an editor sees the
     real cuts. Otherwise (or full mode) the rendered input is a single clip.
     """
-    source_video = CONFIG.get("source_video", "")
-    plan_path = Path(work_dir) / "clip_plan.json"
-    if source_video and os.path.exists(source_video) and plan_path.exists():
+    source_video = _explicit_source_video()
+    if source_video and os.path.exists(source_video):
         try:
-            import json
-            plan = json.loads(plan_path.read_text(encoding="utf-8"))
+            plan = _load_cut_timeline_plan(work_dir)
+            if plan is None:
+                raise ValueError("missing clip_plan.json")
             entries = plan.get("clips", plan) if isinstance(plan, dict) else plan
             clips, cursor = [], 0.0
             for c in entries:
-                ss, se = float(c["start"]), float(c["end"])
+                ss = float(c.get("source_start", c.get("start")))
+                se = float(c.get("source_end", c.get("end")))
+                timeline_start = c.get("output_start")
+                timeline_end = c.get("output_end")
                 dur = max(0.0, se - ss)
                 if dur <= 0:
                     continue
+                if timeline_start is None or timeline_end is None:
+                    timeline_start = cursor
+                    timeline_end = cursor + dur
+                    cursor += dur
+                else:
+                    timeline_start = float(timeline_start)
+                    timeline_end = float(timeline_end)
+                    cursor = max(cursor, timeline_end)
                 clips.append({"source_path": source_video, "source_start": ss,
-                              "source_end": se, "timeline_start": cursor,
-                              "timeline_end": cursor + dur})
-                cursor += dur
+                              "source_end": se, "timeline_start": timeline_start,
+                              "timeline_end": timeline_end})
             if clips:
                 return clips
-        except (ValueError, KeyError, OSError) as exc:
+        except (TypeError, ValueError, KeyError, OSError) as exc:
             log(f"  时间线: clip_plan 解析失败，回退单片 ({exc})")
     return [{"source_path": str(input_video), "source_start": 0.0,
              "source_end": float(duration_s), "timeline_start": 0.0,
@@ -66,48 +175,44 @@ def _build_video_clips(input_video, work_dir, duration_s):
 
 
 def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
-    """Build and persist the backend-neutral multi-track timeline.json (best-effort)."""
-    try:
-        canvas = _probe_canvas(input_video)
-        video_clips = _build_video_clips(input_video, work_dir, duration_s)
-        narration_segments = []
-        for seg in tts_segments:
-            if not isinstance(seg, dict):
-                continue
-            s, e = _seg_place_window(seg)
-            if e <= s:
-                continue
-            narration_segments.append({
-                "source_path": seg.get("audio_path", ""),
-                "timeline_start": s, "timeline_end": e,
-                "text": seg.get("narration", ""),
-                "overlaps_speech": seg.get("overlaps_speech", True),
-                "gain": 1.0,
-            })
-        fade = CONFIG.get("duck_fade_seconds", 0.25)
-        bgm = None
-        if has_bgm:
-            bgm = {"source_path": CONFIG.get("bgm_path", ""),
-                   "volume": CONFIG.get("bgm_volume", 0.18),
-                   "ducking_volume": CONFIG.get("bgm_ducking_volume", 0.10),
+    """Build and persist the backend-neutral multi-track timeline.json."""
+    canvas = _probe_canvas(input_video)
+    video_clips = _build_video_clips(input_video, work_dir, duration_s)
+    narration_segments = []
+    for seg in tts_segments:
+        if not isinstance(seg, dict):
+            continue
+        s, e = _seg_place_window(seg)
+        if e <= s:
+            continue
+        narration_segments.append({
+            "source_path": seg.get("audio_path", ""),
+            "timeline_start": s, "timeline_end": e,
+            "text": seg.get("narration", ""),
+            "overlaps_speech": seg.get("overlaps_speech", True),
+            "gain": 1.0,
+        })
+    fade = CONFIG.get("duck_fade_seconds", 0.25)
+    bgm = None
+    if has_bgm:
+        bgm = {"source_path": CONFIG.get("bgm_path", ""),
+               "volume": CONFIG.get("bgm_volume", 0.18),
+               "ducking_volume": CONFIG.get("bgm_ducking_volume", 0.10),
+               "fade": fade}
+    # carry ducking automation whenever ducking is on at all; even under sidechain
+    # mode the draft gets editable volume keyframes (ffmpeg stays the canonical mix)
+    ducking = None
+    if CONFIG.get("ducking_mode", "fixed") != "none":
+        ducking = {"idle": CONFIG.get("idle_orig_volume", 0.85),
+                   "speech": CONFIG.get("speech_ducking_volume", 0.2),
+                   "quiet": CONFIG.get("zone_ducking_volume", 0.12),
                    "fade": fade}
-        # carry ducking automation whenever ducking is on at all; even under sidechain
-        # mode the draft gets editable volume keyframes (ffmpeg stays the canonical mix)
-        ducking = None
-        if CONFIG.get("ducking_mode", "fixed") != "none":
-            ducking = {"idle": CONFIG.get("idle_orig_volume", 0.85),
-                       "speech": CONFIG.get("speech_ducking_volume", 0.2),
-                       "quiet": CONFIG.get("zone_ducking_volume", 0.12),
-                       "fade": fade}
-        timeline = build_timeline(canvas, duration_s, video_clips,
-                                  narration_segments, bgm=bgm, ducking=ducking)
-        out = Path(work_dir) / "timeline.json"
-        save_timeline(timeline, out)
-        log(f"时间线模型: {out} ({len(timeline['tracks'])} 轨)")
-        return timeline
-    except Exception as exc:  # never let timeline emission break the render
-        log(f"  ⚠️ 时间线生成失败（不影响成片）: {exc}")
-        return None
+    timeline = build_timeline(canvas, duration_s, video_clips,
+                              narration_segments, bgm=bgm, ducking=ducking)
+    out = Path(work_dir) / "timeline.json"
+    save_timeline(timeline, out)
+    log(f"时间线模型: {out} ({len(timeline['tracks'])} 轨)")
+    return timeline
 
 
 def _seconds_to_srt_time(seconds):
@@ -156,19 +261,34 @@ def assembly_settings_fingerprint():
         "version": SUBTITLE_RENDER_VERSION,
         "burn_subtitles": bool(CONFIG.get("burn_subtitles", False)),
         "force_video_reencode": bool(CONFIG.get("force_video_reencode", False)),
+        "video_filters": {
+            "mask_source_subtitles": bool(CONFIG.get("mask_source_subtitles", False)),
+            "source_subtitle_mask_ratio": CONFIG.get("source_subtitle_mask_ratio", 0.14),
+        },
         "narration_timing": {
             "delay_seconds": CONFIG.get("narration_delay_seconds", 1.5),
             "tail_pad_seconds": CONFIG.get("narration_tail_pad_seconds", 0.1),
             "fade_ms": CONFIG.get("fade_ms", 300),
+            "narration_speed": CONFIG.get("narration_speed", 1.0),
         },
         "audio_mix": {
             "ducking_mode": CONFIG.get("ducking_mode", "fixed"),
+            "duck_fade_seconds": CONFIG.get("duck_fade_seconds", 0.25),
             "ducking_narr_weight": CONFIG.get("ducking_narr_weight", 1.5),
             "ducking_orig_volume": CONFIG.get("ducking_orig_volume", 0.5),
+            "idle_orig_volume": CONFIG.get("idle_orig_volume", 0.85),
             "speech_ducking_volume": CONFIG.get("speech_ducking_volume", 0.2),
             "zone_ducking_volume": CONFIG.get("zone_ducking_volume", 0.12),
-            "zone_fade_seconds": CONFIG.get("zone_fade_seconds", 0.5),
+            "ducking_threshold": CONFIG.get("ducking_threshold", 0.15),
+            "ducking_ratio": CONFIG.get("ducking_ratio", 3),
+            "ducking_attack": CONFIG.get("ducking_attack", 10),
+            "ducking_release": CONFIG.get("ducking_release", 300),
+            "ducking_level_sc": CONFIG.get("ducking_level_sc", 2.0),
+            "ducking_makeup": CONFIG.get("ducking_makeup", 1.2),
             "final_loudnorm": final_loudnorm_filter() or "off",
+            "bgm_path": CONFIG.get("bgm_path", ""),
+            "bgm_volume": CONFIG.get("bgm_volume", 0.18),
+            "bgm_ducking_volume": CONFIG.get("bgm_ducking_volume", 0.10),
         },
     }
     if fingerprint["burn_subtitles"]:
@@ -299,7 +419,7 @@ def _escape_subtitle_filter_path(path):
     for raw, escaped in (
         ("\\", "\\\\"),
         (":", "\\:"),
-        ("'", "\\'"),
+        ("'", "\\\\\\'"),
         (",", "\\,"),
         ("[", "\\["),
         ("]", "\\]"),
@@ -310,7 +430,7 @@ def _escape_subtitle_filter_path(path):
 
 def _subtitle_burn_filter(subtitle_path):
     """Build the ffmpeg video filter used for hard-sub rendering."""
-    return f"subtitles=filename='{_escape_subtitle_filter_path(subtitle_path)}'"
+    return f"subtitles=filename={_escape_subtitle_filter_path(subtitle_path)}"
 
 
 def final_loudnorm_filter():
@@ -387,6 +507,8 @@ def _amix_tail(narr_vol, bgm_chain=""):
 
 def _duck_ramp(s, e, fade):
     """A 0→1 trapezoid over [s,e] with `fade`-second ramps at each edge (no clicks)."""
+    if float(fade or 0) <= 0:
+        return f"between(t,{s:.2f},{e:.2f})"
     return f"min(1,max(0,min(t-{s:.2f},{e:.2f}-t)/{fade:.2f}))"
 
 
@@ -428,7 +550,13 @@ def _bgm_envelope(tts_segments, base, duck, fade):
     return f"max(0,min(1,{base}{''.join(terms)}))"
 
 
-def _build_audio_filter_complex(tts_segments, has_bgm=False):
+def _build_audio_filter_complex(
+    tts_segments,
+    has_bgm=False,
+    *,
+    original_audio_label="0:a",
+    bgm_audio_label=None,
+):
     """Compose the audio tracks into [aout], like a cut-software timeline.
 
     Tracks:
@@ -444,6 +572,8 @@ def _build_audio_filter_complex(tts_segments, has_bgm=False):
     ducking_mode = CONFIG.get("ducking_mode", "fixed")
     narr_vol = CONFIG.get("ducking_narr_weight", 1.5)
     fade = CONFIG.get("duck_fade_seconds", 0.25)
+    original_in = f"[{original_audio_label}]"
+    bgm_in = f"[{bgm_audio_label or '2:a'}]"
 
     # BGM bed (input [2:a]): ducked under each narration window when present.
     bgm_chain = ""
@@ -451,14 +581,14 @@ def _build_audio_filter_complex(tts_segments, has_bgm=False):
         base = CONFIG.get("bgm_volume", 0.18)
         bgm_expr = _bgm_envelope(tts_segments, base, CONFIG.get("bgm_ducking_volume", 0.10), fade)
         if bgm_expr:
-            bgm_chain = f"[2:a]volume='{bgm_expr}':eval=frame,aresample=48000[bgm];"
+            bgm_chain = f"{bgm_in}volume='{bgm_expr}':eval=frame,aresample=48000[bgm];"
         else:
-            bgm_chain = f"[2:a]volume={base},aresample=48000[bgm];"
+            bgm_chain = f"{bgm_in}volume={base},aresample=48000[bgm];"
 
     if ducking_mode == "sidechaincompress":
         # The narration keys the compressor; split it so it can also be mixed in.
         head = (
-            "[0:a]aresample=48000[o0];"
+            f"{original_in}aresample=48000[o0];"
             "[1:a]aresample=48000,asplit=2[sckey][scnarr];"
             f"[o0][sckey]sidechaincompress="
             f"threshold={CONFIG['ducking_threshold']}:ratio={CONFIG['ducking_ratio']}"
@@ -471,7 +601,7 @@ def _build_audio_filter_complex(tts_segments, has_bgm=False):
         return head + narr + "[orig][narr]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
 
     if ducking_mode == "none":
-        return "[0:a]aresample=48000[orig];" + _amix_tail(narr_vol, bgm_chain)
+        return f"{original_in}aresample=48000[orig];" + _amix_tail(narr_vol, bgm_chain)
 
     # fixed (default): gap-fill ducking envelope on the original track.
     idle = CONFIG.get("idle_orig_volume", 0.85)
@@ -482,19 +612,17 @@ def _build_audio_filter_complex(tts_segments, has_bgm=False):
         n_overlap = sum(1 for s in tts_segments if isinstance(s, dict) and s.get("overlaps_speech", True))
         n_quiet = sum(1 for s in tts_segments if isinstance(s, dict) and not s.get("overlaps_speech", True))
         log(f"gap-fill ducking: 间隙原声={idle}, 对白段={speech_vol}({n_overlap}), 安静段={quiet_vol}({n_quiet})")
-        orig = f"[0:a]volume='{expr}':eval=frame,aresample=48000[orig];"
+        orig = f"{original_in}volume='{expr}':eval=frame,aresample=48000[orig];"
     else:
         # No placement info at all: hold the original at a constant level.
-        orig = f"[0:a]volume={CONFIG.get('ducking_orig_volume', 0.3)},aresample=48000[orig];"
+        orig = f"{original_in}volume={CONFIG.get('ducking_orig_volume', 0.3)},aresample=48000[orig];"
     return orig + _amix_tail(narr_vol, bgm_chain)
 
 
 def assemble_video(input_video, tts_segments, work_dir, output_path):
     """组装最终视频"""
     if not tts_segments:
-        log("没有解说音频，直接复制原视频")
-        shutil.copy2(str(input_video), str(output_path))
-        return output_path
+        raise RuntimeError("tts_meta.json 没有有效解说音频，已中止以避免生成无解说视频")
 
     video_duration = get_video_duration(input_video)
 
@@ -523,7 +651,25 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     _emit_timeline(input_video, tts_segments, work_dir, video_duration, has_bgm)
 
     # 混合原始音频 + 解说音频（+ 可选 BGM）
-    filter_complex = _build_audio_filter_complex(tts_segments, has_bgm)
+    source_has_audio = _has_audio_stream(input_video)
+    if source_has_audio:
+        original_audio_input = []
+        original_audio_label = "0:a"
+        bgm_audio_label = "2:a"
+    else:
+        log("源视频无音轨，使用静音原声音轨进行混音")
+        original_audio_input = [
+            "-f", "lavfi", "-t", str(video_duration),
+            "-i", "anullsrc=channel_layout=stereo:sample_rate=48000",
+        ]
+        original_audio_label = "2:a"
+        bgm_audio_label = "3:a"
+    filter_complex = _build_audio_filter_complex(
+        tts_segments,
+        has_bgm,
+        original_audio_label=original_audio_label,
+        bgm_audio_label=bgm_audio_label,
+    )
 
     # 对于超长 volume 表达式（多段解说），使用 -filter_complex_script 避免命令行溢出
     # 末端整体响度归一：ducking 只管相对平衡，这一步统一成片绝对响度
@@ -547,6 +693,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             "ffmpeg", "-y",
             "-i", str(input_video),
             "-i", str(narration_wav),
+            *original_audio_input,
             *bgm_input,
             "-filter_complex_script", str(fc_script),
             "-map", "0:v", "-map", aout_label,
@@ -556,6 +703,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             "ffmpeg", "-y",
             "-i", str(input_video),
             "-i", str(narration_wav),
+            *original_audio_input,
             *bgm_input,
             "-filter_complex", filter_complex,
             "-map", "0:v", "-map", aout_label,
@@ -594,6 +742,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
 
 def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0):
     """如果 TTS 音频超过目标时长，用 ffmpeg atempo 温和加速"""
+    audio_path = Path(audio_path)
     current_dur = get_video_duration(audio_path)
     if current_dur <= target_duration or current_dur == 0:
         return str(audio_path), current_dur
@@ -606,7 +755,7 @@ def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0
 
     if ratio > effective_max:
         # 实际截断到目标时长，加 fade-out 防止爆音
-        truncated_path = Path(str(audio_path).replace(".wav", "_cut.wav"))
+        truncated_path = audio_path.with_name(f"{audio_path.stem}_cut{audio_path.suffix}")
         fade_out = min(0.15, target_duration * 0.1)
         cmd = ["ffmpeg", "-y", "-i", str(audio_path),
                "-t", f"{target_duration:.3f}",
@@ -622,7 +771,7 @@ def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0
 
     # 温和加速
     tempo = min(ratio, effective_max)
-    adjusted_path = Path(str(audio_path).replace(".wav", "_adj.wav"))
+    adjusted_path = audio_path.with_name(f"{audio_path.stem}_adj{audio_path.suffix}")
     cmd = ["ffmpeg", "-y", "-i", str(audio_path),
            "-filter:a", f"atempo={tempo:.3f}",
            "-ar", "44100", "-ac", "1", str(adjusted_path)]
@@ -642,6 +791,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
     last_written_end = 0  # 追踪已写入位置，防止重叠
     prev_pause_samples = 0  # 前一段的 pause_after_ms，控制段间间隔
     skipped_count = 0  # 因 WAV 缺失/损坏/重采样失败而被跳过的段数
+    placed_count = 0  # 真正写入音频的段数；防止“成功”生成全静音旁白
 
     for seg in tts_segments:
         wav_path = seg["audio_path"]
@@ -776,6 +926,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         seg["actual_place_end"] = (actual_start + write_samples) / sample_rate
         last_written_end = actual_start + write_samples
         prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+        placed_count += 1
 
     with wave.open(str(output_wav), "wb") as wf:
         wf.setnchannels(1)
@@ -783,8 +934,13 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         wf.setframerate(sample_rate)
         wf.writeframes(bytes(buffer))
 
-    if tts_segments and skipped_count >= len(tts_segments):
-        log(f"  ⚠️ 严重警告: 全部 {len(tts_segments)} 段解说均被跳过（WAV 缺失/损坏/重采样失败），成片将没有解说音频")
+    if tts_segments and placed_count == 0:
+        output_wav.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"全部 {len(tts_segments)} 段解说均被跳过或未能写入"
+            f"（WAV 缺失/损坏/重采样失败/无可用时间；跳过 {skipped_count} 段），"
+            "已中止以避免生成无解说视频"
+        )
 
     log(f"解说音轨: {video_duration:.1f}s, {len(tts_segments)} 段")
 
@@ -817,6 +973,13 @@ def main():
         CONFIG["burn_subtitles"] = True
     if args.source_video:
         CONFIG["source_video"] = args.source_video
+        CONFIG["source_video_explicit"] = True
+    else:
+        # SOURCE_VIDEO is an ambient env var in lib.CONFIG. Do not let a stale
+        # shell value silently bind full-mode/direct timeline.json or JianYing
+        # exports to an unrelated original; cut mode must pass --source-video.
+        CONFIG["source_video"] = ""
+        CONFIG["source_video_explicit"] = False
     if args.export_jianying:
         CONFIG["export_jianying"] = True
     if args.jianying_bundle_media:
@@ -829,9 +992,14 @@ def main():
     assemble_video(args.video, tts_segments, work_dir, output_path)
     stem = args.recap_stem or Path(args.video).stem
     base = Path(args.output_dir) if args.output_dir else work_dir.parent
-    final_output = base / f"recap_{stem}.mp4"
-    if final_output != output_path:
-        shutil.copy2(str(output_path), str(final_output))
+    base.mkdir(parents=True, exist_ok=True)
+    final_output = _resolve_final_output(base, stem)
+    shutil.copy2(str(output_path), str(final_output))
+    manifest = _assembly_manifest_payload(
+        args.video, tts_segments, work_dir, output_path,
+        tts_meta_path=tts_meta, final_output=final_output,
+    )
+    _write_assembly_manifest(work_dir, manifest)
     log(f"组装完成: {final_output}")
 
     # OPTIONAL, decoupled: export a 剪映 draft from the timeline (lazy import; never

--- a/skills/video-assemble/scripts/export_jianying.py
+++ b/skills/video-assemble/scripts/export_jianying.py
@@ -21,6 +21,7 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
 import uuid
 
 DRAFT_VERSION = 360000
@@ -89,6 +90,48 @@ def _volume_keyframes(keyframes, seg_start_s, new_id):
              "property_type": "KFTypeVolume"}]
 
 
+def _windowed_volume_keyframes(keyframes, seg_start_s, seg_end_s, default_gain, new_id):
+    """Keyframes that affect one split segment, without leaking earlier beats.
+
+    The timeline stores absolute keyframes. When a looped BGM bed is split into
+    several JianYing segments, each piece must receive only the automation for
+    its target window. If a duck spans a piece boundary, seed the piece with the
+    gain active at its start; otherwise leave flat/default pieces keyframe-free.
+    """
+    if not keyframes:
+        return []
+    start = float(seg_start_s)
+    end = float(seg_end_s)
+    default_gain = float(default_gain)
+    ordered = sorted((
+        {"t": float(kf["t"]), "gain": float(kf["gain"])}
+        for kf in keyframes
+        if "t" in kf and "gain" in kf
+    ), key=lambda kf: kf["t"])
+    if not ordered or end <= start:
+        return []
+
+    start_gain = default_gain
+    for kf in ordered:
+        if kf["t"] <= start:
+            start_gain = kf["gain"]
+        else:
+            break
+    inner = [kf for kf in ordered if start <= kf["t"] <= end]
+    if not inner and abs(start_gain - default_gain) < 1e-4:
+        return []
+
+    selected = [{"t": start, "gain": start_gain}]
+    for kf in inner:
+        if abs(kf["t"] - start) < 1e-4:
+            selected[-1] = {"t": start, "gain": kf["gain"]}
+        else:
+            selected.append(kf)
+    if all(abs(kf["gain"] - default_gain) < 1e-4 for kf in selected):
+        return []
+    return _volume_keyframes(selected, start, new_id)
+
+
 def _base_segment(material_id, target_start_us, target_dur_us, render_index,
                   volume, keyframes, new_id):
     return {
@@ -104,6 +147,17 @@ def _base_segment(material_id, target_start_us, target_dur_us, render_index,
         "speed": 1.0, "volume": round(float(volume), 4),
         "is_tone_modify": False, "render_index": render_index,
     }
+
+
+def _audio_segment_piece(material_id, target_start_us, target_dur_us, source_start_us,
+                         source_dur_us, render_index, volume, keyframes, new_id):
+    seg = _base_segment(material_id, target_start_us, target_dur_us, render_index,
+                        volume, keyframes, new_id)
+    seg["source_timerange"] = _timerange(source_start_us, source_dur_us)
+    seg["extra_material_refs"] = []
+    seg["clip"] = None
+    seg["hdr_settings"] = None
+    return seg
 
 
 def _clip_default():
@@ -188,8 +242,11 @@ def build_draft(timeline, new_id=None, probe=None):
                 want_us = _us(te - ts)
                 place_us = want_us
                 if mat_dur_us and want_us > mat_dur_us:
-                    place_us = mat_dur_us
-                    if role == "bgm":  # looping a bed matters; a beat clamp is sub-frame rounding
+                    if role == "bgm" and track.get("loop"):
+                        place_us = want_us
+                    else:
+                        place_us = mat_dur_us
+                    if role == "bgm" and not track.get("loop"):  # looping a bed matters; a beat clamp is sub-frame rounding
                         notes.append(f"BGM 素材({mat_dur_us/1e6:.1f}s) 短于时间线({(te - ts):.1f}s)，剪映中未循环铺满（可在剪映里手动复制延长）")
                 mat_id = new_id()
                 materials["audios"].append({
@@ -199,16 +256,34 @@ def build_draft(timeline, new_id=None, probe=None):
                     "formula_id": "", "id": mat_id, "local_material_id": mat_id,
                     "music_id": mat_id, "name": os.path.basename(path), "path": path,
                     "source_platform": 0, "type": "extract_music", "wave_points": []})
-                speed = _speed_material(new_id)
-                materials["speeds"].append(speed)
                 kfs = _volume_keyframes(s.get("volume_keyframes"), ts, new_id)
                 vol = s.get("gain", 1.0) if not kfs else 1.0
-                seg = _base_segment(mat_id, _us(ts), place_us, ri, vol, kfs, new_id)
-                seg["source_timerange"] = _timerange(0, place_us)
-                seg["extra_material_refs"] = [speed["id"]]
-                seg["clip"] = None
-                seg["hdr_settings"] = None
-                segs.append(seg)
+                if role == "bgm" and track.get("loop") and mat_dur_us and want_us > mat_dur_us:
+                    cursor = 0
+                    while cursor < want_us:
+                        piece = min(mat_dur_us, want_us - cursor)
+                        if piece <= 0:
+                            break
+                        piece_start_s = ts + (cursor / 1_000_000)
+                        piece_end_s = ts + ((cursor + piece) / 1_000_000)
+                        speed = _speed_material(new_id)
+                        materials["speeds"].append(speed)
+                        piece_kfs = _windowed_volume_keyframes(
+                            s.get("volume_keyframes"), piece_start_s, piece_end_s,
+                            s.get("gain", 1.0), new_id)
+                        piece_vol = s.get("gain", 1.0) if not piece_kfs else 1.0
+                        seg = _audio_segment_piece(
+                            mat_id, _us(ts) + cursor, piece, 0, piece, ri, piece_vol, piece_kfs, new_id)
+                        seg["extra_material_refs"] = [speed["id"]]
+                        segs.append(seg)
+                        cursor += piece
+                else:
+                    speed = _speed_material(new_id)
+                    materials["speeds"].append(speed)
+                    seg = _audio_segment_piece(
+                        mat_id, _us(ts), place_us, 0, place_us, ri, vol, kfs, new_id)
+                    seg["extra_material_refs"] = [speed["id"]]
+                    segs.append(seg)
             tracks.append({"attribute": 0, "flag": 0, "id": new_id(),
                            "is_default_name": False, "name": role,
                            "segments": segs, "type": "audio"})
@@ -347,6 +422,40 @@ def _bundle_media(content, draft_dir):
     return notes
 
 
+def _draft_dir_has_user_content(draft_dir):
+    """Return True when writing here could overwrite an existing draft/material."""
+    if not os.path.exists(draft_dir):
+        return False
+    try:
+        return any(os.scandir(draft_dir))
+    except OSError:
+        return True
+
+
+def _collision_safe_draft_dir(out_dir, draft_name):
+    """Pick a fresh draft folder instead of overwriting an existing non-empty one."""
+    base = os.path.join(out_dir, draft_name)
+    if not _draft_dir_has_user_content(base):
+        return base, draft_name
+    idx = 2
+    while True:
+        candidate_name = f"{draft_name}_{idx}"
+        candidate = os.path.join(out_dir, candidate_name)
+        if not _draft_dir_has_user_content(candidate):
+            return candidate, candidate_name
+        idx += 1
+
+
+def _rewrite_material_prefix(content, old_prefix, new_prefix):
+    old_prefix = os.path.abspath(old_prefix)
+    new_prefix = os.path.abspath(new_prefix)
+    for arr in (content["materials"]["videos"], content["materials"]["audios"]):
+        for material in arr:
+            path = material.get("path")
+            if path and os.path.abspath(path).startswith(old_prefix + os.sep):
+                material["path"] = new_prefix + os.path.abspath(path)[len(old_prefix):]
+
+
 def export_timeline_to_jianying(timeline, out_dir, draft_name="recap", new_id=None,
                                 probe=None, bundle_media=False):
     """Write a 剪映 draft folder under out_dir/draft_name. Returns (folder, notes).
@@ -354,19 +463,37 @@ def export_timeline_to_jianying(timeline, out_dir, draft_name="recap", new_id=No
     bundle_media=True copies the referenced media into the draft folder so it is
     self-contained and portable to another machine."""
     content, meta, notes = build_draft(timeline, new_id=new_id, probe=probe)
-    draft_dir = os.path.join(out_dir, draft_name)
-    os.makedirs(draft_dir, exist_ok=True)
-    if bundle_media:
-        notes = notes + _bundle_media(content, draft_dir)
-    meta["draft_name"] = draft_name
-    meta["draft_fold_path"] = draft_dir
-    content["name"] = draft_name
-    # write both filenames for cross-version compatibility (5.9 reads draft_info.json)
-    for fname in ("draft_content.json", "draft_info.json"):
-        with open(os.path.join(draft_dir, fname), "w", encoding="utf-8") as f:
-            json.dump(content, f, ensure_ascii=False, indent=2)
-    with open(os.path.join(draft_dir, "draft_meta_info.json"), "w", encoding="utf-8") as f:
-        json.dump(meta, f, ensure_ascii=False, indent=2)
+    out_dir = os.path.abspath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    draft_dir, actual_name = _collision_safe_draft_dir(out_dir, draft_name)
+    if actual_name != draft_name:
+        notes.append(f"草稿目录已存在，改写为 {actual_name} 以避免覆盖")
+
+    tmp_parent = tempfile.mkdtemp(prefix=f".{actual_name}.", dir=out_dir)
+    tmp_dir = os.path.join(tmp_parent, actual_name)
+    try:
+        os.makedirs(tmp_dir, exist_ok=False)
+        if bundle_media:
+            notes = notes + _bundle_media(content, tmp_dir)
+            _rewrite_material_prefix(content, tmp_dir, draft_dir)
+        meta["draft_name"] = actual_name
+        meta["draft_fold_path"] = draft_dir
+        content["name"] = actual_name
+        # write both filenames for cross-version compatibility (5.9 reads draft_info.json)
+        for fname in ("draft_content.json", "draft_info.json"):
+            with open(os.path.join(tmp_dir, fname), "w", encoding="utf-8") as f:
+                json.dump(content, f, ensure_ascii=False, indent=2)
+        with open(os.path.join(tmp_dir, "draft_meta_info.json"), "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+        if os.path.isdir(draft_dir) and not _draft_dir_has_user_content(draft_dir):
+            os.rmdir(draft_dir)
+        os.replace(tmp_dir, draft_dir)
+    except Exception:
+        shutil.rmtree(tmp_parent, ignore_errors=True)
+        raise
+    finally:
+        if os.path.exists(tmp_parent):
+            shutil.rmtree(tmp_parent, ignore_errors=True)
     return draft_dir, notes
 
 

--- a/skills/video-assemble/scripts/timeline.py
+++ b/skills/video-assemble/scripts/timeline.py
@@ -66,6 +66,49 @@ def ducking_keyframes(windows, idle, duck, fade, span_start, span_end):
     return [_kf(t, g) for t, g in out]
 
 
+def variable_ducking_keyframes(windows, idle, fade, span_start, span_end):
+    """Volume automation with a per-window duck gain.
+
+    `windows` is [(start_s, end_s, duck_gain)]. Unlike `ducking_keyframes`,
+    this preserves the canonical renderer's speech-vs-quiet ducking levels for
+    timeline/JianYing export instead of flattening every narration beat to the
+    same target gain.
+    """
+    rel = sorted(
+        (max(span_start, float(w[0])), min(span_end, float(w[1])), float(w[2]))
+        for w in windows
+        if float(w[1]) > span_start and float(w[0]) < span_end and float(w[1]) > float(w[0])
+    )
+    if not rel:
+        return []
+
+    pts = [(span_start, idle)]
+    for idx, (s, e, gain) in enumerate(rel):
+        prev_end = rel[idx - 1][1] if idx else None
+        next_start = rel[idx + 1][0] if idx + 1 < len(rel) else None
+        close_to_prev = prev_end is not None and s - prev_end < 2 * fade
+        close_to_next = next_start is not None and next_start - e < 2 * fade
+
+        if not close_to_prev:
+            pts.append((max(span_start, s - fade), idle))
+        pts.append((s, gain))
+        pts.append((e, gain))
+        if not close_to_next:
+            pts.append((min(span_end, e + fade), idle))
+    pts.append((span_end, idle))
+
+    pts.sort(key=lambda p: p[0])
+    out = []
+    for t, g in pts:
+        if out and abs(out[-1][0] - t) < 1e-4:
+            # At adjacent windows, prefer the lower gain to avoid a one-frame
+            # swell between back-to-back narration beats.
+            out[-1] = (t, min(out[-1][1], g))
+        else:
+            out.append((t, g))
+    return [_kf(t, g) for t, g in out]
+
+
 def build_timeline(canvas, duration_s, video_clips, narration_segments,
                    bgm=None, ducking=None):
     """Assemble a Timeline dict from resolved placement data.
@@ -84,6 +127,15 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
     windows = [(float(s["timeline_start"]), float(s["timeline_end"]))
                for s in narration_segments
                if s.get("timeline_end", 0) > s.get("timeline_start", 0)]
+    duck_windows = [
+        (
+            float(s["timeline_start"]),
+            float(s["timeline_end"]),
+            float((ducking or {}).get("speech" if s.get("overlaps_speech", True) else "quiet", 1.0)),
+        )
+        for s in narration_segments
+        if s.get("timeline_end", 0) > s.get("timeline_start", 0)
+    ]
 
     # --- video track: each clip carries its original audio + ducking automation
     video_clip_objs = []
@@ -91,8 +143,8 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
         ts, te = float(c["timeline_start"]), float(c["timeline_end"])
         audio = {"role": "original", "volume_keyframes": []}
         if ducking is not None:
-            audio["volume_keyframes"] = ducking_keyframes(
-                windows, ducking["idle"], ducking["speech"], ducking["fade"], ts, te)
+            audio["volume_keyframes"] = variable_ducking_keyframes(
+                duck_windows, ducking["idle"], ducking["fade"], ts, te)
             audio["base_gain"] = round(float(ducking["idle"]), 4)
         else:
             audio["base_gain"] = 1.0

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -1,5 +1,6 @@
 """Cut-style recap helpers for agent-selected source ranges."""
 
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -77,6 +78,76 @@ def _clip_value(raw, *names):
 def load_clip_plan(path):
     """Load `clip_plan.json`, accepting either a list or {"clips": [...]} object."""
     return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _stable_json_dumps(value):
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def value_fingerprint(value):
+    """Return a stable fingerprint for JSON-serializable non-secret values."""
+    return hashlib.md5(_stable_json_dumps(value).encode("utf-8")).hexdigest()
+
+
+def cut_plan_fingerprint(validated_plan):
+    """Hash the exact normalized clip plan that determines edited_source.mp4 bytes."""
+    if isinstance(validated_plan, dict):
+        payload = dict(validated_plan)
+        # Provenance for raw-plan freshness is not part of the edited media bytes.
+        payload.pop("raw_plan_fingerprint", None)
+    else:
+        payload = validated_plan
+    return value_fingerprint(payload)
+
+
+def file_fingerprint(path, chunk_size=1024 * 1024):
+    """Full-content fingerprint for source media cache provenance."""
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _edited_source_meta_path(output_path):
+    return Path(str(output_path) + ".meta.json")
+
+
+def _load_edited_source_meta(output_path):
+    meta_path = _edited_source_meta_path(output_path)
+    if not meta_path.exists():
+        return None
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_edited_source_meta(output_path, validated_plan, input_video):
+    meta_path = _edited_source_meta_path(output_path)
+    meta_path.write_text(json.dumps({
+        "schema_version": 1,
+        "clip_plan_fingerprint": cut_plan_fingerprint(validated_plan),
+        "source_video_fingerprint": file_fingerprint(input_video),
+        "edited_source_fingerprint": file_fingerprint(output_path),
+        "total_duration": validated_plan.get("total_duration"),
+        "clip_count": len(validated_plan.get("clips", [])),
+    }, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def should_reuse_edited_source(output_path, validated_plan, input_video):
+    """Return True only when edited_source.mp4 matches source media and cut params."""
+    output_path = Path(output_path)
+    if not output_path.exists():
+        return False
+    meta = _load_edited_source_meta(output_path)
+    return bool(
+        meta
+        and meta.get("clip_plan_fingerprint") == cut_plan_fingerprint(validated_plan)
+        and meta.get("source_video_fingerprint") == file_fingerprint(input_video)
+        and meta.get("edited_source_fingerprint") == file_fingerprint(output_path)
+    )
 
 
 def normalize_clip_plan(raw_plan, video_duration, target_duration=None, clip_padding=0.0, min_clip_duration=0.3, allow_overlap=False):
@@ -297,6 +368,7 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
     if result.returncode != 0:
         raise RuntimeError(f"剪辑源视频失败: {result.stderr}")
 
+    _write_edited_source_meta(output_path, validated_plan, input_video)
     duration = get_video_duration(output_path)
     log(f"剪辑源视频: {output_path} ({duration:.1f}s, {len(clips)} clips)")
     return output_path
@@ -328,11 +400,13 @@ def main():
         clip_padding=args.clip_padding,
         allow_overlap=args.allow_overlap,
     )
+    if isinstance(validated_plan, dict):
+        validated_plan["raw_plan_fingerprint"] = value_fingerprint(raw_plan)
     (work_dir / "clip_plan_validated.json").write_text(
         json.dumps(validated_plan, ensure_ascii=False, indent=2), encoding="utf-8")
 
     edited_source_path = work_dir / "edited_source.mp4"
-    if edited_source_path.exists() and edited_source_path.stat().st_mtime >= clip_plan_path.stat().st_mtime:
+    if should_reuse_edited_source(edited_source_path, validated_plan, args.video):
         log(f"复用剪辑源视频: {edited_source_path}")
     else:
         build_edited_source_video(args.video, validated_plan, work_dir, edited_source_path)

--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -17,8 +17,10 @@ JSON/MP4 artifacts in a `work_dir` — no shared code):
 video-understanding ─▶ (agent writes narration.json per video-script) ─▶ [video-cut] ─▶ video-voiceover ─▶ video-assemble
 ```
 
-It is **stateless**: rerun the same command after writing `narration.json` to continue.
-Understanding artifacts are reused when fresh. For per-stage detail, read each skill's own SKILL.md.
+It is resume-safe: rerun the same command after writing `narration.json` to continue.
+Phase B validates `recap_run_manifest.json` so an old `work_dir` from another source video or
+different run settings is rejected instead of silently reusing stale narration. Understanding
+artifacts are reused only when their provenance matches. For per-stage detail, read each skill's own SKILL.md.
 
 ## Install / env
 

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -32,7 +32,7 @@ bundle ships no root `CLAUDE.md` (so it never collides with your project/global 
 | 剪映 export (optional) | `--export-jianying` / `EXPORT_JIANYING` | off | after rendering, also write a 剪映/JianYing draft from `timeline.json`. Decoupled — the core render never needs it |
 | 剪映 draft dir | `JIANYING_DRAFT_DIR` | work_dir | parent folder for the exported draft (point it at 剪映's drafts root to open in-app) |
 | 剪映 bundle media | `JIANYING_BUNDLE_MEDIA` / `--jianying-no-bundle-media` | **on** | copies media into the draft folder so it is self-contained. **Required on macOS** — 剪映 is sandboxed and cannot read external paths, so an unbundled draft opens with all media offline. Use `--jianying-no-bundle-media` only if 剪映 can reach the original paths |
-| Source video | `--source-video` / `SOURCE_VIDEO` | — | original video (cut mode) so `timeline.json` / 剪映 export reference the real source clips instead of the concatenated `edited_source.mp4` |
+| Source video | `--source-video` | — | original video (cut mode) so `timeline.json` / 剪映 export reference the real source clips instead of the concatenated `edited_source.mp4`; direct `video-assemble` runs intentionally ignore ambient `SOURCE_VIDEO` unless `--source-video` is passed |
 
 `video-assemble` always writes `timeline.json` — a backend-neutral multi-track model
 (video / original-audio / narration / BGM / subtitle, with ducking automation). The

--- a/skills/video-recap/references/timeline-and-jianying.md
+++ b/skills/video-recap/references/timeline-and-jianying.md
@@ -33,7 +33,7 @@ inspection and what the **optional** 剪映 exporter consumes. Times are plain
 }
 ```
 
-- **video** — the source clip(s). In cut mode (with `--source-video` / `SOURCE_VIDEO`)
+- **video** — the source clip(s). In cut mode (with explicit `--source-video`)
   each `clip_plan` entry references the real source range; otherwise a single clip
   spans the rendered input. The clip's `audio` carries the **original-audio ducking
   automation** (gap-fill: held at `base_gain` between sentences, dipped under each
@@ -63,7 +63,7 @@ unbundled draft opens with every clip "暂无访问权限 / offline". Drop the d
 its `materials/`) into 剪映's drafts root — on this setup
 `~/Movies/JianyingPro/User Data/Projects/com.lveditor.draft/` — and it appears in
 the 草稿 list. Use `--jianying-no-bundle-media` only when 剪映 can reach the original
-paths (e.g. media already under the drafts root).
+paths (e.g. media already under the drafts root). If the requested draft folder already exists and is non-empty, the exporter writes a numbered sibling (for example `recap_demo_2`) rather than overwriting an edited draft.
 
 **Decoupling guarantees** (the core never depends on 剪映):
 - the exporter is **lazy-imported** only when an export is requested; importing the
@@ -72,8 +72,7 @@ paths (e.g. media already under the drafts root).
 - any failure is caught and logged; it never breaks the ffmpeg render.
 
 **Limitations** (documented, not bugs): the draft references the *un-burned* source,
-so the source's own hardcoded subtitles show in 剪映 (mask them there if needed); a
-BGM shorter than the recap is not auto-looped in the draft (copy it to extend);
+so the source's own hardcoded subtitles show in 剪映 (mask them there if needed);
 ffmpeg remains the canonical mix — the 剪映 mix is an editable approximation.
 
 ## Acknowledgements

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -7,15 +7,22 @@ Chains the independent video-* stage skills into a full narrated recap:
   [video-cut]  ->  video-voiceover  ->  video-assemble
 
 Each stage is a self-contained sibling skill invoked as a subprocess; they communicate
-only through JSON/MP4 artifacts in the shared work_dir. Stateless: rerun the same command
-after writing narration.json to continue (understanding artifacts are reused if fresh).
+only through JSON/MP4 artifacts in the shared work_dir. Resume by rerunning the same
+command after writing narration.json; Phase B verifies a run manifest before reusing
+work_dir artifacts.
 """
 import argparse
+import hashlib
+import json
+import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
 
 BUNDLE = Path(__file__).resolve().parents[2]  # the skills/ directory
+RUN_MANIFEST = "recap_run_manifest.json"
+ASSEMBLY_MANIFEST = "assembly_manifest.json"
 
 
 def _entry(skill, script):
@@ -30,6 +37,113 @@ def _run(skill, script, *cli_args):
         raise SystemExit(f"{skill}/{script} 失败 (exit {res.returncode})")
 
 
+def _file_fingerprint(path, chunk_size=1024 * 1024):
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _run_manifest_payload(video, args):
+    return {
+        "schema_version": 1,
+        "source_video": str(Path(video).resolve()),
+        "source_video_fingerprint": _file_fingerprint(video),
+        "settings": {
+            "context": args.context,
+            "scene_threshold": args.scene_threshold,
+            "style": args.style,
+            "edit_mode": args.edit_mode,
+            "target_duration": args.target_duration,
+            "skip_asr": bool(args.skip_asr),
+            "mimo_video_overview": bool(args.mimo_video_overview),
+            "consolidate": bool(args.consolidate),
+            "consolidate_asr": bool(args.consolidate_asr),
+        },
+    }
+
+
+def _write_run_manifest(work_dir, video, args):
+    payload = _run_manifest_payload(video, args)
+    (work_dir / RUN_MANIFEST).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _load_run_manifest(work_dir):
+    path = Path(work_dir) / RUN_MANIFEST
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _load_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _manifest_mismatches(work_dir, video, args):
+    expected = _run_manifest_payload(video, args)
+    actual = _load_run_manifest(work_dir)
+    if not actual:
+        return ["缺少或无法读取 recap_run_manifest.json；不能证明 work_dir 属于当前视频/参数"]
+    mismatches = []
+    for key in ("source_video", "source_video_fingerprint"):
+        if actual.get(key) != expected.get(key):
+            mismatches.append(f"{key}: expected {expected.get(key)!r}, got {actual.get(key)!r}")
+    if actual.get("settings") != expected.get("settings"):
+        mismatches.append("settings: 当前 CLI/env 参数与 Phase A manifest 不匹配")
+    return mismatches
+
+
+def _read_assembly_output(work_dir):
+    manifest = _load_json(Path(work_dir) / ASSEMBLY_MANIFEST)
+    if isinstance(manifest, dict) and manifest.get("final_output"):
+        return Path(manifest["final_output"])
+    return None
+
+
+def _continuation_command(video, work_dir, args):
+    parts = [sys.executable, str(_entry("video-recap", "recap.py")), str(video), "--work-dir", str(work_dir)]
+    if args.context:
+        parts += ["--context", args.context]
+    if args.scene_threshold is not None:
+        parts += ["--scene-threshold", str(args.scene_threshold)]
+    if args.style != "纪录片":
+        parts += ["--style", args.style]
+    if args.edit_mode != "full":
+        parts += ["--edit-mode", args.edit_mode]
+    if args.target_duration:
+        parts += ["--target-duration", args.target_duration]
+    if args.skip_asr:
+        parts.append("--skip-asr")
+    if args.mimo_video_overview:
+        parts.append("--mimo-video-overview")
+    if args.consolidate:
+        parts.append("--consolidate")
+    if args.consolidate_asr:
+        parts.append("--consolidate-asr")
+    if getattr(args, "mimo_tts_voice", None):
+        parts += ["--mimo-tts-voice", args.mimo_tts_voice]
+    if getattr(args, "allow_partial_tts", False):
+        parts.append("--allow-partial-tts")
+    if getattr(args, "burn_subtitles", False):
+        parts.append("--burn-subtitles")
+    if getattr(args, "output_dir", None):
+        parts += ["--output-dir", args.output_dir]
+    if getattr(args, "export_jianying", False):
+        parts.append("--export-jianying")
+    if getattr(args, "jianying_bundle_media", False):
+        parts.append("--jianying-bundle-media")
+    if getattr(args, "jianying_no_bundle_media", False):
+        parts.append("--jianying-no-bundle-media")
+    return " ".join(shlex.quote(part) for part in parts)
+
+
 def main():
     ap = argparse.ArgumentParser(description="Full video recap orchestrator (video-* skill bundle).")
     ap.add_argument("video", nargs="?")
@@ -37,13 +151,15 @@ def main():
     ap.add_argument("--context", default="")
     ap.add_argument("--scene-threshold", type=float, default=None)
     ap.add_argument("--style", default="纪录片")
-    ap.add_argument("--edit-mode", default="full", choices=["full", "cut"])
-    ap.add_argument("--target-duration", default=None)
+    ap.add_argument("--edit-mode", default=os.environ.get("EDIT_MODE", "full"), choices=["full", "cut"])
+    ap.add_argument("--target-duration", default=os.environ.get("TARGET_DURATION") or None)
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
     ap.add_argument("--consolidate", action="store_true", help="build understanding index (Pass B)")
     ap.add_argument("--consolidate-asr", action="store_true", help="also clean ASR (Pass A)")
     ap.add_argument("--mimo-tts-voice", default=None, help="MiMo TTS voice")
+    ap.add_argument("--allow-partial-tts", action="store_true",
+                    help="allow video-voiceover to continue when some narration segments fail TTS")
     ap.add_argument("--burn-subtitles", action="store_true")
     ap.add_argument("--output-dir", default=None)
     ap.add_argument("--export-jianying", action="store_true",
@@ -76,6 +192,10 @@ def main():
             uargs += ["--context", args.context]
         if args.scene_threshold is not None:
             uargs += ["--scene-threshold", str(args.scene_threshold)]
+        if args.edit_mode:
+            uargs += ["--edit-mode", args.edit_mode]
+        if args.target_duration:
+            uargs += ["--target-duration", args.target_duration]
         if args.skip_asr:
             uargs.append("--skip-asr")
         if args.mimo_video_overview:
@@ -85,10 +205,9 @@ def main():
         if args.consolidate_asr:
             uargs.append("--consolidate-asr")
         _run("video-understanding", "understand.py", *uargs)
+        _write_run_manifest(work_dir, video, args)
         brief = work_dir / "agent_narration_brief.md"
-        cont = f"python3 {_entry('video-recap', 'recap.py')} {video} --work-dir {work_dir}"
-        if cut:
-            cont += " --edit-mode cut"
+        cont = _continuation_command(video, work_dir, args)
         print("=" * 50)
         need = f"{narration_json}" + (f" 和 {clip_plan_json}" if cut else "")
         print(f"[video-recap] ⏸  阅读 {brief}（按 video-script 规则）后写入 {need}")
@@ -97,6 +216,14 @@ def main():
         return
 
     # Phase B: produce
+    mismatches = _manifest_mismatches(work_dir, video, args)
+    if mismatches:
+        details = "\n  - ".join(mismatches)
+        raise SystemExit(
+            "work_dir 与当前 recap 输入不匹配，拒绝复用既有 narration/clip_plan；"
+            "请使用新的 --work-dir，或删除旧产物后重新运行 Phase A。\n"
+            f"  - {details}"
+        )
     _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", args.edit_mode)
     assemble_video_path = video
     if cut:
@@ -106,9 +233,12 @@ def main():
         _run("video-cut", "cut.py", *cargs)
         assemble_video_path = work_dir / "edited_source.mp4"
 
-    vargs = ["--work-dir", str(work_dir)]
+    narration_for_tts = work_dir / ("narration_mapped.json" if cut else "narration.json")
+    vargs = ["--work-dir", str(work_dir), "--narration", str(narration_for_tts)]
     if args.mimo_tts_voice:
         vargs += ["--mimo-voice", args.mimo_tts_voice]
+    if args.allow_partial_tts:
+        vargs.append("--allow-partial-tts")
     _run("video-voiceover", "voiceover.py", *vargs)
 
     aargs = [str(assemble_video_path), "--work-dir", str(work_dir), "--recap-stem", video.stem]
@@ -128,7 +258,8 @@ def main():
     _run("video-assemble", "assemble.py", *aargs)
 
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
-    print(f"[video-recap] ✅ 完成: {final_dir / ('recap_' + video.stem + '.mp4')}")
+    final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + video.stem + ".mp4"))
+    print(f"[video-recap] ✅ 完成: {final_output}")
 
 
 if __name__ == "__main__":

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -320,32 +320,20 @@ def stable_hash(value):
     """Return an md5 digest for deterministic JSON-serializable values."""
     return hashlib.md5(stable_json_dumps(value).encode("utf-8")).hexdigest()
 
-def file_fingerprint(path, sample_bytes=65536):
-    """Return a fast content fingerprint based on file size plus head/tail bytes.
+def file_fingerprint(path, chunk_size=1024 * 1024):
+    """Return a full-content fingerprint for cache-correct identity checks.
 
     This intentionally avoids mtime/path so copied videos or JSON artifacts can
-    be reused when their bytes are identical, while changed bytes invalidate the
-    cache even if timestamps are misleading.
+    be reused when their bytes are identical, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
     """
-    path = os.fspath(path)
-    size = os.path.getsize(path)
-    h = hashlib.md5()
-    h.update(str(size).encode("ascii"))
-    h.update(b"\0")
-    with open(path, "rb") as f:
-        head = f.read(sample_bytes)
-        if size > sample_bytes:
-            f.seek(max(0, size - sample_bytes))
-            tail = f.read(sample_bytes)
-        else:
-            tail = b""
-    h.update(head)
-    h.update(b"\0")
-    h.update(tail)
+    h = hashlib.sha256()
+    with open(os.fspath(path), "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
     return h.hexdigest()
-
 def video_fingerprint(video_path):
-    """Fast video content fingerprint used as the root pipeline asset print."""
+    """Full video content fingerprint used as the root pipeline asset print."""
     return file_fingerprint(video_path)
 
 def step_cache_key(video_path, step_name, params_fingerprint=""):

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1,8 +1,9 @@
+import hashlib
 import json
 import re
 from pathlib import Path
 
-from lib import CONFIG
+from lib import CONFIG, file_fingerprint, stable_hash
 from lib import log
 
 
@@ -500,6 +501,11 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
             normalized.append({"index": idx, "start": start, "end": end, "char_count": char_count})
 
     sorted_segments = sorted(normalized, key=lambda item: item["start"])
+    if isinstance(narration, list) and not sorted_segments:
+        errors.append(_lint_issue(
+            "error", None, "empty_narration_file",
+            "narration.json must contain at least one valid narration segment",
+        ))
     for prev, curr in zip(sorted_segments, sorted_segments[1:]):
         if curr["start"] < prev["end"]:
             errors.append(_lint_issue(
@@ -973,16 +979,62 @@ def _format_timeline_fusion_for_brief(fusion, max_items=40):
     return lines
 
 
-def _load_consolidation(work_dir):
-    """Load consolidate.py's understanding_index.json if present, else {}."""
-    path = Path(work_dir) / "understanding_index.json"
-    if not path.exists():
+def _consolidation_model():
+    return CONFIG.get("vlm_model", "")
+
+
+def _clean_asr_prompt_fingerprint():
+    # Keep this literal in sync with consolidate.CLEAN_PROMPT without importing it;
+    # brief.py and narration.py must remain byte-identical cross-skill copies.
+    prompt = """你在清洗中文视频的 ASR 逐段转写。对【每一段】做：补标点、修明显同音/错别字、（能判断时）在句首轻标说话人，让长段连读文本变成清晰可读的句子。
+铁律：
+- 不要合并或拆分段落，输出段数必须与输入完全一致，顺序一致。
+- 不要改时间，不要输出 start/end（时间由程序保留）。
+- 只清洗 text，不要增删事实、不要脑补画面。
+只返回 JSON：{"segments":[{"i":0,"text":"清洗后的文本","speaker":"可选说话人"}, ...]}，i 为输入段的下标。"""
+    return hashlib.md5(prompt.encode("utf-8")).hexdigest()
+
+
+def _index_prompt_fingerprint():
+    prompt = """你在根据逐场景画面分析，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
+只依据给到的画面证据（场景描述 + 帧实动作），不要脑补画面之外的剧情。
+只返回 JSON：
+{"characters":[{"name":"角色名或外观指代","description":"身份/特征"}],
+ "relationships":[{"a":"角色","b":"角色","relation":"关系"}],
+ "plot_points":["按时间顺序的关键剧情节点"],
+ "entities":["重要物件/地点/线索"]}"""
+    return hashlib.md5(prompt.encode("utf-8")).hexdigest()
+
+
+def _load_consolidation(work_dir, scenes_analysis=None):
+    """Load consolidate.py's understanding_index.json only when provenance matches VLM input."""
+    work_dir = Path(work_dir)
+    path = work_dir / "understanding_index.json"
+    meta_path = work_dir / "understanding_index.json.meta.json"
+    if not path.exists() or not meta_path.exists():
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict) or not isinstance(meta, dict):
+        return {}
+    src_path = work_dir / "vlm_analysis.json"
+    try:
+        source_md5 = hashlib.md5(src_path.read_bytes()).hexdigest()
+    except OSError:
+        return {}
+    if meta.get("source_md5") != source_md5:
+        return {}
+    expected_count = len([s for s in (scenes_analysis or []) if isinstance(s, dict)])
+    if expected_count and meta.get("scene_count") != expected_count:
+        return {}
+    if meta.get("model") != _consolidation_model():
+        return {}
+    if meta.get("prompt_md5") != _index_prompt_fingerprint():
+        return {}
+    return data
 
 
 def _format_consolidation(index):
@@ -1054,10 +1106,13 @@ def _load_clean_asr(work_dir, asr_result):
     if not isinstance(segments, list) or len(segments) != len(base):
         return None
     try:
-        import hashlib
         if payload.get("source_md5") != hashlib.md5(src_path.read_bytes()).hexdigest():
             return None
     except OSError:
+        return None
+    if payload.get("model") != _consolidation_model():
+        return None
+    if payload.get("prompt_md5") != _clean_asr_prompt_fingerprint():
         return None
     for orig, clean in zip(base, segments):
         if not isinstance(clean, dict):
@@ -1072,7 +1127,130 @@ def _load_clean_asr(work_dir, asr_result):
     return segments
 
 
-def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片"):
+_MIMO_REJECTION_MARKERS = (
+    "request was rejected", "considered high risk", "high risk",
+    "content policy", "cannot process", "无法处理", "内容审核", "违规",
+)
+
+
+def _is_mimo_chunk_usable(content):
+    text = str(content or "").strip()
+    if not text:
+        return False
+    low = text.lower()
+    return not any(marker in low for marker in _MIMO_REJECTION_MARKERS)
+
+
+def _mimo_video_settings_fingerprint():
+    return {
+        "model": CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG.get("vlm_model"),
+        "mimo_video_api_url": CONFIG.get("mimo_video_api_url"),
+        "mimo_video_fps": CONFIG.get("mimo_video_fps", 2.0),
+        "mimo_media_resolution": CONFIG.get("mimo_media_resolution", "default"),
+        "mimo_video_chunk_max_seconds": CONFIG.get("mimo_video_chunk_max_seconds", 20.0),
+        "mimo_video_chunk_min_seconds": CONFIG.get("mimo_video_chunk_min_seconds", 1.0),
+        "mimo_video_base64_max_mb": CONFIG.get("mimo_video_base64_max_mb", 45.0),
+        "mimo_video_prompt": CONFIG.get("mimo_video_prompt", ""),
+        "mimo_disable_thinking": CONFIG.get("mimo_disable_thinking", True),
+    }
+
+
+def _mimo_chunk_cache_key(chunk):
+    return (
+        f"{chunk['chunk_id']}|{chunk['scene_id']}|"
+        f"{float(chunk['start']):.3f}-{float(chunk['end']):.3f}"
+    )
+
+
+def _mimo_cached_chunks_fingerprint(done):
+    return stable_hash(done)
+
+
+def _mimo_overview_payload_fingerprint(overview):
+    payload = dict(overview)
+    payload.pop("overview_fingerprint", None)
+    return stable_hash(payload)
+
+
+def _mimo_video_chunks_for_brief(scenes):
+    max_seconds = float(CONFIG.get("mimo_video_chunk_max_seconds", 20.0) or 20.0)
+    min_seconds = float(CONFIG.get("mimo_video_chunk_min_seconds", 1.0) or 1.0)
+    chunks = []
+    for scene_index, scene in enumerate(scenes or []):
+        if not isinstance(scene, dict):
+            continue
+        try:
+            start = float(scene.get("start", 0.0))
+            end = float(scene.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        scene_id = scene.get("scene_id", scene_index)
+        cursor = start
+        while cursor < end:
+            chunk_end = min(end, cursor + max_seconds)
+            if end - chunk_end < min_seconds and chunk_end < end:
+                chunk_end = end
+            if chunk_end > cursor:
+                chunks.append({
+                    "chunk_id": len(chunks),
+                    "scene_id": scene_id,
+                    "start": round(cursor, 3),
+                    "end": round(chunk_end, 3),
+                })
+            cursor = chunk_end
+    return chunks
+
+
+def _mimo_overview_matches_current_inputs(overview, scenes_analysis, video_path=None):
+    if not isinstance(overview, dict) or overview.get("input") != "scene_chunks":
+        return False
+    if overview.get("settings") != _mimo_video_settings_fingerprint():
+        return False
+    overview_fingerprint = overview.get("overview_fingerprint")
+    if not overview_fingerprint or overview_fingerprint != _mimo_overview_payload_fingerprint(overview):
+        return False
+    if video_path is not None:
+        try:
+            if overview.get("source_video_fingerprint") != file_fingerprint(video_path):
+                return False
+        except OSError:
+            return False
+    chunks = overview.get("chunks")
+    if not isinstance(chunks, list) or not all(
+        isinstance(chunk, dict) and _is_mimo_chunk_usable(chunk.get("content"))
+        for chunk in chunks
+    ):
+        return False
+    chunks_fingerprint = overview.get("chunks_fingerprint")
+    if not chunks_fingerprint or chunks_fingerprint != _mimo_cached_chunks_fingerprint(chunks):
+        return False
+    expected_chunks = _mimo_video_chunks_for_brief(scenes_analysis)
+    if not expected_chunks or len(chunks) != len(expected_chunks):
+        return False
+    try:
+        cached_keys = [_mimo_chunk_cache_key(chunk) for chunk in chunks]
+        expected_keys = [_mimo_chunk_cache_key(chunk) for chunk in expected_chunks]
+    except (KeyError, TypeError, ValueError):
+        return False
+    return cached_keys == expected_keys
+
+
+def _load_mimo_overview_for_brief(work_dir, scenes_analysis, enabled=None, video_path=None):
+    overview_enabled = CONFIG.get("mimo_video_overview", False) if enabled is None else enabled
+    if not overview_enabled:
+        return {}
+    path = Path(work_dir) / "mimo_video_overview.json"
+    if not path.exists():
+        return {}
+    try:
+        overview = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return overview if _mimo_overview_matches_current_inputs(overview, scenes_analysis, video_path=video_path) else {}
+
+def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
     """Write a compact brief that tells the agent exactly how to author recap artifacts."""
     effective_rate = CONFIG["speech_rate"] * CONFIG["speech_safety_margin"]
     breath_sec = CONFIG.get("breath_ms", 250) / 1000
@@ -1083,7 +1261,6 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     edit_mode = CONFIG.get("edit_mode", "full")
     target_duration = CONFIG.get("target_duration") or "(not set)"
     target_count = max(1, round(video_duration / 60 * target_spm))
-    mimo_overview_path = Path(work_dir) / "mimo_video_overview.json"
     lines = [
         "# Agent Narration Brief",
         "",
@@ -1105,7 +1282,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     substrate = assess_understanding_substrate(scenes_analysis, asr_result)
     lines.extend(_format_substrate_warning(substrate))
     lines.extend(_format_background_research(_load_background_research(work_dir)))
-    lines.extend(_format_consolidation(_load_consolidation(work_dir)))
+    lines.extend(_format_consolidation(_load_consolidation(work_dir, scenes_analysis)))
 
     asr_for_chunks = _load_clean_asr(work_dir, asr_result) or asr_result
     asr_chunks = _chunk_asr_for_writing(asr_for_chunks, scenes_analysis)
@@ -1115,19 +1292,17 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     lines.extend(_format_asr_chunks_for_brief(asr_chunks))
     lines.extend(_format_timeline_fusion_for_brief(timeline_fusion))
 
-    if mimo_overview_path.exists():
-        try:
-            mimo_overview = json.loads(mimo_overview_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            mimo_overview = {}
-        overview_text = (mimo_overview.get("content") or "").strip()
-        if overview_text:
-            lines.extend([
-                "## MiMo scene-chunk video overview",
-                "",
-                overview_text[:2000],
-                "",
-            ])
+    mimo_overview = _load_mimo_overview_for_brief(
+        work_dir, scenes_analysis, enabled=mimo_overview_enabled, video_path=mimo_overview_video_path,
+    )
+    overview_text = (mimo_overview.get("content") or "").strip()
+    if overview_text:
+        lines.extend([
+            "## MiMo scene-chunk video overview",
+            "",
+            overview_text[:2000],
+            "",
+        ])
 
     if edit_mode == "cut":
         lines.extend([

--- a/skills/video-script/scripts/validate.py
+++ b/skills/video-script/scripts/validate.py
@@ -6,6 +6,7 @@ understanding index produced by video-understanding. Writes narration_lint.json 
 in full mode, rewrites narration.json with quiet-window alignment applied.
 """
 import argparse
+import hashlib
 import json
 from pathlib import Path
 
@@ -20,6 +21,32 @@ from narration import (
 def _load(path):
     path = Path(path)
     return json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
+
+
+def _value_fingerprint(value):
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.md5(payload.encode("utf-8")).hexdigest()
+
+
+def _load_cut_clip_plan(work_dir):
+    raw_plan = Path(work_dir) / "clip_plan.json"
+    validated_plan = Path(work_dir) / "clip_plan_validated.json"
+    if not validated_plan.exists():
+        return _load(raw_plan)
+    if not raw_plan.exists():
+        return _load(validated_plan)
+
+    raw = _load(raw_plan)
+    validated = _load(validated_plan)
+    if (
+        isinstance(validated, dict)
+        and validated.get("raw_plan_fingerprint") == _value_fingerprint(raw)
+    ):
+        return validated
+    # The orchestrator validates before video-cut refreshes clip_plan_validated.json.
+    # Without a matching raw-plan provenance fingerprint, lint against the current
+    # raw plan even when mtimes are equal or misleading.
+    return raw
 
 
 def main():
@@ -38,7 +65,7 @@ def main():
     silence_periods = _load(work_dir / "silence_periods.json") or []
     clip_plan = None
     if args.mode == "cut":
-        clip_plan = _load(work_dir / "clip_plan_validated.json") or _load(work_dir / "clip_plan.json")
+        clip_plan = _load_cut_clip_plan(work_dir)
 
     validate_narration_or_raise(narration, vlm_analysis, clip_plan=clip_plan,
                                 mode=args.mode, work_dir=work_dir)

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -20,7 +20,8 @@ Turns a source video into an **understanding index** an agent (or a downstream s
 5. **VLM analysis** — `vlm_analysis.json` (per-scene description, depth analysis, `frame_facts`).
 6. **Timeline fusion + brief** — `timeline_fusion.json`, `asr_writing_chunks.json`, `agent_narration_brief.md`.
 
-Stateless: a stage is skipped only if its output exists and is newer than its input. `--force` recomputes.
+Stateless: reusable stages are skipped only when their output and provenance sidecar match
+the current source video plus output-affecting settings. `--force` recomputes.
 
 ## Requirements
 

--- a/skills/video-understanding/scripts/asr.py
+++ b/skills/video-understanding/scripts/asr.py
@@ -3,11 +3,26 @@ import json
 from pathlib import Path
 
 from lib import CONFIG
-from lib import log, run_cmd, get_video_duration, mimo_asr_api_call
+from lib import log, run_cmd, get_video_duration, mimo_asr_api_call, file_fingerprint
 
 # ── Step 3: ASR 转录（MiMo mimo-v2.5-asr，云端 API）────────────────────────
 
 _ASR_AUDIO_MIME = "audio/wav"
+
+
+def _audio_meta_path(work_dir):
+    return Path(work_dir) / "audio.wav.meta.json"
+
+
+def _write_audio_meta(work_dir, video_path):
+    _audio_meta_path(work_dir).write_text(
+        json.dumps({
+            "schema_version": 1,
+            "source_video_fingerprint": file_fingerprint(video_path),
+            "audio": "audio.wav",
+        }, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
 
 
 def transcribe_audio(video_path, work_dir):
@@ -28,6 +43,7 @@ def transcribe_audio(video_path, work_dir):
     result = run_cmd(cmd)
     if result.returncode != 0:
         raise RuntimeError(f"音频提取失败: {result.stderr}")
+    _write_audio_meta(work_dir, video_path)
 
     # 获取音频时长
     duration = get_video_duration(video_path)
@@ -63,7 +79,8 @@ def _run_asr(wav_path):
     """用 MiMo ASR (mimo-v2.5-asr) 转录单个 wav 文件，返回纯文本。
 
     音频以 base64 data-URI 放进 OpenAI 风格的 chat/completions 消息里，转写文本回到
-    choices[0].message.content。单段失败只记日志返回空串（保留其它段），与本地 ASR 旧行为一致。
+    choices[0].message.content。API/响应结构失败会抛错，避免把瞬时失败缓存成空转写；
+    只有无音频、超体积等确定不可发送的片段返回空串。
     """
     try:
         raw = Path(wav_path).read_bytes()
@@ -94,13 +111,11 @@ def _run_asr(wav_path):
     try:
         resp = mimo_asr_api_call(payload)
     except Exception as e:
-        log(f"ASR 警告: MiMo ASR 调用失败: {e}")
-        return ""
+        raise RuntimeError(f"MiMo ASR 调用失败: {e}") from e
     try:
         return str(resp["choices"][0]["message"]["content"] or "").strip()
     except (KeyError, IndexError, TypeError):
-        log(f"ASR 警告: MiMo ASR 返回结构异常: {json.dumps(resp, ensure_ascii=False)[:200]}")
-        return ""
+        raise RuntimeError(f"MiMo ASR 返回结构异常: {json.dumps(resp, ensure_ascii=False)[:200]}")
 
 
 def _segment_and_transcribe(audio_wav, segments_dir, total_duration, segment_length=None):

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1,8 +1,9 @@
+import hashlib
 import json
 import re
 from pathlib import Path
 
-from lib import CONFIG
+from lib import CONFIG, file_fingerprint, stable_hash
 from lib import log
 
 
@@ -500,6 +501,11 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
             normalized.append({"index": idx, "start": start, "end": end, "char_count": char_count})
 
     sorted_segments = sorted(normalized, key=lambda item: item["start"])
+    if isinstance(narration, list) and not sorted_segments:
+        errors.append(_lint_issue(
+            "error", None, "empty_narration_file",
+            "narration.json must contain at least one valid narration segment",
+        ))
     for prev, curr in zip(sorted_segments, sorted_segments[1:]):
         if curr["start"] < prev["end"]:
             errors.append(_lint_issue(
@@ -973,16 +979,62 @@ def _format_timeline_fusion_for_brief(fusion, max_items=40):
     return lines
 
 
-def _load_consolidation(work_dir):
-    """Load consolidate.py's understanding_index.json if present, else {}."""
-    path = Path(work_dir) / "understanding_index.json"
-    if not path.exists():
+def _consolidation_model():
+    return CONFIG.get("vlm_model", "")
+
+
+def _clean_asr_prompt_fingerprint():
+    # Keep this literal in sync with consolidate.CLEAN_PROMPT without importing it;
+    # brief.py and narration.py must remain byte-identical cross-skill copies.
+    prompt = """你在清洗中文视频的 ASR 逐段转写。对【每一段】做：补标点、修明显同音/错别字、（能判断时）在句首轻标说话人，让长段连读文本变成清晰可读的句子。
+铁律：
+- 不要合并或拆分段落，输出段数必须与输入完全一致，顺序一致。
+- 不要改时间，不要输出 start/end（时间由程序保留）。
+- 只清洗 text，不要增删事实、不要脑补画面。
+只返回 JSON：{"segments":[{"i":0,"text":"清洗后的文本","speaker":"可选说话人"}, ...]}，i 为输入段的下标。"""
+    return hashlib.md5(prompt.encode("utf-8")).hexdigest()
+
+
+def _index_prompt_fingerprint():
+    prompt = """你在根据逐场景画面分析，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
+只依据给到的画面证据（场景描述 + 帧实动作），不要脑补画面之外的剧情。
+只返回 JSON：
+{"characters":[{"name":"角色名或外观指代","description":"身份/特征"}],
+ "relationships":[{"a":"角色","b":"角色","relation":"关系"}],
+ "plot_points":["按时间顺序的关键剧情节点"],
+ "entities":["重要物件/地点/线索"]}"""
+    return hashlib.md5(prompt.encode("utf-8")).hexdigest()
+
+
+def _load_consolidation(work_dir, scenes_analysis=None):
+    """Load consolidate.py's understanding_index.json only when provenance matches VLM input."""
+    work_dir = Path(work_dir)
+    path = work_dir / "understanding_index.json"
+    meta_path = work_dir / "understanding_index.json.meta.json"
+    if not path.exists() or not meta_path.exists():
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict) or not isinstance(meta, dict):
+        return {}
+    src_path = work_dir / "vlm_analysis.json"
+    try:
+        source_md5 = hashlib.md5(src_path.read_bytes()).hexdigest()
+    except OSError:
+        return {}
+    if meta.get("source_md5") != source_md5:
+        return {}
+    expected_count = len([s for s in (scenes_analysis or []) if isinstance(s, dict)])
+    if expected_count and meta.get("scene_count") != expected_count:
+        return {}
+    if meta.get("model") != _consolidation_model():
+        return {}
+    if meta.get("prompt_md5") != _index_prompt_fingerprint():
+        return {}
+    return data
 
 
 def _format_consolidation(index):
@@ -1054,10 +1106,13 @@ def _load_clean_asr(work_dir, asr_result):
     if not isinstance(segments, list) or len(segments) != len(base):
         return None
     try:
-        import hashlib
         if payload.get("source_md5") != hashlib.md5(src_path.read_bytes()).hexdigest():
             return None
     except OSError:
+        return None
+    if payload.get("model") != _consolidation_model():
+        return None
+    if payload.get("prompt_md5") != _clean_asr_prompt_fingerprint():
         return None
     for orig, clean in zip(base, segments):
         if not isinstance(clean, dict):
@@ -1072,7 +1127,130 @@ def _load_clean_asr(work_dir, asr_result):
     return segments
 
 
-def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片"):
+_MIMO_REJECTION_MARKERS = (
+    "request was rejected", "considered high risk", "high risk",
+    "content policy", "cannot process", "无法处理", "内容审核", "违规",
+)
+
+
+def _is_mimo_chunk_usable(content):
+    text = str(content or "").strip()
+    if not text:
+        return False
+    low = text.lower()
+    return not any(marker in low for marker in _MIMO_REJECTION_MARKERS)
+
+
+def _mimo_video_settings_fingerprint():
+    return {
+        "model": CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG.get("vlm_model"),
+        "mimo_video_api_url": CONFIG.get("mimo_video_api_url"),
+        "mimo_video_fps": CONFIG.get("mimo_video_fps", 2.0),
+        "mimo_media_resolution": CONFIG.get("mimo_media_resolution", "default"),
+        "mimo_video_chunk_max_seconds": CONFIG.get("mimo_video_chunk_max_seconds", 20.0),
+        "mimo_video_chunk_min_seconds": CONFIG.get("mimo_video_chunk_min_seconds", 1.0),
+        "mimo_video_base64_max_mb": CONFIG.get("mimo_video_base64_max_mb", 45.0),
+        "mimo_video_prompt": CONFIG.get("mimo_video_prompt", ""),
+        "mimo_disable_thinking": CONFIG.get("mimo_disable_thinking", True),
+    }
+
+
+def _mimo_chunk_cache_key(chunk):
+    return (
+        f"{chunk['chunk_id']}|{chunk['scene_id']}|"
+        f"{float(chunk['start']):.3f}-{float(chunk['end']):.3f}"
+    )
+
+
+def _mimo_cached_chunks_fingerprint(done):
+    return stable_hash(done)
+
+
+def _mimo_overview_payload_fingerprint(overview):
+    payload = dict(overview)
+    payload.pop("overview_fingerprint", None)
+    return stable_hash(payload)
+
+
+def _mimo_video_chunks_for_brief(scenes):
+    max_seconds = float(CONFIG.get("mimo_video_chunk_max_seconds", 20.0) or 20.0)
+    min_seconds = float(CONFIG.get("mimo_video_chunk_min_seconds", 1.0) or 1.0)
+    chunks = []
+    for scene_index, scene in enumerate(scenes or []):
+        if not isinstance(scene, dict):
+            continue
+        try:
+            start = float(scene.get("start", 0.0))
+            end = float(scene.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        scene_id = scene.get("scene_id", scene_index)
+        cursor = start
+        while cursor < end:
+            chunk_end = min(end, cursor + max_seconds)
+            if end - chunk_end < min_seconds and chunk_end < end:
+                chunk_end = end
+            if chunk_end > cursor:
+                chunks.append({
+                    "chunk_id": len(chunks),
+                    "scene_id": scene_id,
+                    "start": round(cursor, 3),
+                    "end": round(chunk_end, 3),
+                })
+            cursor = chunk_end
+    return chunks
+
+
+def _mimo_overview_matches_current_inputs(overview, scenes_analysis, video_path=None):
+    if not isinstance(overview, dict) or overview.get("input") != "scene_chunks":
+        return False
+    if overview.get("settings") != _mimo_video_settings_fingerprint():
+        return False
+    overview_fingerprint = overview.get("overview_fingerprint")
+    if not overview_fingerprint or overview_fingerprint != _mimo_overview_payload_fingerprint(overview):
+        return False
+    if video_path is not None:
+        try:
+            if overview.get("source_video_fingerprint") != file_fingerprint(video_path):
+                return False
+        except OSError:
+            return False
+    chunks = overview.get("chunks")
+    if not isinstance(chunks, list) or not all(
+        isinstance(chunk, dict) and _is_mimo_chunk_usable(chunk.get("content"))
+        for chunk in chunks
+    ):
+        return False
+    chunks_fingerprint = overview.get("chunks_fingerprint")
+    if not chunks_fingerprint or chunks_fingerprint != _mimo_cached_chunks_fingerprint(chunks):
+        return False
+    expected_chunks = _mimo_video_chunks_for_brief(scenes_analysis)
+    if not expected_chunks or len(chunks) != len(expected_chunks):
+        return False
+    try:
+        cached_keys = [_mimo_chunk_cache_key(chunk) for chunk in chunks]
+        expected_keys = [_mimo_chunk_cache_key(chunk) for chunk in expected_chunks]
+    except (KeyError, TypeError, ValueError):
+        return False
+    return cached_keys == expected_keys
+
+
+def _load_mimo_overview_for_brief(work_dir, scenes_analysis, enabled=None, video_path=None):
+    overview_enabled = CONFIG.get("mimo_video_overview", False) if enabled is None else enabled
+    if not overview_enabled:
+        return {}
+    path = Path(work_dir) / "mimo_video_overview.json"
+    if not path.exists():
+        return {}
+    try:
+        overview = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return overview if _mimo_overview_matches_current_inputs(overview, scenes_analysis, video_path=video_path) else {}
+
+def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
     """Write a compact brief that tells the agent exactly how to author recap artifacts."""
     effective_rate = CONFIG["speech_rate"] * CONFIG["speech_safety_margin"]
     breath_sec = CONFIG.get("breath_ms", 250) / 1000
@@ -1083,7 +1261,6 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     edit_mode = CONFIG.get("edit_mode", "full")
     target_duration = CONFIG.get("target_duration") or "(not set)"
     target_count = max(1, round(video_duration / 60 * target_spm))
-    mimo_overview_path = Path(work_dir) / "mimo_video_overview.json"
     lines = [
         "# Agent Narration Brief",
         "",
@@ -1105,7 +1282,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     substrate = assess_understanding_substrate(scenes_analysis, asr_result)
     lines.extend(_format_substrate_warning(substrate))
     lines.extend(_format_background_research(_load_background_research(work_dir)))
-    lines.extend(_format_consolidation(_load_consolidation(work_dir)))
+    lines.extend(_format_consolidation(_load_consolidation(work_dir, scenes_analysis)))
 
     asr_for_chunks = _load_clean_asr(work_dir, asr_result) or asr_result
     asr_chunks = _chunk_asr_for_writing(asr_for_chunks, scenes_analysis)
@@ -1115,19 +1292,17 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     lines.extend(_format_asr_chunks_for_brief(asr_chunks))
     lines.extend(_format_timeline_fusion_for_brief(timeline_fusion))
 
-    if mimo_overview_path.exists():
-        try:
-            mimo_overview = json.loads(mimo_overview_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            mimo_overview = {}
-        overview_text = (mimo_overview.get("content") or "").strip()
-        if overview_text:
-            lines.extend([
-                "## MiMo scene-chunk video overview",
-                "",
-                overview_text[:2000],
-                "",
-            ])
+    mimo_overview = _load_mimo_overview_for_brief(
+        work_dir, scenes_analysis, enabled=mimo_overview_enabled, video_path=mimo_overview_video_path,
+    )
+    overview_text = (mimo_overview.get("content") or "").strip()
+    if overview_text:
+        lines.extend([
+            "## MiMo scene-chunk video overview",
+            "",
+            overview_text[:2000],
+            "",
+        ])
 
     if edit_mode == "cut":
         lines.extend([

--- a/skills/video-understanding/scripts/consolidate.py
+++ b/skills/video-understanding/scripts/consolidate.py
@@ -172,6 +172,47 @@ def _asr_source_md5(work_dir):
     return hashlib.md5(path.read_bytes()).hexdigest() if path.exists() else ""
 
 
+def _vlm_source_md5(work_dir):
+    """Provenance: md5 of the on-disk vlm_analysis.json bytes."""
+    path = Path(work_dir) / "vlm_analysis.json"
+    return hashlib.md5(path.read_bytes()).hexdigest() if path.exists() else ""
+
+
+def _index_meta_path(work_dir):
+    return Path(work_dir) / "understanding_index.json.meta.json"
+
+
+def _prompt_fingerprint(prompt):
+    return hashlib.md5(str(prompt or "").encode("utf-8")).hexdigest()
+
+
+def _write_index_meta(work_dir, vlm_analysis):
+    _index_meta_path(work_dir).write_text(json.dumps({
+        "schema_version": 1,
+        "source_md5": _vlm_source_md5(work_dir),
+        "scene_count": len([s for s in (vlm_analysis or []) if isinstance(s, dict)]),
+        "model": CONFIG.get("vlm_model", ""),
+        "prompt_md5": _prompt_fingerprint(INDEX_PROMPT),
+    }, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _index_cache_matches(work_dir, vlm_analysis):
+    meta_path = _index_meta_path(work_dir)
+    if not meta_path.exists():
+        return False
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    return (
+        isinstance(meta, dict)
+        and meta.get("source_md5") == _vlm_source_md5(work_dir)
+        and meta.get("scene_count") == len([s for s in (vlm_analysis or []) if isinstance(s, dict)])
+        and meta.get("model") == CONFIG.get("vlm_model", "")
+        and meta.get("prompt_md5") == _prompt_fingerprint(INDEX_PROMPT)
+    )
+
+
 # ── thin drivers (I/O + api_call) ─────────────────────────────────────────────
 
 def _load(work_dir, name):
@@ -193,7 +234,11 @@ def consolidate_transcript(work_dir):
     out_path = work_dir / "asr_clean.json"
     if _fresh(out_path, work_dir / "asr_result.json"):
         existing = _load(work_dir, "asr_clean.json") or {}
-        if existing.get("source_md5") == _asr_source_md5(work_dir):
+        if (
+            existing.get("source_md5") == _asr_source_md5(work_dir)
+            and existing.get("model") == CONFIG.get("vlm_model", "")
+            and existing.get("prompt_md5") == _prompt_fingerprint(CLEAN_PROMPT)
+        ):
             log("consolidate(asr): asr_clean.json 已最新，跳过")
             return existing
     resp = api_call({"model": CONFIG.get("vlm_model", ""),
@@ -201,7 +246,12 @@ def consolidate_transcript(work_dir):
                      "max_tokens": 4000, "temperature": 0.2})
     content = _response_text(resp)
     segments = parse_clean_response(content, asr_result)
-    payload = {"source_md5": _asr_source_md5(work_dir), "segments": segments}
+    payload = {
+        "source_md5": _asr_source_md5(work_dir),
+        "model": CONFIG.get("vlm_model", ""),
+        "prompt_md5": _prompt_fingerprint(CLEAN_PROMPT),
+        "segments": segments,
+    }
     out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     log(f"consolidate(asr): 写出 asr_clean.json（{len(segments)} 段）")
     return payload
@@ -214,7 +264,7 @@ def consolidate_index(work_dir):
         log("consolidate(index): 无 vlm_analysis.json，跳过")
         return None
     out_path = work_dir / "understanding_index.json"
-    if _fresh(out_path, work_dir / "vlm_analysis.json"):
+    if _fresh(out_path, work_dir / "vlm_analysis.json") and _index_cache_matches(work_dir, vlm_analysis):
         log("consolidate(index): understanding_index.json 已最新，跳过")
         return _load(work_dir, "understanding_index.json")
     resp = api_call({"model": CONFIG.get("vlm_model", ""),
@@ -222,6 +272,7 @@ def consolidate_index(work_dir):
                      "max_tokens": 2500, "temperature": 0.2})
     index = parse_index_response(_response_text(resp))
     out_path.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
+    _write_index_meta(work_dir, vlm_analysis)
     (work_dir / "understanding_index.md").write_text(format_index_md(index), encoding="utf-8")
     log(f"consolidate(index): 写出 understanding_index.json（角色 {len(index['characters'])}）")
     return index

--- a/skills/video-understanding/scripts/detect.py
+++ b/skills/video-understanding/scripts/detect.py
@@ -2,9 +2,10 @@ import json
 import os
 import re
 import subprocess
+from pathlib import Path
 
 from lib import CONFIG
-from lib import log, run_cmd, get_video_duration
+from lib import log, run_cmd, get_video_duration, file_fingerprint
 
 # ── Step 2: 场景检测 ──────────────────────────────────────────────────
 
@@ -165,7 +166,9 @@ def _filter_junk_scenes(scenes, video_path):
 def detect_silence_periods(video_path, work_dir, asr_result=None):
     """用 ffmpeg silencedetect 检测安静时段，作为解说插入的候选窗口"""
     audio_path = work_dir / "audio.wav"
-    if not audio_path.exists():
+    if not _audio_cache_matches(audio_path, video_path):
+        if audio_path.exists():
+            audio_path.unlink()
         # 提取到临时文件，成功后原子移动到位，避免被中断的 -y 运行留下半截 audio.wav
         tmp_path = work_dir / "audio.wav.tmp"
         extract = run_cmd([
@@ -179,6 +182,7 @@ def detect_silence_periods(video_path, work_dir, asr_result=None):
                 tmp_path.unlink()
             return []
         os.replace(str(tmp_path), str(audio_path))
+        _write_audio_meta(work_dir, video_path)
 
     noise = CONFIG["silence_noise_threshold"]
     min_dur = CONFIG["silence_min_duration"]
@@ -256,3 +260,36 @@ def detect_silence_periods(video_path, work_dir, asr_result=None):
         flag = " [有语音]" if qp["has_speech"] else ""
         log(f"  {qp['start']:.1f}s-{qp['end']:.1f}s ({qp['duration']:.1f}s){flag}")
     return periods
+
+
+def _audio_meta_path(work_dir):
+    return Path(work_dir) / "audio.wav.meta.json"
+
+
+def _audio_cache_matches(audio_path, video_path):
+    audio_path = Path(audio_path)
+    if not audio_path.exists():
+        return False
+    meta_path = _audio_meta_path(audio_path.parent)
+    if not meta_path.exists():
+        return False
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return False
+    try:
+        expected = file_fingerprint(video_path)
+    except OSError:
+        return False
+    return meta.get("source_video_fingerprint") == expected
+
+
+def _write_audio_meta(work_dir, video_path):
+    _audio_meta_path(work_dir).write_text(
+        json.dumps({
+            "schema_version": 1,
+            "source_video_fingerprint": file_fingerprint(video_path),
+            "audio": "audio.wav",
+        }, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -320,32 +320,20 @@ def stable_hash(value):
     """Return an md5 digest for deterministic JSON-serializable values."""
     return hashlib.md5(stable_json_dumps(value).encode("utf-8")).hexdigest()
 
-def file_fingerprint(path, sample_bytes=65536):
-    """Return a fast content fingerprint based on file size plus head/tail bytes.
+def file_fingerprint(path, chunk_size=1024 * 1024):
+    """Return a full-content fingerprint for cache-correct identity checks.
 
     This intentionally avoids mtime/path so copied videos or JSON artifacts can
-    be reused when their bytes are identical, while changed bytes invalidate the
-    cache even if timestamps are misleading.
+    be reused when their bytes are identical, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
     """
-    path = os.fspath(path)
-    size = os.path.getsize(path)
-    h = hashlib.md5()
-    h.update(str(size).encode("ascii"))
-    h.update(b"\0")
-    with open(path, "rb") as f:
-        head = f.read(sample_bytes)
-        if size > sample_bytes:
-            f.seek(max(0, size - sample_bytes))
-            tail = f.read(sample_bytes)
-        else:
-            tail = b""
-    h.update(head)
-    h.update(b"\0")
-    h.update(tail)
+    h = hashlib.sha256()
+    with open(os.fspath(path), "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
     return h.hexdigest()
-
 def video_fingerprint(video_path):
-    """Fast video content fingerprint used as the root pipeline asset print."""
+    """Full video content fingerprint used as the root pipeline asset print."""
     return file_fingerprint(video_path)
 
 def step_cache_key(video_path, step_name, params_fingerprint=""):

--- a/skills/video-understanding/scripts/understand.py
+++ b/skills/video-understanding/scripts/understand.py
@@ -3,18 +3,20 @@
 
 Analyze a source video into a structured understanding index (scenes, ASR transcript,
 per-scene VLM analysis, silence windows, fused timeline) plus a narration-writing brief.
-Stateless: a stage is skipped only when its output artifact already exists and is newer
-than its input (use --force to recompute everything).
+Stateless: a semantic stage is skipped only when its output artifact and provenance
+sidecar match the current source video plus output-affecting settings (use --force
+to recompute everything).
 """
 import argparse
+import hashlib
 import json
 from pathlib import Path
 
-from lib import CONFIG, log, get_video_duration, api_call
+from lib import CONFIG, log, get_video_duration, api_call, file_fingerprint, load_prompt
 from extract import extract_frames
 from detect import detect_scenes, detect_silence_periods
 from asr import transcribe_audio
-from vlm import analyze_scenes, analyze_video_overview
+from vlm import analyze_scenes, analyze_video_overview, mimo_video_overview_cache_fresh
 from brief import build_agent_brief, assess_understanding_substrate
 
 
@@ -26,6 +28,183 @@ def _fresh(out, *inputs):
     if not ins:
         return out.stat().st_size > 0
     return out.stat().st_mtime >= max(p.stat().st_mtime for p in ins)
+
+
+def _artifact_meta_path(artifact_path):
+    artifact_path = Path(artifact_path)
+    return artifact_path.with_name(f"{artifact_path.name}.meta.json")
+
+
+def _load_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _artifact_fingerprint(path):
+    path = Path(path)
+    return file_fingerprint(path) if path.exists() else None
+
+
+def _stage_cache_valid(artifact_path, expected_meta):
+    artifact_path = Path(artifact_path)
+    if not artifact_path.exists():
+        return False
+    meta_path = _artifact_meta_path(artifact_path)
+    if not meta_path.exists():
+        return False
+    try:
+        meta = _load_json(meta_path)
+    except (OSError, ValueError, TypeError):
+        return False
+    recorded = meta.get("artifact_fingerprint") if isinstance(meta, dict) else None
+    if not recorded or recorded != _artifact_fingerprint(artifact_path):
+        return False
+    expected = dict(expected_meta)
+    expected["artifact_fingerprint"] = recorded
+    return meta == expected
+
+
+def _write_stage_meta(artifact_path, meta):
+    meta_path = _artifact_meta_path(artifact_path)
+    payload = dict(meta)
+    payload["artifact_fingerprint"] = _artifact_fingerprint(artifact_path)
+    meta_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _remove_stage_meta(artifact_path):
+    _artifact_meta_path(artifact_path).unlink(missing_ok=True)
+
+
+def _scene_cache_payload(video_path):
+    return {
+        "schema_version": 1,
+        "stage": "scenes",
+        "source_video_fingerprint": file_fingerprint(video_path),
+        "settings": {
+            "scene_threshold": CONFIG.get("scene_threshold"),
+            "scene_junk_filter": CONFIG.get("scene_junk_filter"),
+            "scene_merge_min": CONFIG.get("scene_merge_min"),
+            "scene_junk_dark_luma": CONFIG.get("scene_junk_dark_luma"),
+            "scene_junk_bright_luma": CONFIG.get("scene_junk_bright_luma"),
+            "scene_junk_pixel_ratio": CONFIG.get("scene_junk_pixel_ratio"),
+        },
+    }
+
+
+def _asr_cache_payload(video_path, *, skip_asr=False):
+    return {
+        "schema_version": 1,
+        "stage": "asr",
+        "source_video_fingerprint": file_fingerprint(video_path),
+        "settings": {
+            "skip_asr": bool(skip_asr),
+            "mimo_asr_api_key_present": bool(CONFIG.get("mimo_asr_api_key")),
+            "mimo_asr_api_url": CONFIG.get("mimo_asr_api_url"),
+            "mimo_asr_model": CONFIG.get("mimo_asr_model"),
+            "mimo_asr_language": CONFIG.get("mimo_asr_language"),
+            "mimo_asr_base64_max_mb": CONFIG.get("mimo_asr_base64_max_mb"),
+            "asr_segment_seconds": CONFIG.get("asr_segment_seconds"),
+        },
+    }
+
+
+def _silence_cache_payload(video_path, asr_json):
+    return {
+        "schema_version": 1,
+        "stage": "silence",
+        "source_video_fingerprint": file_fingerprint(video_path),
+        "asr_result_fingerprint": _artifact_fingerprint(asr_json),
+        "asr_meta": _load_json(_artifact_meta_path(asr_json)) if _artifact_meta_path(asr_json).exists() else None,
+        "settings": {
+            "silence_noise_threshold": CONFIG.get("silence_noise_threshold"),
+            "silence_min_duration": CONFIG.get("silence_min_duration"),
+            "quiet_window_min": CONFIG.get("quiet_window_min"),
+            "silence_merge_gap": CONFIG.get("silence_merge_gap"),
+        },
+    }
+
+
+def _vlm_prompt_fingerprint():
+    prompt = load_prompt("VLM_DEPTH_PROMPT")
+    if not prompt:
+        prompt = (
+            "仔细观察这些视频帧。分两部分输出：\n"
+            "【描述】不超过80字，描述画面中正在发生什么。\n"
+            "【深层分析】不超过120字，分析角色情绪、关系动态、潜台词。"
+        )
+    context = CONFIG.get("context_info", "")
+    if context:
+        prompt = f"已知信息：{context}\n\n{prompt}"
+    return {
+        "prompt_text_fingerprint": _text_fingerprint(prompt),
+        "context_info_fingerprint": _text_fingerprint(context),
+    }
+
+
+def _text_fingerprint(value):
+    return hashlib.md5(str(value or "").encode("utf-8")).hexdigest()
+
+
+def _vlm_cache_payload(video_path, work_dir, scenes_json, frames):
+    return {
+        "schema_version": 1,
+        "stage": "vlm",
+        "source_video_fingerprint": file_fingerprint(video_path),
+        "scenes_fingerprint": _artifact_fingerprint(scenes_json),
+        "frames": _frame_cache_payload(video_path, CONFIG.get("fps"), frames),
+        "prompt": _vlm_prompt_fingerprint(),
+        "settings": {
+            "fps": CONFIG.get("fps"),
+            "vlm_model": CONFIG.get("vlm_model"),
+            "api_url": CONFIG.get("api_url"),
+            "mimo_disable_thinking": CONFIG.get("mimo_disable_thinking", True),
+            "mimo_media_resolution": CONFIG.get("mimo_media_resolution"),
+            "background_research_fingerprint": _artifact_fingerprint(Path(work_dir) / "background_research.json"),
+        },
+    }
+
+
+def _frames_manifest_path(work_dir):
+    return Path(work_dir) / "frames" / "frames_manifest.json"
+
+
+def _frame_cache_payload(video_path, fps, frames):
+    frame_names = [Path(frame).name for frame in frames]
+    return {
+        "schema_version": 1,
+        "source_video_fingerprint": file_fingerprint(video_path),
+        "fps": float(fps),
+        "frame_count": len(frames),
+        "frames": frame_names,
+        "frame_fingerprints": {
+            name: file_fingerprint(frame)
+            for name, frame in zip(frame_names, frames)
+        },
+    }
+
+
+def _write_frames_manifest(work_dir, video_path, fps, frames):
+    manifest_path = _frames_manifest_path(work_dir)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(_frame_cache_payload(video_path, fps, frames), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _frames_cache_valid(video_path, work_dir, fps):
+    frames_dir = Path(work_dir) / "frames"
+    frames = sorted(frames_dir.glob("frame_*.jpg"))
+    if not frames:
+        return False
+    manifest_path = _frames_manifest_path(work_dir)
+    if not manifest_path.exists():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        expected = _frame_cache_payload(video_path, fps, frames)
+    except (OSError, ValueError, TypeError):
+        return False
+    return manifest == expected
 
 
 def _research_context(work_dir):
@@ -69,6 +248,8 @@ def main():
     ap.add_argument("--context", default="", help="extra context (show name, character names, ...)")
     ap.add_argument("--scene-threshold", type=float, default=None)
     ap.add_argument("--style", default="纪录片")
+    ap.add_argument("--edit-mode", default=None, choices=["full", "cut"], help="recap mode to document in the writing brief")
+    ap.add_argument("--target-duration", default=None, help="cut-mode target duration to document in the writing brief")
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
     ap.add_argument("--force", action="store_true", help="ignore cached artifacts and recompute")
@@ -89,6 +270,10 @@ def main():
         log(f"已并入 background_research.json 到理解上下文（{len(research_ctx)} 字）")
     if args.scene_threshold is not None:
         CONFIG["scene_threshold"] = args.scene_threshold
+    if args.edit_mode is not None:
+        CONFIG["edit_mode"] = args.edit_mode
+    if args.target_duration is not None:
+        CONFIG["target_duration"] = args.target_duration
     if args.mimo_video_overview:
         CONFIG["mimo_video_overview"] = True
     scene_threshold = CONFIG.get("scene_threshold")
@@ -105,45 +290,54 @@ def main():
     frames_dir = work_dir / "frames"
 
     # Step 1: frame extraction
-    if not args.force and frames_dir.exists() and any(frames_dir.glob("frame_*.jpg")):
+    if not args.force and _frames_cache_valid(video, work_dir, CONFIG["fps"]):
         frames = sorted(frames_dir.glob("frame_*.jpg"))
-        log(f"跳过帧提取（已存在 {len(frames)} 帧）")
+        log(f"跳过帧提取（缓存匹配 {len(frames)} 帧）")
     else:
         frames = extract_frames(video, work_dir)
+        _write_frames_manifest(work_dir, video, CONFIG["fps"], frames)
 
     # Step 2: scene detection
-    if not args.force and _fresh(scenes_json, video):
-        scenes = json.loads(scenes_json.read_text(encoding="utf-8"))
+    scenes_meta = _scene_cache_payload(video)
+    if not args.force and _stage_cache_valid(scenes_json, scenes_meta):
+        scenes = _load_json(scenes_json)
         log(f"跳过场景检测（已存在 {len(scenes)} 个场景）")
     else:
         scenes = detect_scenes(video, work_dir, scene_threshold)
+        _write_stage_meta(scenes_json, scenes_meta)
 
     # Step 3: ASR
+    asr_meta = _asr_cache_payload(video, skip_asr=args.skip_asr)
     if args.skip_asr:
         asr_result = []
         asr_json.write_text(json.dumps(asr_result, ensure_ascii=False, indent=2), encoding="utf-8")
+        _write_stage_meta(asr_json, asr_meta)
         log("跳过 ASR（--skip-asr）")
-    elif not args.force and _fresh(asr_json, video):
-        asr_result = json.loads(asr_json.read_text(encoding="utf-8"))
+    elif not args.force and _stage_cache_valid(asr_json, asr_meta):
+        asr_result = _load_json(asr_json)
         log(f"跳过 ASR（已存在 {len(asr_result)} 段）")
     else:
         try:
             asr_result = transcribe_audio(video, work_dir)
         except Exception as e:
-            log(f"ASR 失败（继续无 ASR）: {e}")
-            asr_result = []
-            asr_json.write_text(json.dumps(asr_result, ensure_ascii=False, indent=2), encoding="utf-8")
+            _remove_stage_meta(asr_json)
+            asr_json.unlink(missing_ok=True)
+            raise RuntimeError(f"ASR 失败；未写入可复用缓存，请修复后重试或显式使用 --skip-asr: {e}") from e
+        _write_stage_meta(asr_json, asr_meta)
 
     # Step 3.5: silence detection
-    if not args.force and _fresh(silence_json, asr_json):
-        silence_periods = json.loads(silence_json.read_text(encoding="utf-8"))
+    silence_meta = _silence_cache_payload(video, asr_json)
+    if not args.force and _stage_cache_valid(silence_json, silence_meta):
+        silence_periods = _load_json(silence_json)
         log(f"跳过静音检测（已存在 {len(silence_periods)} 个窗口）")
     else:
         silence_periods = detect_silence_periods(video, work_dir, asr_result)
+        _write_stage_meta(silence_json, silence_meta)
 
     # Step 4: VLM analysis (the only stage that requires the chat API key)
-    if not args.force and _fresh(vlm_json, scenes_json):
-        vlm_analysis = json.loads(vlm_json.read_text(encoding="utf-8"))
+    vlm_meta = _vlm_cache_payload(video, work_dir, scenes_json, frames)
+    if not args.force and _stage_cache_valid(vlm_json, vlm_meta):
+        vlm_analysis = _load_json(vlm_json)
         log(f"跳过 VLM 分析（已存在 {len(vlm_analysis)} 个场景）")
     else:
         if not CONFIG.get("api_key"):
@@ -153,18 +347,24 @@ def main():
         api_call({"model": CONFIG.get("vlm_model", ""),
                   "messages": [{"role": "user", "content": "hi"}], "max_tokens": 5})
         vlm_analysis = analyze_scenes(scenes, frames, work_dir)
+        _write_stage_meta(vlm_json, vlm_meta)
 
     # Step 4.1: optional MiMo scene-chunk video understanding
+    overview_path = work_dir / "mimo_video_overview.json"
     if CONFIG.get("mimo_video_overview", False):
         if not CONFIG.get("mimo_video_api_key"):
             log("跳过 MiMo 分片视频概览：未设置 MIMO_API_KEY")
-        elif _fresh(work_dir / "mimo_video_overview.json", scenes_json):
-            log("跳过 MiMo 分片视频概览（已存在）")
+            overview_path.unlink(missing_ok=True)
+        elif mimo_video_overview_cache_fresh(overview_path, video, scenes):
+            log("跳过 MiMo 分片视频概览（缓存匹配）")
         else:
+            overview_path.unlink(missing_ok=True)
             try:
                 analyze_video_overview(video, work_dir, scenes)
             except Exception as e:
                 log(f"MiMo 分片视频概览失败（忽略）: {e}")
+    else:
+        overview_path.unlink(missing_ok=True)
 
     # optional consolidation (整理): build the understanding index before the brief folds it in
     if args.consolidate or args.consolidate_asr:
@@ -180,7 +380,11 @@ def main():
         banner = "理解素材为空" if substrate["level"] == "empty" else "理解素材偏薄"
         log(f"⚠️  {banner}：ASR {substrate['asr_chars']} 字 | 场景 {substrate['scene_count']} | "
             f"带 frame_facts 的场景 {substrate['scenes_with_frame_facts']} | 平均画面描述 {substrate['avg_description_len']} 字")
-    brief_path = build_agent_brief(vlm_analysis, asr_result, silence_periods, video_duration, work_dir, args.style)
+    brief_path = build_agent_brief(
+        vlm_analysis, asr_result, silence_periods, video_duration, work_dir, args.style,
+        mimo_overview_enabled=CONFIG.get("mimo_video_overview", False),
+        mimo_overview_video_path=video,
+    )
 
     log("=" * 50)
     log(f"理解完成。写作 brief: {brief_path}")

--- a/skills/video-understanding/scripts/vlm.py
+++ b/skills/video-understanding/scripts/vlm.py
@@ -2,10 +2,11 @@ import base64
 import json
 import mimetypes
 import re
+from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from lib import CONFIG
-from lib import log, api_call, load_prompt, mimo_video_api_call, run_cmd
+from lib import log, api_call, load_prompt, mimo_video_api_call, run_cmd, file_fingerprint, stable_hash
 
 # ── Step 4: VLM 视觉分析 ─────────────────────────────────────────────
 
@@ -152,6 +153,9 @@ def analyze_scenes(scenes, frames, work_dir):
                     "max_tokens": 800,
                 }
 
+        if not raw_response.strip():
+            raise RuntimeError("VLM 连续 3 次返回空内容")
+
         # 解析 【描述】、【帧标签】和【深层分析】
         description, depth_analysis, frame_facts = _parse_vlm_depth_response(raw_response)
 
@@ -174,6 +178,7 @@ def analyze_scenes(scenes, frames, work_dir):
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {executor.submit(_analyze_single_scene, i, s): i for i, s in enumerate(scenes)}
+        failures = []
         for future in as_completed(futures):
             try:
                 idx, result = future.result()
@@ -181,10 +186,14 @@ def analyze_scenes(scenes, frames, work_dir):
             except Exception as e:
                 i = futures[future]
                 log(f"VLM 场景 {i+1} 分析失败: {e}")
-                analyses[i] = {
-                    "scene_id": i, "start": scenes[i]["start"], "end": scenes[i]["end"],
-                    "description": f"(VLM 分析失败: {e})", "depth_analysis": "", "frame_facts": {},
-                }
+                failures.append((i, str(e)))
+
+    if failures:
+        sample = "; ".join(f"场景 {i+1}: {msg}" for i, msg in failures[:3])
+        raise RuntimeError(
+            f"VLM 分析失败 {len(failures)}/{len(scenes)} 个场景，已中止以避免缓存不完整画面理解。"
+            f"示例: {sample}"
+        )
 
     # 保存
     vlm_file = work_dir / "vlm_analysis.json"
@@ -288,6 +297,7 @@ def mimo_video_settings_fingerprint():
     """Return non-secret MiMo video-overview settings that affect generated content."""
     return {
         "model": _mimo_video_model(),
+        "mimo_video_api_url": CONFIG.get("mimo_video_api_url"),
         "mimo_video_fps": CONFIG.get("mimo_video_fps", 2.0),
         "mimo_media_resolution": CONFIG.get("mimo_media_resolution", "default"),
         "mimo_video_chunk_max_seconds": CONFIG.get("mimo_video_chunk_max_seconds", 20.0),
@@ -306,11 +316,28 @@ def _mimo_chunk_cache_key(chunk):
     )
 
 
-def _load_mimo_partial(partial_path):
+def _mimo_cached_chunks_fingerprint(done):
+    return stable_hash(done)
+
+
+def _mimo_overview_payload_fingerprint(overview):
+    payload = dict(overview)
+    payload.pop("overview_fingerprint", None)
+    return stable_hash(payload)
+
+
+def _mimo_partial_provenance(video_path, scenes):
+    return {
+        "source_video_fingerprint": file_fingerprint(video_path),
+        "chunks": [_mimo_chunk_cache_key(chunk) for chunk in _mimo_video_chunks(scenes)],
+    }
+
+
+def _load_mimo_partial(partial_path, video_path=None, scenes=None):
     """Load the internal partial chunk cache, keyed by chunk identifier.
 
-    Returns {} when missing/unreadable or when the settings fingerprint differs,
-    so a settings change invalidates already-cached chunks.
+    Returns {} when missing/unreadable or when settings/source/chunk provenance differs,
+    so a changed source video or scene plan cannot reuse paid chunks from another run.
     """
     if not partial_path.exists():
         return {}
@@ -322,19 +349,78 @@ def _load_mimo_partial(partial_path):
         return {}
     if partial.get("settings") != mimo_video_settings_fingerprint():
         return {}
+    if video_path is not None or scenes is not None:
+        try:
+            if partial.get("provenance") != _mimo_partial_provenance(video_path, scenes):
+                return {}
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return {}
     done = partial.get("chunks")
     if not isinstance(done, dict):
+        return {}
+    recorded = partial.get("chunks_fingerprint")
+    if not recorded or recorded != _mimo_cached_chunks_fingerprint(done):
         return {}
     return done
 
 
-def _save_mimo_partial(partial_path, done):
+def _save_mimo_partial(partial_path, done, video_path=None, scenes=None):
     """Persist completed chunk results incrementally so paid chunks survive a mid-loop failure."""
     payload = {
         "settings": mimo_video_settings_fingerprint(),
         "chunks": done,
+        "chunks_fingerprint": _mimo_cached_chunks_fingerprint(done),
     }
+    if video_path is not None or scenes is not None:
+        payload["provenance"] = _mimo_partial_provenance(video_path, scenes)
     partial_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _mimo_chunks_match(cached_chunks, expected_chunks):
+    if not isinstance(cached_chunks, list) or len(cached_chunks) != len(expected_chunks):
+        return False
+    try:
+        cached_keys = [_mimo_chunk_cache_key(chunk) for chunk in cached_chunks]
+        expected_keys = [_mimo_chunk_cache_key(chunk) for chunk in expected_chunks]
+    except (KeyError, TypeError, ValueError):
+        return False
+    return cached_keys == expected_keys
+
+
+def mimo_video_overview_cache_fresh(overview_path, video_path, scenes):
+    """Return True only when the final MiMo overview matches current inputs/settings."""
+    overview_path = Path(overview_path) if not hasattr(overview_path, "read_text") else overview_path
+    if not overview_path.exists():
+        return False
+    try:
+        overview = json.loads(overview_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(overview, dict) or overview.get("input") != "scene_chunks":
+        return False
+    if overview.get("settings") != mimo_video_settings_fingerprint():
+        return False
+    overview_fingerprint = overview.get("overview_fingerprint")
+    if not overview_fingerprint or overview_fingerprint != _mimo_overview_payload_fingerprint(overview):
+        return False
+    recorded = overview.get("chunks_fingerprint")
+    if not recorded:
+        return False
+    chunks = overview.get("chunks")
+    if not isinstance(chunks, list) or not all(
+        isinstance(chunk, dict) and _is_mimo_chunk_usable(chunk.get("content"))
+        for chunk in chunks
+    ):
+        return False
+    if recorded != _mimo_cached_chunks_fingerprint(chunks):
+        return False
+    try:
+        if overview.get("source_video_fingerprint") != file_fingerprint(video_path):
+            return False
+        expected_chunks = _mimo_video_chunks(scenes)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    return _mimo_chunks_match(chunks, expected_chunks)
 
 
 def _analyze_mimo_video_chunk(chunk_path, chunk):
@@ -404,20 +490,25 @@ def analyze_video_overview(video_path, work_dir, scenes=None):
 
     # 增量缓存：已完成的分片先落盘，避免一段失败时丢弃所有已付费分片
     partial_path = work_dir / "mimo_video_overview.partial.json"
-    done = _load_mimo_partial(partial_path)
+    done = _load_mimo_partial(partial_path, video_path, scenes)
 
     log(f"MiMo 视频理解：按 ffmpeg scene 分片分析 {len(chunks)} 段...")
     chunk_results = []
+    unusable_chunks = []
+    removed_stale_cache = False
     for chunk in chunks:
         cache_key = _mimo_chunk_cache_key(chunk)
         cached = done.get(cache_key)
         if cached is not None:
-            log(
-                f"  MiMo 分片 {chunk['chunk_id'] + 1}/{len(chunks)}: "
-                f"{chunk['start']:.1f}-{chunk['end']:.1f}s（命中增量缓存，跳过）"
-            )
-            chunk_results.append(cached)
-            continue
+            if _is_mimo_chunk_usable(cached.get("content")):
+                log(
+                    f"  MiMo 分片 {chunk['chunk_id'] + 1}/{len(chunks)}: "
+                    f"{chunk['start']:.1f}-{chunk['end']:.1f}s（命中增量缓存，跳过）"
+                )
+                chunk_results.append(cached)
+                continue
+            done.pop(cache_key, None)
+            removed_stale_cache = True
         chunk_path = chunks_dir / (
             f"chunk_{chunk['chunk_id']:03d}_scene_{chunk['scene_id']}_"
             f"{chunk['start']:.2f}-{chunk['end']:.2f}.mp4"
@@ -428,23 +519,36 @@ def analyze_video_overview(video_path, work_dir, scenes=None):
             f"{chunk['start']:.1f}-{chunk['end']:.1f}s"
         )
         chunk_result = _analyze_mimo_video_chunk(chunk_path, chunk)
-        chunk_results.append(chunk_result)
-        done[cache_key] = chunk_result
-        _save_mimo_partial(partial_path, done)
+        if _is_mimo_chunk_usable(chunk_result.get("content")):
+            chunk_results.append(chunk_result)
+            done[cache_key] = chunk_result
+            _save_mimo_partial(partial_path, done, video_path, scenes)
+        else:
+            unusable_chunks.append(chunk)
+            log(f"  MiMo 分片 {chunk['chunk_id'] + 1}: 未返回有效内容，保留为待重试")
 
-    usable = sum(1 for it in chunk_results if _is_mimo_chunk_usable(it.get("content")))
-    if usable == 0:
-        log(f"MiMo 视频概览：{len(chunk_results)} 段均无有效内容（疑似被内容审核拦截），跳过概览")
+    if removed_stale_cache:
+        _save_mimo_partial(partial_path, done, video_path, scenes)
+
+    if not chunk_results:
+        log(f"MiMo 视频概览：{len(chunks)} 段均无有效内容（疑似被内容审核拦截），跳过概览")
         try:
             partial_path.unlink()
         except OSError:
             pass
         return None
 
+    if unusable_chunks:
+        sample = ", ".join(str(chunk["chunk_id"] + 1) for chunk in unusable_chunks[:5])
+        raise RuntimeError(
+            f"MiMo 视频概览部分分片无有效内容 {len(unusable_chunks)}/{len(chunks)}，"
+            f"未写入最终缓存；已保留可用分片，待重试分片: {sample}"
+        )
+
     content = "\n\n".join(
         f"### 分片 {item['chunk_id'] + 1} "
         f"(scene {item['scene_id']}, {item['start']:.1f}-{item['end']:.1f}s)\n"
-        f"{item['content'].strip() if _is_mimo_chunk_usable(item.get('content')) else '(MiMo 未返回内容)'}"
+        f"{item['content'].strip()}"
         for item in chunk_results
     )
 
@@ -456,9 +560,12 @@ def analyze_video_overview(video_path, work_dir, scenes=None):
         "fps": CONFIG.get("mimo_video_fps", 2.0),
         "media_resolution": CONFIG.get("mimo_media_resolution", "default"),
         "input": "scene_chunks",
+        "source_video_fingerprint": file_fingerprint(video_path),
         "chunk_max_seconds": CONFIG.get("mimo_video_chunk_max_seconds", 20.0),
         "settings": mimo_video_settings_fingerprint(),
+        "chunks_fingerprint": _mimo_cached_chunks_fingerprint(chunk_results),
     }
+    overview["overview_fingerprint"] = _mimo_overview_payload_fingerprint(overview)
     overview_path = work_dir / "mimo_video_overview.json"
     overview_path.write_text(json.dumps(overview, ensure_ascii=False, indent=2), encoding="utf-8")
     # 所有分片完成后清理增量缓存，保持 work_dir 仅有规范产物

--- a/skills/video-voiceover/SKILL.md
+++ b/skills/video-voiceover/SKILL.md
@@ -5,7 +5,7 @@ description: >
  Synthesize Chinese narration audio (TTS voiceover) from a timestamped narration.json.
  Use to turn a written narration script into per-segment speech audio, with MiMo TTS
  (mimo-v2.5-tts), dynamic speed fitting, and loudness handling. Part of the video-recap bundle:
- consumes narration.json (or narration_mapped.json), produces tts_segments + tts_meta.json.
+ consumes narration.json (or an explicit narration_mapped.json), produces tts_segments + tts_meta.json.
  触发词: 配音, 语音合成, TTS, 解说配音, voiceover, text to speech, 旁白配音.
 ---
 
@@ -23,17 +23,19 @@ export MIMO_API_KEY=***         # MiMo TTS (or a TTS-specific MIMO_TTS_API_KEY)
 
 ## Input contract
 
-`work_dir/narration.json` (or `work_dir/narration_mapped.json` in cut mode) — segments with
+`work_dir/narration.json` (or an explicit `work_dir/narration_mapped.json` in cut mode) — segments with
 `start` / `end` / `narration` (+ optional `pause_after_ms`, `overlaps_speech`). Times are the
 **output-timeline** seconds the audio will be placed at.
 
 ## Run
 
 ```bash
-python3 scripts/voiceover.py --work-dir <work_dir> [--mimo-voice 冰糖]
+python3 scripts/voiceover.py --work-dir <work_dir> --narration <narration.json> [--mimo-voice 冰糖]
 ```
 
-(Defaults to `narration_mapped.json` if present, else `narration.json`.)
+For direct one-off use, omitting `--narration` reads `work_dir/narration.json`.
+Pass `--narration work_dir/narration_mapped.json` explicitly for cut-mode output;
+the video-recap orchestrator always passes the intended file.
 
 ## Output contract
 
@@ -42,7 +44,7 @@ python3 scripts/voiceover.py --work-dir <work_dir> [--mimo-voice 冰糖]
   `audio_path`, timing, `pause_after_ms`, and placement fields consumed by **video-assemble**.
 
 ## Notes
-- To re-voice after editing narration, delete `tts_segments/` + `tts_meta.json` and rerun.
+- Re-runs safely reuse only matching per-segment audio; edited narration or TTS settings regenerate the affected WAVs.
 - `TTS_WORKERS`, `TTS_TIMEOUT`, `TTS_RETRIES`, `ALLOW_PARTIAL_TTS` tune throughput/robustness.
 
 ## What this skill does NOT do

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -320,32 +320,20 @@ def stable_hash(value):
     """Return an md5 digest for deterministic JSON-serializable values."""
     return hashlib.md5(stable_json_dumps(value).encode("utf-8")).hexdigest()
 
-def file_fingerprint(path, sample_bytes=65536):
-    """Return a fast content fingerprint based on file size plus head/tail bytes.
+def file_fingerprint(path, chunk_size=1024 * 1024):
+    """Return a full-content fingerprint for cache-correct identity checks.
 
     This intentionally avoids mtime/path so copied videos or JSON artifacts can
-    be reused when their bytes are identical, while changed bytes invalidate the
-    cache even if timestamps are misleading.
+    be reused when their bytes are identical, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
     """
-    path = os.fspath(path)
-    size = os.path.getsize(path)
-    h = hashlib.md5()
-    h.update(str(size).encode("ascii"))
-    h.update(b"\0")
-    with open(path, "rb") as f:
-        head = f.read(sample_bytes)
-        if size > sample_bytes:
-            f.seek(max(0, size - sample_bytes))
-            tail = f.read(sample_bytes)
-        else:
-            tail = b""
-    h.update(head)
-    h.update(b"\0")
-    h.update(tail)
+    h = hashlib.sha256()
+    with open(os.fspath(path), "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
     return h.hexdigest()
-
 def video_fingerprint(video_path):
-    """Fast video content fingerprint used as the root pipeline asset print."""
+    """Full video content fingerprint used as the root pipeline asset print."""
     return file_fingerprint(video_path)
 
 def step_cache_key(video_path, step_name, params_fingerprint=""):

--- a/skills/video-voiceover/scripts/voiceover.py
+++ b/skills/video-voiceover/scripts/voiceover.py
@@ -3,12 +3,14 @@ import os
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 
 from lib import CONFIG
 from lib import log, mimo_tts_api_call, get_video_duration
-from lib import _truncate_at_sentence
+from lib import _truncate_at_sentence, stable_hash, file_fingerprint
 
 SUPPORTED_TTS_ENGINES = {"mimo-tts"}
+TTS_CACHE_VERSION = 1
 
 
 def _parse_rate_offset(rate_str):
@@ -78,23 +80,13 @@ def _clean_narration_text(text):
 
 def _synthesize_segment(i, seg, narration, tts_dir, engine):
     """合成单个 TTS 段（线程安全），支持 resume 跳过已有文件"""
-    text = _clean_narration_text(seg["narration"])
-    if not text or not text.strip():
+    prepared = _prepare_tts_segment(i, seg, narration, tts_dir, engine)
+    if prepared is None:
         return None
-
-    output_wav = tts_dir / f"narr_{i:03d}.wav"
-
-    # Resume: 已有 WAV 文件直接复用（narration 在 step 5 后不变）
-    if output_wav.exists():
-        existing_dur = _get_audio_duration(output_wav)
-        if existing_dur > 0:
-            log(f"  段 {i+1}: 复用已有 ({existing_dur:.1f}s)")
-            return _build_tts_segment_result(i, seg, text, output_wav, existing_dur, 0.0)
-
-    if CONFIG.get("tts_dynamic_params", True):
-        rate, pitch = _compute_tts_params(text, narration, i)
-    else:
-        rate, pitch = "+0%", "+0Hz"
+    text, output_wav, rate, pitch, cache_key = prepared
+    cached = _reuse_tts_segment_cache(i, seg, output_wav, text, rate, cache_key)
+    if cached:
+        return cached
 
     _run_tts_engine(engine, text, output_wav, rate=rate, pitch=pitch)
 
@@ -112,6 +104,7 @@ def _synthesize_segment(i, seg, narration, tts_dir, engine):
             _run_tts_engine(engine, text, output_wav, rate=rate, pitch=pitch)
             dur = _get_audio_duration(output_wav)
 
+    _write_tts_segment_cache(output_wav, cache_key, text, dur, _parse_rate_offset(rate))
     return _build_tts_segment_result(i, seg, text, output_wav, dur, _parse_rate_offset(rate))
 
 
@@ -138,14 +131,37 @@ def synthesize_tts(narration, work_dir):
     tts_dir = work_dir / "tts_segments"
     tts_dir.mkdir(exist_ok=True)
 
+    if not narration:
+        raise RuntimeError("narration.json 没有可配音的解说段，已中止以避免生成无解说视频")
+
+    cache_engine = "mimo-tts"
+    cached_segments = []
+    needs_fresh = False
+    prepared_count = 0
+    for i, seg in enumerate(narration):
+        prepared = _prepare_tts_segment(i, seg, narration, tts_dir, cache_engine)
+        if prepared is None:
+            continue
+        prepared_count += 1
+        text, output_wav, rate, _pitch, cache_key = prepared
+        cached = _reuse_tts_segment_cache(i, seg, output_wav, text, rate, cache_key)
+        if not cached:
+            needs_fresh = True
+            break
+        cached_segments.append(cached)
+    if prepared_count == 0:
+        raise RuntimeError("narration.json 没有可配音的有效文本，已中止以避免生成无解说视频")
+    if not needs_fresh:
+        cached_segments.sort(key=lambda x: x["index"])
+        log(f"TTS 引擎: {cache_engine} (cache)")
+        return cached_segments, cache_engine
+
     engine = resolve_tts_engine()
     if engine == "mimo-tts" and not CONFIG.get("mimo_tts_api_key"):
         key_name = CONFIG.get("mimo_tts_api_key_source", "MIMO_API_KEY")
         raise RuntimeError(f"请设置 {key_name} 环境变量用于 MiMo TTS")
 
     log(f"TTS 引擎: {engine}")
-    if not narration:
-        return [], engine
 
     segments = []
     failures = []
@@ -177,6 +193,8 @@ def synthesize_tts(narration, work_dir):
         )
     if failures:
         log(f"警告: TTS 部分失败 {len(failures)}/{len(narration)} 段，继续生成部分解说")
+    if not segments:
+        raise RuntimeError("TTS 没有生成任何有效解说音频，已中止以避免生成无解说视频")
     return segments, engine
 
 
@@ -212,14 +230,108 @@ def _run_tts_engine(engine, text, output_wav, rate="+0%", pitch="+0Hz"):
 
 def _cleanup_partial_tts_outputs(output_wav):
     """Remove stale partial media files before/after a failed TTS attempt."""
-    wav_path = str(output_wav)
-    mp3_path = wav_path.replace(".wav", ".mp3")
-    for path in (wav_path, mp3_path):
+    wav_path = Path(output_wav)
+    mp3_path = wav_path.with_suffix(".mp3")
+    cache_path = str(_tts_segment_cache_path(output_wav))
+    for path in (str(wav_path), str(mp3_path), cache_path):
         try:
             if os.path.exists(path):
                 os.remove(path)
         except OSError:
             pass
+
+
+def _tts_segment_cache_path(output_wav):
+    return Path(str(output_wav) + ".cache.json")
+
+
+def _prepare_tts_segment(index, seg, narration, tts_dir, engine):
+    text = _clean_narration_text(seg["narration"])
+    if not text or not text.strip():
+        return None
+    output_wav = tts_dir / f"narr_{index:03d}.wav"
+    if CONFIG.get("tts_dynamic_params", True):
+        rate, pitch = _compute_tts_params(text, narration, index)
+    else:
+        rate, pitch = "+0%", "+0Hz"
+    cache_key = _tts_segment_cache_key(engine, index, seg, text, rate, pitch)
+    return text, output_wav, rate, pitch, cache_key
+
+
+def _reuse_tts_segment_cache(index, seg, output_wav, source_text, rate, cache_key):
+    cached = _load_tts_segment_cache(output_wav, cache_key)
+    if not cached:
+        return None
+    existing_dur = _get_audio_duration(output_wav)
+    if existing_dur <= 0:
+        return None
+    spoken_text = str(cached.get("spoken_text") or source_text)
+    rate_offset = float(cached.get("tts_rate_offset", _parse_rate_offset(rate)) or 0.0)
+    log(f"  段 {index+1}: 复用已有 ({existing_dur:.1f}s)")
+    return _build_tts_segment_result(index, seg, spoken_text, output_wav, existing_dur, rate_offset)
+
+
+def _tts_segment_cache_key(engine, index, seg, source_text, rate, pitch):
+    """Fingerprint the exact inputs that make a cached segment safe to reuse."""
+    pause = seg.get("pause_after_ms", CONFIG.get("breath_ms", 250))
+    try:
+        pause = int(pause)
+    except (TypeError, ValueError):
+        pause = CONFIG.get("breath_ms", 250)
+    payload = {
+        "version": TTS_CACHE_VERSION,
+        "engine": engine,
+        "source_text": source_text,
+        "segment_index": int(index),
+        "start": round(float(seg.get("start", 0.0)), 3),
+        "end": round(float(seg.get("end", 0.0)), 3),
+        "pause_after_ms": pause,
+        "rate": rate,
+        "pitch": pitch,
+        "settings": tts_settings_fingerprint(engine),
+    }
+    return stable_hash(payload)
+
+
+def _load_tts_segment_cache(output_wav, cache_key):
+    """Return cache metadata only when the sidecar proves the WAV matches narration."""
+    if not output_wav.exists():
+        return None
+    cache_path = _tts_segment_cache_path(output_wav)
+    if not cache_path.exists():
+        return None
+    try:
+        import json
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("cache_key") != cache_key:
+        return None
+    try:
+        if data.get("audio_fingerprint") != file_fingerprint(output_wav):
+            return None
+    except OSError:
+        return None
+    return data
+
+
+def _write_tts_segment_cache(output_wav, cache_key, spoken_text, duration, rate_offset):
+    """Persist non-secret provenance for safe per-segment TTS reuse."""
+    try:
+        import json
+        _tts_segment_cache_path(output_wav).write_text(
+            json.dumps({
+                "version": TTS_CACHE_VERSION,
+                "cache_key": cache_key,
+                "audio_fingerprint": file_fingerprint(output_wav),
+                "spoken_text": spoken_text,
+                "audio_duration": duration,
+                "tts_rate_offset": rate_offset,
+            }, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        log(f"  TTS 缓存元数据写入失败（忽略）: {exc}")
 
 
 def _detect_tts_engine():
@@ -312,13 +424,20 @@ def main():
     ap.add_argument("--narration", default=None,
                     help="narration json (default: narration_mapped.json if present, else narration.json)")
     ap.add_argument("--mimo-voice", default=None, help="MiMo TTS voice name")
+    ap.add_argument("--allow-partial-tts", action="store_true",
+                    help="allow output when some narration segments fail TTS")
     args = ap.parse_args()
     work_dir = Path(args.work_dir)
     if args.mimo_voice:
         CONFIG["mimo_tts_voice"] = args.mimo_voice
+    if args.allow_partial_tts:
+        CONFIG["allow_partial_tts"] = True
     if args.narration:
         narration_path = Path(args.narration)
     else:
+        # Cut mode remaps narration to the output timeline (narration_mapped.json);
+        # prefer it when present so a direct run in a cut work_dir voices the right
+        # timestamps. The orchestrator always passes --narration explicitly.
         mapped = work_dir / "narration_mapped.json"
         narration_path = mapped if mapped.exists() else work_dir / "narration.json"
     narration = json.loads(narration_path.read_text(encoding="utf-8"))

--- a/tests/assemble/test_assemble_fixes.py
+++ b/tests/assemble/test_assemble_fixes.py
@@ -46,13 +46,14 @@ def test_resample_failure_degrades_instead_of_raising(monkeypatch, tmp_path):
     }
 
     out = tmp_path / "out.wav"
-    # Must not raise FileNotFoundError from wave.open on a missing tmp file.
-    _build_timed_narration([segment], out, 3.0, tmp_path)
+    # Must fail cleanly instead of leaving a reusable silent narration track.
+    import pytest
+    with pytest.raises(RuntimeError, match="全部 1 段解说均被跳过"):
+        _build_timed_narration([segment], out, 3.0, tmp_path)
 
-    # Degraded exactly like the deliberate skip paths.
     assert segment["actual_place_start"] == segment["start"]
     assert segment["actual_place_end"] == segment["start"]
-    assert out.exists()
+    assert not out.exists()
 
 
 def test_missing_wav_skip_sets_zero_width_window(monkeypatch, tmp_path):
@@ -67,7 +68,9 @@ def test_missing_wav_skip_sets_zero_width_window(monkeypatch, tmp_path):
     }
 
     out = tmp_path / "out.wav"
-    _build_timed_narration([segment], out, 4.0, tmp_path)
+    import pytest
+    with pytest.raises(RuntimeError, match="全部 1 段解说均被跳过"):
+        _build_timed_narration([segment], out, 4.0, tmp_path)
 
     assert segment["actual_place_start"] == segment["start"]
     assert segment["actual_place_end"] == segment["start"]
@@ -78,6 +81,7 @@ def test_missing_wav_skip_sets_zero_width_window(monkeypatch, tmp_path):
     # _seg_place_window yields a zero-width window -> no ducking over silence.
     s, e = _seg_place_window(segment)
     assert e - s < 0.1
+    assert not out.exists()
 
 
 def test_bad_wav_format_skip_sets_zero_width_window(monkeypatch, tmp_path):
@@ -95,13 +99,16 @@ def test_bad_wav_format_skip_sets_zero_width_window(monkeypatch, tmp_path):
     }
 
     out = tmp_path / "out.wav"
-    _build_timed_narration([segment], out, 4.0, tmp_path)
+    import pytest
+    with pytest.raises(RuntimeError, match="全部 1 段解说均被跳过"):
+        _build_timed_narration([segment], out, 4.0, tmp_path)
 
     assert segment["actual_place_start"] == segment["start"]
     assert segment["actual_place_end"] == segment["start"]
     assert _subtitle_entries([segment]) == []
     s, e = _seg_place_window(segment)
     assert e - s < 0.1
+    assert not out.exists()
 
 
 def test_all_skipped_logs_loud_warning(monkeypatch, tmp_path):
@@ -129,11 +136,11 @@ def test_all_skipped_logs_loud_warning(monkeypatch, tmp_path):
     ]
 
     out = tmp_path / "out.wav"
-    _build_timed_narration(segments, out, 5.0, tmp_path)
+    import pytest
+    with pytest.raises(RuntimeError, match="全部 2 段解说均被跳过"):
+        _build_timed_narration(segments, out, 5.0, tmp_path)
 
-    assert any("全部" in m and "跳过" in m for m in logs), logs
-    # Still best-effort: an (empty) narration track is produced.
-    assert out.exists()
+    assert not out.exists()
 
 
 def test_partial_skip_does_not_log_all_skipped_warning(monkeypatch, tmp_path):

--- a/tests/assemble/test_assemble_integration.py
+++ b/tests/assemble/test_assemble_integration.py
@@ -84,3 +84,29 @@ def test_assemble_video_runs_with_loudnorm_disabled_and_quiet_branch(tmp_path, m
     assemble_video(src, segs, work, out)
     assert out.exists()
     assert "audio" in _stream_types(out)
+
+
+
+def _make_silent_source_video(path, seconds=3):
+    subprocess.run([
+        "ffmpeg", "-y",
+        "-f", "lavfi", "-i", f"color=c=red:s=320x240:d={seconds}:r=25",
+        "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p",
+        str(path),
+    ], check=True, capture_output=True)
+
+
+def test_assemble_video_runs_when_source_has_no_audio_stream(tmp_path, monkeypatch):
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    work = tmp_path / "silent_work"
+    work.mkdir()
+    src = tmp_path / "silent_src.mp4"
+    _make_silent_source_video(src, seconds=3)
+    segs = _segment(work, 0.5, 2.5, overlaps=False, dur=1.0)
+    out = work / "silent_out.mp4"
+
+    assemble_video(src, segs, work, out)
+
+    assert out.exists() and out.stat().st_size > 0
+    assert "audio" in _stream_types(out)

--- a/tests/assemble/test_export_jianying.py
+++ b/tests/assemble/test_export_jianying.py
@@ -97,6 +97,21 @@ def test_export_writes_three_files(tmp_path):
     assert meta["draft_name"] == "recap_demo" and meta["tm_duration"] == 15_000_000
 
 
+def test_export_uses_collision_safe_draft_folder(tmp_path):
+    existing = tmp_path / "recap_demo"
+    existing.mkdir()
+    (existing / "draft_content.json").write_text("manual edit", encoding="utf-8")
+
+    draft_dir, notes = export_timeline_to_jianying(
+        _sample_timeline(), str(tmp_path), draft_name="recap_demo",
+        new_id=_counter_ids(), probe=_fake_probe)
+
+    assert Path(draft_dir).name == "recap_demo_2"
+    assert (existing / "draft_content.json").read_text(encoding="utf-8") == "manual edit"
+    assert any("避免覆盖" in note for note in notes)
+    assert (Path(draft_dir) / "draft_content.json").exists()
+
+
 def test_exporter_handles_timeline_without_bgm():
     tl = build_timeline({"width": 100, "height": 100, "fps": 30}, 5.0,
                         [{"source_path": "/s.mp4", "source_start": 0.0, "source_end": 5.0,
@@ -149,3 +164,49 @@ def test_core_assemble_does_not_import_exporter():
             "assert 'export_jianying' not in sys.modules, 'core imported the 剪映 exporter'")
     r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert r.returncode == 0, r.stderr
+
+
+
+def test_exporter_repeats_looped_bgm_to_cover_timeline(tmp_path):
+    bgm = tmp_path / "bgm.mp3"
+    bgm.write_bytes(b"bgm")
+
+    def short_bgm_probe(path):
+        if str(path).endswith("bgm.mp3"):
+            return 5_000_000, 0, 0
+        return 15_000_000, 1920, 1080
+
+    timeline = _sample_timeline()
+    for track in timeline["tracks"]:
+        if track.get("role") == "bgm":
+            track["segments"][0]["source_path"] = str(bgm)
+    content, _meta, notes = build_draft(timeline, new_id=_counter_ids(), probe=short_bgm_probe)
+    bgm_track = next(t for t in content["tracks"] if t["type"] == "audio" and t["name"] == "bgm")
+    starts = [seg["target_timerange"]["start"] for seg in bgm_track["segments"]]
+    durations = [seg["target_timerange"]["duration"] for seg in bgm_track["segments"]]
+
+    assert starts == [0, 5_000_000, 10_000_000]
+    assert durations == [5_000_000, 5_000_000, 5_000_000]
+    assert sum(durations) == 15_000_000
+    assert not any("BGM 素材" in note for note in notes)
+
+
+def test_looped_bgm_keyframes_are_windowed_per_repeated_piece(tmp_path):
+    bgm = tmp_path / "bgm.mp3"
+    bgm.write_bytes(b"bgm")
+
+    def short_bgm_probe(path):
+        if str(path).endswith("bgm.mp3"):
+            return 5_000_000, 0, 0
+        return 15_000_000, 1920, 1080
+
+    timeline = _sample_timeline()
+    for track in timeline["tracks"]:
+        if track.get("role") == "bgm":
+            track["segments"][0]["source_path"] = str(bgm)
+    content, _meta, _notes = build_draft(timeline, new_id=_counter_ids(), probe=short_bgm_probe)
+    bgm_track = next(t for t in content["tracks"] if t["type"] == "audio" and t["name"] == "bgm")
+    keyframe_counts = [len(seg["common_keyframes"]) for seg in bgm_track["segments"]]
+
+    assert keyframe_counts[0] == 1
+    assert keyframe_counts[1:] == [0, 0]

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -1,10 +1,180 @@
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
+import json
 import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
-from assemble import _apply_narration_speed, _build_audio_filter_complex, _build_timed_narration, _escape_ass_text, _generate_ass, _generate_srt, _seconds_to_ass_time, _seconds_to_srt_time, _source_subtitle_mask_filter, _subtitle_burn_filter, assemble_video, assembly_settings_fingerprint, final_loudnorm_filter
+from assemble import _adjust_tts_speed, _apply_narration_speed, _assembly_manifest_payload, _build_audio_filter_complex, _build_timed_narration, _build_video_clips, _emit_timeline, _resolve_final_output, _value_fingerprint, _escape_ass_text, _generate_ass, _generate_srt, _seconds_to_ass_time, _seconds_to_srt_time, _source_subtitle_mask_filter, _subtitle_burn_filter, assemble_video, assembly_settings_fingerprint, final_loudnorm_filter
 from lib import CONFIG
+
+
+def test_adjust_tts_speed_derives_outputs_from_audio_name_only(monkeypatch, tmp_path):
+    """Parent dirs containing .wav must not redirect adjusted files outside the audio dir."""
+    wav_parent = tmp_path / "episode.wav-cache"
+    wav_parent.mkdir()
+    src = wav_parent / "narr_000.wav"
+    src.write_bytes(b"wav")
+    commands = []
+
+    def fake_run_cmd(cmd, **kw):
+        commands.append(cmd)
+        Path(cmd[-1]).write_bytes(b"adjusted")
+        return CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 2.2 if Path(path) == src else 2.0)
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    adjusted, actual_dur = _adjust_tts_speed(src, target_duration=2.0, work_dir=tmp_path)
+
+    assert actual_dur == 2.0
+    assert Path(adjusted) == wav_parent / "narr_000_adj.wav"
+    assert commands[-1][-1] == str(wav_parent / "narr_000_adj.wav")
+
+
+def test_adjust_tts_speed_truncation_keeps_output_next_to_audio(monkeypatch, tmp_path):
+    wav_parent = tmp_path / "episode.wav-cache"
+    wav_parent.mkdir()
+    src = wav_parent / "narr_000.wav"
+    src.write_bytes(b"wav")
+    commands = []
+
+    def fake_run_cmd(cmd, **kw):
+        commands.append(cmd)
+        Path(cmd[-1]).write_bytes(b"cut")
+        return CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 10.0 if Path(path) == src else 1.0)
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    adjusted, actual_dur = _adjust_tts_speed(src, target_duration=1.0, work_dir=tmp_path)
+
+    assert actual_dur == 1.0
+    assert Path(adjusted) == wav_parent / "narr_000_cut.wav"
+    assert commands[-1][-1] == str(wav_parent / "narr_000_cut.wav")
+
+
+def test_build_video_clips_prefers_fingerprint_matched_validated_cut_plan(monkeypatch, tmp_path):
+    original = tmp_path / "original.mp4"
+    edited = tmp_path / "edited_source.mp4"
+    original.write_bytes(b"orig")
+    edited.write_bytes(b"edited")
+    import json
+    raw_payload = {"clips": [{"source_start": 99.0, "source_end": 100.0}]}
+    (tmp_path / "clip_plan.json").write_text(json.dumps(raw_payload), encoding="utf-8")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "raw_plan_fingerprint": _value_fingerprint(raw_payload),
+        "clips": [
+            {"clip_id": 0, "source_start": 10.0, "source_end": 20.0, "output_start": 0.0, "output_end": 10.0},
+            {"clip_id": 1, "source_start": 40.0, "source_end": 45.0, "output_start": 10.0, "output_end": 15.0},
+        ],
+    }), encoding="utf-8")
+    monkeypatch.setitem(CONFIG, "source_video", str(original))
+    monkeypatch.setitem(CONFIG, "source_video_explicit", True)
+
+    clips = _build_video_clips(edited, tmp_path, duration_s=15.0)
+
+    assert clips == [
+        {"source_path": str(original), "source_start": 10.0, "source_end": 20.0, "timeline_start": 0.0, "timeline_end": 10.0},
+        {"source_path": str(original), "source_start": 40.0, "source_end": 45.0, "timeline_start": 10.0, "timeline_end": 15.0},
+    ]
+
+
+def test_build_video_clips_ignores_ambient_source_video_without_explicit_opt_in(monkeypatch, tmp_path):
+    original = tmp_path / "ambient_original.mp4"
+    edited = tmp_path / "edited_source.mp4"
+    original.write_bytes(b"orig")
+    edited.write_bytes(b"edited")
+    (tmp_path / "clip_plan.json").write_text(
+        json.dumps({"clips": [{"start": 10.0, "end": 20.0}]}), encoding="utf-8"
+    )
+    monkeypatch.setitem(CONFIG, "source_video", str(original))
+    monkeypatch.setitem(CONFIG, "source_video_explicit", False)
+
+    clips = _build_video_clips(edited, tmp_path, duration_s=15.0)
+    manifest = _assembly_manifest_payload(edited, [], tmp_path, tmp_path / "output.mp4")
+
+    assert clips == [{
+        "source_path": str(edited),
+        "source_start": 0.0,
+        "source_end": 15.0,
+        "timeline_start": 0.0,
+        "timeline_end": 15.0,
+    }]
+    assert manifest["source_video"] is None
+    assert manifest["source_video_fingerprint"] is None
+
+
+def test_build_video_clips_ignores_stale_validated_cut_plan(monkeypatch, tmp_path):
+    import os
+
+    original = tmp_path / "original.mp4"
+    edited = tmp_path / "edited_source.mp4"
+    original.write_bytes(b"orig")
+    edited.write_bytes(b"edited")
+    (tmp_path / "clip_plan.json").write_text(
+        '{"clips":[{"start":40.0,"end":45.0}]}', encoding="utf-8"
+    )
+    (tmp_path / "clip_plan_validated.json").write_text(
+        '{"clips":[{"clip_id":0,"source_start":0.0,"source_end":10.0,"output_start":0.0,"output_end":10.0}]}',
+        encoding="utf-8",
+    )
+    os.utime(tmp_path / "clip_plan_validated.json", (1_000, 1_000))
+    os.utime(tmp_path / "clip_plan.json", (1_000, 1_000))
+    monkeypatch.setitem(CONFIG, "source_video", str(original))
+    monkeypatch.setitem(CONFIG, "source_video_explicit", True)
+
+    clips = _build_video_clips(edited, tmp_path, duration_s=5.0)
+
+    assert clips == [
+        {"source_path": str(original), "source_start": 40.0, "source_end": 45.0, "timeline_start": 0.0, "timeline_end": 5.0},
+    ]
+
+
+def test_assemble_main_creates_missing_output_dir(monkeypatch, tmp_path):
+    import sys
+    import assemble
+
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"video")
+    stale_source = tmp_path / "stale_source.mp4"
+    stale_source.write_bytes(b"stale")
+    monkeypatch.setitem(CONFIG, "source_video", str(stale_source))
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "tts_meta.json").write_text(json.dumps({"segments": []}), encoding="utf-8")
+    (work / "timeline.json").write_text("{}", encoding="utf-8")
+    (work / "narration.wav").write_bytes(b"narration")
+    (work / "subtitles.srt").write_text("", encoding="utf-8")
+    missing_out = tmp_path / "missing" / "nested"
+
+    def fake_assemble(input_video, tts_segments, work_dir, output_path):
+        Path(output_path).write_bytes(b"mp4")
+        return output_path
+
+    monkeypatch.setattr("assemble.assemble_video", fake_assemble)
+    monkeypatch.setattr(sys, "argv", [
+        "assemble.py", str(video), "--work-dir", str(work),
+        "--output-dir", str(missing_out), "--recap-stem", "demo",
+    ])
+
+    assemble.main()
+
+    assert (missing_out / "recap_demo.mp4").read_bytes() == b"mp4"
+    manifest = json.loads((work / "assembly_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["source_video"] is None
+    assert manifest["source_video_fingerprint"] is None
+    assert manifest["final_output"].endswith("recap_demo.mp4")
+
+
+def test_resolve_final_output_overwrites_stable_alias(tmp_path):
+    """The recap output is always the stable alias recap_<stem>.mp4 (overwritten in
+    place), so the iterate-on-narration loop refreshes one file instead of spawning
+    fingerprint-suffixed copies of every render."""
+    (tmp_path / "recap_clip.mp4").write_bytes(b"previous-render")
+
+    resolved = _resolve_final_output(tmp_path, "clip")
+
+    assert resolved == tmp_path / "recap_clip.mp4"
 
 
 def test_source_subtitle_mask_filter_toggles_with_config(monkeypatch):
@@ -130,11 +300,59 @@ def test_build_timed_narration_clamps_delay_to_slot(monkeypatch, tmp_path):
 
 
 def test_subtitle_burn_filter_escapes_path():
-    path = Path("/tmp/video recap/a:b,c[1].ass")
+    path = Path("/tmp/video recap/o'hara/a:b,c[1].ass")
     filt = _subtitle_burn_filter(path)
     assert filt.startswith("subtitles=")
     assert "video recap" in filt
+    assert r"o\\\'hara" in filt
     assert r"a\:b\,c\[1\].ass" in filt
+    assert "filename='" not in filt
+
+
+def test_subtitle_burn_filter_accepts_apostrophe_path_with_ffmpeg(tmp_path):
+    import subprocess
+
+    video = tmp_path / "input.mp4"
+    ass_dir = tmp_path / "video recap"
+    ass_dir.mkdir()
+    ass = ass_dir / "o'hara.ass"
+    ass.write_text(
+        "\n".join([
+            "[Script Info]",
+            "ScriptType: v4.00+",
+            "[V4+ Styles]",
+            (
+                "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
+                "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
+                "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+                "Alignment, MarginL, MarginR, MarginV, Encoding"
+            ),
+            (
+                "Style: Default,Arial,12,&H00FFFFFF,&H000000FF,&H00000000,"
+                "&H00000000,0,0,0,0,100,100,0,0,1,1,0,2,10,10,10,1"
+            ),
+            "[Events]",
+            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+            "Dialogue: 0,0:00:00.00,0:00:00.10,Default,,0,0,0,,Hi",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    create = subprocess.run([
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-f", "lavfi", "-i", "color=c=black:s=16x16:d=0.1",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", str(video),
+    ], capture_output=True, text=True)
+    if create.returncode != 0:
+        pytest.skip(f"ffmpeg unavailable for subtitle smoke test: {create.stderr}")
+
+    burn = subprocess.run([
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-i", str(video), "-vf", _subtitle_burn_filter(ass),
+        "-frames:v", "1", "-f", "null", "-",
+    ], capture_output=True, text=True)
+
+    assert burn.returncode == 0, burn.stderr
 
 
 def test_assemble_video_burns_ass_subtitles(monkeypatch, tmp_path):
@@ -173,6 +391,37 @@ def test_assemble_video_burns_ass_subtitles(monkeypatch, tmp_path):
     assert any(str(arg).startswith("subtitles=") for arg in ffmpeg_cmd)
     assert "-c:v" in ffmpeg_cmd
     assert "libx264" in ffmpeg_cmd
+
+
+def test_assemble_video_rejects_empty_tts_segments(tmp_path):
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"video")
+
+    with pytest.raises(RuntimeError, match="没有有效解说音频"):
+        assemble_video(video, [], tmp_path, tmp_path / "output.mp4")
+
+
+def test_emit_timeline_failure_is_not_swallowed(monkeypatch, tmp_path):
+    def boom(*args, **kwargs):
+        raise RuntimeError("timeline schema failure")
+
+    monkeypatch.setattr("assemble._probe_canvas", lambda path: {"width": 1280, "height": 720, "fps": 30.0})
+    monkeypatch.setattr(
+        "assemble._build_video_clips",
+        lambda input_video, work_dir, duration_s: [{
+            "source_path": str(input_video),
+            "source_start": 0.0,
+            "source_end": 1.0,
+            "timeline_start": 0.0,
+            "timeline_end": 1.0,
+        }],
+    )
+    monkeypatch.setattr("assemble.build_timeline", boom)
+
+    with pytest.raises(RuntimeError, match="timeline schema failure"):
+        _emit_timeline(tmp_path / "input.mp4", [{"start": 0.0, "end": 1.0}], tmp_path, 1.0, False)
+
+    assert not (tmp_path / "timeline.json").exists()
 
 
 def test_assemble_video_without_burn_keeps_video_copy(monkeypatch, tmp_path):
@@ -346,3 +595,69 @@ def test_final_loudnorm_filter_and_fingerprint(monkeypatch):
     monkeypatch.setitem(CONFIG, "final_loudnorm", False)
     assert final_loudnorm_filter() is None
     assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "off"
+
+
+def test_assembly_settings_fingerprint_tracks_render_affecting_settings(monkeypatch):
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.14)
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.0)
+    monkeypatch.setitem(CONFIG, "bgm_path", "")
+    monkeypatch.setitem(CONFIG, "bgm_volume", 0.18)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    base = assembly_settings_fingerprint()
+
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.20)
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.14)
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.2)
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.0)
+    monkeypatch.setitem(CONFIG, "bgm_path", "/tmp/bgm.mp3")
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "bgm_path", "")
+    monkeypatch.setitem(CONFIG, "bgm_volume", 0.30)
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "bgm_volume", 0.18)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.50)
+    assert assembly_settings_fingerprint() != base
+
+
+
+def test_assemble_video_uses_silent_original_track_when_source_has_no_audio(monkeypatch, tmp_path):
+    video = tmp_path / "silent.mp4"
+    video.write_bytes(b"video")
+    output = tmp_path / "output.mp4"
+    commands = []
+
+    def fake_run_cmd(cmd):
+        commands.append(cmd)
+        output.write_bytes(b"mp4")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
+    monkeypatch.setattr("assemble._has_audio_stream", lambda path: False)
+    monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    assemble_video(video, [{
+        "start": 0.0,
+        "end": 3.0,
+        "actual_place_start": 0.2,
+        "actual_place_end": 2.0,
+        "narration": "无原声音轨也应能混音。",
+        "audio_path": str(tmp_path / "narr.wav"),
+        "audio_duration": 1.0,
+    }], tmp_path, output)
+
+    ffmpeg_cmd = commands[-1]
+    joined = " ".join(str(part) for part in ffmpeg_cmd)
+    assert "anullsrc=channel_layout=stereo:sample_rate=48000" in joined
+    assert "[2:a]volume=" in joined
+    assert output.exists()

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -300,59 +300,11 @@ def test_build_timed_narration_clamps_delay_to_slot(monkeypatch, tmp_path):
 
 
 def test_subtitle_burn_filter_escapes_path():
-    path = Path("/tmp/video recap/o'hara/a:b,c[1].ass")
+    path = Path("/tmp/video recap/a:b,c[1].ass")
     filt = _subtitle_burn_filter(path)
     assert filt.startswith("subtitles=")
     assert "video recap" in filt
-    assert r"o\\\'hara" in filt
     assert r"a\:b\,c\[1\].ass" in filt
-    assert "filename='" not in filt
-
-
-def test_subtitle_burn_filter_accepts_apostrophe_path_with_ffmpeg(tmp_path):
-    import subprocess
-
-    video = tmp_path / "input.mp4"
-    ass_dir = tmp_path / "video recap"
-    ass_dir.mkdir()
-    ass = ass_dir / "o'hara.ass"
-    ass.write_text(
-        "\n".join([
-            "[Script Info]",
-            "ScriptType: v4.00+",
-            "[V4+ Styles]",
-            (
-                "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
-                "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
-                "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
-                "Alignment, MarginL, MarginR, MarginV, Encoding"
-            ),
-            (
-                "Style: Default,Arial,12,&H00FFFFFF,&H000000FF,&H00000000,"
-                "&H00000000,0,0,0,0,100,100,0,0,1,1,0,2,10,10,10,1"
-            ),
-            "[Events]",
-            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
-            "Dialogue: 0,0:00:00.00,0:00:00.10,Default,,0,0,0,,Hi",
-            "",
-        ]),
-        encoding="utf-8",
-    )
-    create = subprocess.run([
-        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-        "-f", "lavfi", "-i", "color=c=black:s=16x16:d=0.1",
-        "-c:v", "libx264", "-pix_fmt", "yuv420p", str(video),
-    ], capture_output=True, text=True)
-    if create.returncode != 0:
-        pytest.skip(f"ffmpeg unavailable for subtitle smoke test: {create.stderr}")
-
-    burn = subprocess.run([
-        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-        "-i", str(video), "-vf", _subtitle_burn_filter(ass),
-        "-frames:v", "1", "-f", "null", "-",
-    ], capture_output=True, text=True)
-
-    assert burn.returncode == 0, burn.stderr
 
 
 def test_assemble_video_burns_ass_subtitles(monkeypatch, tmp_path):

--- a/tests/assemble/test_timeline.py
+++ b/tests/assemble/test_timeline.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
 import json  # noqa: E402
-from timeline import build_timeline, ducking_keyframes, save_timeline, load_timeline  # noqa: E402
+from timeline import build_timeline, ducking_keyframes, load_timeline, save_timeline, variable_ducking_keyframes  # noqa: E402
 
 
 def test_ducking_keyframes_holds_idle_and_dips_under_window():
@@ -86,3 +86,35 @@ def test_timeline_round_trips(tmp_path):
     save_timeline(tl, p)
     assert load_timeline(p) == tl
     assert json.loads(p.read_text(encoding="utf-8")) == tl
+
+
+
+def test_build_timeline_uses_quiet_ducking_gain_for_quiet_segments():
+    tl = build_timeline(
+        {"width": 1280, "height": 720, "fps": 25},
+        10.0,
+        [{"source_path": "/src.mp4", "source_start": 0.0, "source_end": 10.0,
+          "timeline_start": 0.0, "timeline_end": 10.0}],
+        [{"source_path": "/n0.wav", "timeline_start": 2.0, "timeline_end": 4.0,
+          "text": "quiet", "overlaps_speech": False}],
+        ducking={"idle": 0.85, "speech": 0.2, "quiet": 0.12, "fade": 0.25},
+    )
+
+    keyframes = tl["tracks"][0]["clips"][0]["audio"]["volume_keyframes"]
+    gains = [kf["gain"] for kf in keyframes]
+    assert 0.12 in gains
+    assert 0.2 not in gains
+
+
+def test_variable_ducking_keyframes_do_not_release_to_idle_between_close_windows():
+    keyframes = variable_ducking_keyframes(
+        [(1.0, 4.0, 0.2), (4.1, 5.0, 0.12)],
+        idle=0.85,
+        fade=0.25,
+        span_start=0.0,
+        span_end=8.0,
+    )
+
+    between = [kf for kf in keyframes if 4.0 < kf["t"] < 5.0]
+    assert between
+    assert all(kf["gain"] != 0.85 for kf in between)

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -127,3 +127,149 @@ def test_build_edited_source_video_uses_ffmpeg_concat(monkeypatch, tmp_path):
     ffmpeg_cmd = [cmd for cmd in commands if cmd[0] == "ffmpeg"][0]
     assert "trim=start=0.000:end=1.000" in " ".join(ffmpeg_cmd)
     assert "concat=n=2" in " ".join(ffmpeg_cmd)
+
+
+
+
+def test_cut_source_fingerprint_detects_middle_only_changes(tmp_path):
+    import cut
+
+    first = tmp_path / "a.mp4"
+    second = tmp_path / "b.mp4"
+    first.write_bytes(b"A" * 70000 + b"middle-one" + b"Z" * 70000)
+    second.write_bytes(b"A" * 70000 + b"middle-two" + b"Z" * 70000)
+
+    assert first.stat().st_size == second.stat().st_size
+    assert cut.file_fingerprint(first) != cut.file_fingerprint(second)
+
+
+def test_cut_main_does_not_reuse_edited_source_when_normalized_plan_changes(monkeypatch, tmp_path):
+    import json
+    import sys
+    import cut
+
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "clip_plan.json").write_text(json.dumps([{"start": 10.0, "end": 20.0}]), encoding="utf-8")
+    edited = work / "edited_source.mp4"
+    edited.write_bytes(b"old-edited")
+
+    calls = []
+
+    def fake_build(video_path, validated_plan, work_dir, output_path=None):
+        calls.append(validated_plan)
+        Path(output_path).write_bytes(b"new-edited")
+        cut._write_edited_source_meta(output_path, validated_plan, video_path)
+        return Path(output_path)
+
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 100.0)
+    monkeypatch.setattr("cut.build_edited_source_video", fake_build)
+    monkeypatch.setattr(sys, "argv", [
+        "cut.py", str(video), "--work-dir", str(work), "--clip-padding", "5",
+    ])
+
+    cut.main()
+
+    assert len(calls) == 1
+    assert json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["clips"][0]["source_start"] == 5.0
+    assert edited.read_bytes() == b"new-edited"
+
+
+def test_cut_main_reuses_edited_source_when_fingerprint_matches(monkeypatch, tmp_path):
+    import json
+    import sys
+    import cut
+
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    raw_plan = [{"start": 10.0, "end": 20.0}]
+    (work / "clip_plan.json").write_text(json.dumps(raw_plan), encoding="utf-8")
+    validated = cut.normalize_clip_plan(raw_plan, video_duration=100.0)
+    edited = work / "edited_source.mp4"
+    edited.write_bytes(b"cached-edited")
+    cut._write_edited_source_meta(edited, validated, video)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("matching edited_source cache should be reused")
+
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 100.0)
+    monkeypatch.setattr("cut.build_edited_source_video", boom)
+    monkeypatch.setattr(sys, "argv", ["cut.py", str(video), "--work-dir", str(work)])
+
+    cut.main()
+
+    assert edited.read_bytes() == b"cached-edited"
+
+
+def test_cut_main_rebuilds_when_source_video_bytes_change(monkeypatch, tmp_path):
+    import json
+    import sys
+    import cut
+
+    old_video = tmp_path / "video_old.mp4"
+    new_video = tmp_path / "video_new.mp4"
+    old_video.write_bytes(b"old source bytes")
+    new_video.write_bytes(b"new source bytes")
+    work = tmp_path / "work"
+    work.mkdir()
+    raw_plan = [{"start": 10.0, "end": 20.0}]
+    (work / "clip_plan.json").write_text(json.dumps(raw_plan), encoding="utf-8")
+    validated = cut.normalize_clip_plan(raw_plan, video_duration=100.0)
+    edited = work / "edited_source.mp4"
+    edited.write_bytes(b"edited-from-old-source")
+    cut._write_edited_source_meta(edited, validated, old_video)
+
+    calls = []
+
+    def fake_build(video_path, validated_plan, work_dir, output_path=None):
+        calls.append(Path(video_path).name)
+        Path(output_path).write_bytes(b"edited-from-new-source")
+        cut._write_edited_source_meta(output_path, validated_plan, video_path)
+        return Path(output_path)
+
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 100.0)
+    monkeypatch.setattr("cut.build_edited_source_video", fake_build)
+    monkeypatch.setattr(sys, "argv", ["cut.py", str(new_video), "--work-dir", str(work)])
+
+    cut.main()
+
+    assert calls == ["video_new.mp4"]
+    assert edited.read_bytes() == b"edited-from-new-source"
+
+
+def test_cut_main_rebuilds_when_cached_edited_source_bytes_change(monkeypatch, tmp_path):
+    import json
+    import sys
+    import cut
+
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    raw_plan = [{"start": 10.0, "end": 20.0}]
+    (work / "clip_plan.json").write_text(json.dumps(raw_plan), encoding="utf-8")
+    validated = cut.normalize_clip_plan(raw_plan, video_duration=100.0)
+    edited = work / "edited_source.mp4"
+    edited.write_bytes(b"cached-edited")
+    cut._write_edited_source_meta(edited, validated, video)
+    edited.write_bytes(b"externally-mutated-edited-source")
+    calls = []
+
+    def fake_build(video_path, validated_plan, work_dir, output_path=None):
+        calls.append(Path(video_path).name)
+        Path(output_path).write_bytes(b"rebuilt-edited")
+        cut._write_edited_source_meta(output_path, validated_plan, video_path)
+        return Path(output_path)
+
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 100.0)
+    monkeypatch.setattr("cut.build_edited_source_video", fake_build)
+    monkeypatch.setattr(sys, "argv", ["cut.py", str(video), "--work-dir", str(work)])
+
+    cut.main()
+
+    assert calls == ["video.mp4"]
+    assert edited.read_bytes() == b"rebuilt-edited"

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -1,8 +1,27 @@
 import sys
+from argparse import Namespace
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-recap' / 'scripts'))
+import json
 import pytest  # noqa: F401
 import doctor
+import recap
+
+
+def _manifest_args(**overrides):
+    defaults = {
+        "context": "",
+        "scene_threshold": None,
+        "style": "纪录片",
+        "edit_mode": "full",
+        "target_duration": None,
+        "skip_asr": False,
+        "mimo_video_overview": False,
+        "consolidate": False,
+        "consolidate_asr": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
 
 
 def _tools_present(monkeypatch):
@@ -56,3 +75,284 @@ def test_doctor_warns_when_asr_unconfigured_but_key_present(monkeypatch):
 
     assert report["ok"] is True
     assert any("ASR not configured" in w for w in report["warnings"])
+
+
+def test_recap_full_mode_passes_explicit_narration_json(monkeypatch, tmp_path):
+    """A stale cut-mode narration_mapped.json must not override full-mode narration."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    (work / "narration_mapped.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "stale cut。"}]),
+        encoding="utf-8",
+    )
+
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    voiceover_call = next(call for call in calls if call[:2] == ("video-voiceover", "voiceover.py"))
+    args = voiceover_call[2]
+    assert args[args.index("--narration") + 1] == str(work / "narration.json")
+
+
+def test_recap_cut_mode_passes_explicit_mapped_narration(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 10, "end": 12, "narration": "source。"}]),
+        encoding="utf-8",
+    )
+    (work / "clip_plan.json").write_text(
+        json.dumps([{"start": 10, "end": 12}]),
+        encoding="utf-8",
+    )
+
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
+
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "cut.py":
+            (work / "narration_mapped.json").write_text(
+                json.dumps([{"start": 0, "end": 2, "narration": "mapped。"}]),
+                encoding="utf-8",
+            )
+            (work / "edited_source.mp4").write_bytes(b"edited")
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
+
+    recap.main()
+
+    voiceover_call = next(call for call in calls if call[:2] == ("video-voiceover", "voiceover.py"))
+    args = voiceover_call[2]
+    assert args[args.index("--narration") + 1] == str(work / "narration_mapped.json")
+
+
+
+
+def test_recap_manifest_fingerprint_detects_middle_only_source_changes(tmp_path):
+    first = tmp_path / "a.mp4"
+    second = tmp_path / "b.mp4"
+    first.write_bytes(b"A" * 70000 + b"middle-one" + b"Z" * 70000)
+    second.write_bytes(b"A" * 70000 + b"middle-two" + b"Z" * 70000)
+
+    assert first.stat().st_size == second.stat().st_size
+    assert recap._file_fingerprint(first) != recap._file_fingerprint(second)
+
+
+def test_recap_phase_b_rejects_work_dir_from_different_source(monkeypatch, tmp_path):
+    """Phase B must not apply an existing narration.json to a different input video."""
+    old_video = tmp_path / "old.mp4"
+    new_video = tmp_path / "new.mp4"
+    old_video.write_bytes(b"old-video")
+    new_video.write_bytes(b"new-video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "old。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, old_video.resolve(), _manifest_args())
+    monkeypatch.setattr("recap._run", lambda *args: (_ for _ in ()).throw(AssertionError("must fail before stages run")))
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(new_video), "--work-dir", str(work)])
+
+    with pytest.raises(SystemExit, match="work_dir 与当前 recap 输入不匹配"):
+        recap.main()
+
+
+def test_recap_honors_edit_mode_and_target_duration_env(monkeypatch, tmp_path):
+    """Config playbook promises EDIT_MODE/TARGET_DURATION env fallbacks for the orchestrator."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 10, "end": 12, "narration": "source。"}]),
+        encoding="utf-8",
+    )
+    (work / "clip_plan.json").write_text(
+        json.dumps([{"start": 10, "end": 12}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut", target_duration="10m"))
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "cut.py":
+            (work / "narration_mapped.json").write_text(
+                json.dumps([{"start": 0, "end": 2, "narration": "mapped。"}]),
+                encoding="utf-8",
+            )
+            (work / "edited_source.mp4").write_bytes(b"edited")
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setenv("EDIT_MODE", "cut")
+    monkeypatch.setenv("TARGET_DURATION", "10m")
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    cut_call = next(call for call in calls if call[:2] == ("video-cut", "cut.py"))
+    cut_args = cut_call[2]
+    assert "--target-duration" in cut_args
+    assert cut_args[cut_args.index("--target-duration") + 1] == "10m"
+    validate_call = next(call for call in calls if call[:2] == ("video-script", "validate.py"))
+    validate_args = validate_call[2]
+    assert validate_args[validate_args.index("--mode") + 1] == "cut"
+
+
+def test_recap_completion_prints_manifest_final_output(monkeypatch, tmp_path, capsys):
+    """If assemble avoids a basename collision, recap should report that true path."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+    collision_safe = tmp_path / "recap_video_abcd1234ef.mp4"
+
+    def fake_run(skill, script, *cli_args):
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(collision_safe)}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    assert str(collision_safe) in capsys.readouterr().out
+
+
+
+def test_recap_continuation_preserves_phase_b_flags(tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work dir"
+    args = _manifest_args()
+    args.mimo_tts_voice = "冰糖"
+    args.burn_subtitles = True
+    args.output_dir = str(tmp_path / "out dir")
+    args.export_jianying = True
+    args.jianying_bundle_media = True
+    args.jianying_no_bundle_media = False
+    args.allow_partial_tts = True
+
+    cmd = recap._continuation_command(video, work, args)
+
+    assert "--mimo-tts-voice" in cmd and "冰糖" in cmd
+    assert "--allow-partial-tts" in cmd
+    assert "--burn-subtitles" in cmd
+    assert "--output-dir" in cmd and "out dir" in cmd
+    assert "--export-jianying" in cmd
+    assert "--jianying-bundle-media" in cmd
+    assert "--jianying-no-bundle-media" not in cmd
+
+
+def test_recap_forwards_allow_partial_tts_to_voiceover(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--allow-partial-tts",
+    ])
+
+    recap.main()
+
+    voiceover_call = next(call for call in calls if call[:2] == ("video-voiceover", "voiceover.py"))
+    assert "--allow-partial-tts" in voiceover_call[2]
+
+
+def test_recap_phase_b_allows_environment_changes_when_artifacts_are_unchanged(monkeypatch, tmp_path):
+    """Phase-B resume is gated on source bytes + settings; harmless env drift must not block it."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "old。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(skip_asr=True))
+
+    # The minimal resume gate is keyed on source-video bytes + CLI/env settings only.
+    # ASR/VLM endpoint or model env drift does not change Phase-A artifacts already on
+    # disk (Phase B never re-runs them), so it must not block a legitimate resume.
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--skip-asr"])
+
+    recap.main()
+
+    assert any(call[:2] == ("video-assemble", "assemble.py") for call in calls)

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-script' / 'scripts'))
 import json
+import narration
 import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
 from lib import CONFIG
@@ -31,6 +32,14 @@ def test_lint_narration_reports_warnings_and_errors(tmp_path, monkeypatch):
     assert "slot_too_short" in codes
     assert "empty_narration" in codes
     assert "incomplete_sentence" in codes
+    assert (tmp_path / "narration_lint.json").exists()
+
+
+def test_lint_narration_rejects_empty_file(tmp_path):
+    report = lint_narration([], work_dir=tmp_path)
+
+    assert report["ok"] is False
+    assert any(issue["code"] == "empty_narration_file" for issue in report["errors"])
     assert (tmp_path / "narration_lint.json").exists()
 
 
@@ -143,8 +152,21 @@ def test_post_dedup_keeps_distinct_short_beats(monkeypatch):
 
 
 def test_agent_brief_includes_mimo_video_overview(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "mimo_video_overview", True)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 20.0)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 1.0)
+    chunks = [{"chunk_id": 0, "scene_id": 0, "start": 0.0, "end": 3.0, "content": "这是 MiMo 对分片汇总的故事线概览。"}]
+    overview = {
+        "input": "scene_chunks",
+        "content": "这是 MiMo 对分片汇总的故事线概览。",
+        "reasoning_content": "内部推理",
+        "chunks": chunks,
+        "chunks_fingerprint": narration._mimo_cached_chunks_fingerprint(chunks),
+        "settings": narration._mimo_video_settings_fingerprint(),
+    }
+    overview["overview_fingerprint"] = narration._mimo_overview_payload_fingerprint(overview)
     (tmp_path / "mimo_video_overview.json").write_text(
-        '{"input":"scene_chunks","content":"这是 MiMo 对分片汇总的故事线概览。","reasoning_content":"内部推理"}',
+        json.dumps(overview, ensure_ascii=False),
         encoding="utf-8",
     )
     monkeypatch.setitem(CONFIG, "edit_mode", "full")
@@ -239,3 +261,47 @@ def test_assess_understanding_substrate_levels():
         [{"start": 0.0, "end": 3.0, "text": "对白" * 60}],
     )
     assert rich["level"] == "rich"
+
+
+def test_cut_validate_prefers_raw_plan_when_validated_is_stale(tmp_path):
+    import sys
+    import importlib.util
+
+    validate_path = Path(__file__).resolve().parents[2] / "skills" / "video-script" / "scripts" / "validate.py"
+    spec = importlib.util.spec_from_file_location("video_script_validate_under_test", validate_path)
+    validate = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = validate
+    spec.loader.exec_module(validate)
+
+    raw = tmp_path / "clip_plan.json"
+    validated = tmp_path / "clip_plan_validated.json"
+    raw.write_text(json.dumps({"clips": [{"start": 40.0, "end": 50.0}]}), encoding="utf-8")
+    validated.write_text(json.dumps({"clips": [{"clip_id": 0, "source_start": 0.0, "source_end": 10.0}]}), encoding="utf-8")
+
+    plan = validate._load_cut_clip_plan(tmp_path)
+
+    assert plan["clips"][0]["start"] == 40.0
+
+
+def test_cut_validate_uses_validated_plan_when_raw_fingerprint_matches(tmp_path):
+    import sys
+    import importlib.util
+
+    validate_path = Path(__file__).resolve().parents[2] / "skills" / "video-script" / "scripts" / "validate.py"
+    spec = importlib.util.spec_from_file_location("video_script_validate_fresh_under_test", validate_path)
+    validate = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = validate
+    spec.loader.exec_module(validate)
+
+    raw_payload = {"clips": [{"start": 40.0, "end": 50.0}]}
+    raw = tmp_path / "clip_plan.json"
+    validated = tmp_path / "clip_plan_validated.json"
+    raw.write_text(json.dumps(raw_payload), encoding="utf-8")
+    validated.write_text(json.dumps({
+        "raw_plan_fingerprint": validate._value_fingerprint(raw_payload),
+        "clips": [{"clip_id": 0, "source_start": 40.0, "source_end": 50.0}],
+    }), encoding="utf-8")
+
+    plan = validate._load_cut_clip_plan(tmp_path)
+
+    assert plan["clips"][0]["source_start"] == 40.0

--- a/tests/understanding/test_consolidate.py
+++ b/tests/understanding/test_consolidate.py
@@ -63,6 +63,11 @@ def test_consolidate_index_writes_artifacts(monkeypatch, tmp_path):
     idx = consolidate.consolidate_index(tmp_path)
     assert idx["characters"][0]["name"] == "张三"
     assert (tmp_path / "understanding_index.json").exists()
+    meta = json.loads((tmp_path / "understanding_index.json.meta.json").read_text(encoding="utf-8"))
+    assert meta["source_md5"]
+    assert meta["scene_count"] == 1
+    assert meta["model"] == consolidate.CONFIG.get("vlm_model", "")
+    assert meta["prompt_md5"] == consolidate._prompt_fingerprint(consolidate.INDEX_PROMPT)
     md = (tmp_path / "understanding_index.md").read_text(encoding="utf-8")
     assert "张三" in md and "匕首" in md
 
@@ -74,8 +79,42 @@ def test_consolidate_transcript_writes_provenance_and_preserves_spans(monkeypatc
     out = consolidate.consolidate_transcript(tmp_path)
     import hashlib
     assert out["source_md5"] == hashlib.md5((tmp_path / "asr_result.json").read_bytes()).hexdigest()
+    assert out["model"] == consolidate.CONFIG.get("vlm_model", "")
+    assert out["prompt_md5"] == consolidate._prompt_fingerprint(consolidate.CLEAN_PROMPT)
     assert out["segments"][0]["start"] == 0.0 and out["segments"][0]["end"] == 5.0
     assert out["segments"][0]["text"] == "你给我站住！"
+
+
+
+
+def test_consolidate_index_recomputes_when_meta_missing_or_source_changes(monkeypatch, tmp_path):
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps(
+        [{"scene_id": 0, "start": 0, "end": 5, "description": "first"}]), encoding="utf-8")
+    calls = {"n": 0}
+
+    def counting(payload):
+        calls["n"] += 1
+        name = "第一次" if calls["n"] == 1 else "第二次"
+        return _fake(f'{{"characters":[{{"name":"{name}"}}],"relationships":[],"plot_points":[],"entities":[]}}')
+
+    monkeypatch.setattr("consolidate.api_call", counting)
+    first = consolidate.consolidate_index(tmp_path)
+    assert first["characters"][0]["name"] == "第一次"
+
+    # Removing provenance makes the otherwise-fresh index untrusted.
+    (tmp_path / "understanding_index.json.meta.json").unlink()
+    second = consolidate.consolidate_index(tmp_path)
+    assert second["characters"][0]["name"] == "第二次"
+    assert calls["n"] == 2
+
+    # Changing VLM bytes also invalidates the cache even if mtime says fresh.
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps(
+        [{"scene_id": 0, "start": 0, "end": 5, "description": "changed"}]), encoding="utf-8")
+    stale_meta = json.loads((tmp_path / "understanding_index.json.meta.json").read_text(encoding="utf-8"))
+    (tmp_path / "understanding_index.json.meta.json").write_text(json.dumps(stale_meta), encoding="utf-8")
+    third = consolidate.consolidate_index(tmp_path)
+    assert calls["n"] == 3
+    assert third["characters"]
 
 
 def test_consolidate_index_is_idempotent(monkeypatch, tmp_path):
@@ -96,3 +135,48 @@ def test_consolidate_graceful_when_inputs_absent(tmp_path):
     # no vlm_analysis.json / asr_result.json -> no crash, returns empty-ish
     res = consolidate.consolidate(tmp_path, do_asr=True, do_index=True)
     assert res.get("index") is None and res.get("asr_clean") is None
+
+
+
+def test_consolidate_recomputes_asr_clean_when_model_or_prompt_meta_missing(monkeypatch, tmp_path):
+    asr = [{"start": 0.0, "end": 5.0, "text": "你给我站住"}]
+    (tmp_path / "asr_result.json").write_text(json.dumps(asr), encoding="utf-8")
+    calls = {"n": 0}
+
+    def counting(payload):
+        calls["n"] += 1
+        text = "第一次" if calls["n"] == 1 else "第二次"
+        return _fake(f'{{"segments":[{{"i":0,"text":"{text}"}}]}}')
+
+    monkeypatch.setattr("consolidate.api_call", counting)
+    first = consolidate.consolidate_transcript(tmp_path)
+    assert first["segments"][0]["text"] == "第一次"
+
+    payload = json.loads((tmp_path / "asr_clean.json").read_text(encoding="utf-8"))
+    payload.pop("model")
+    (tmp_path / "asr_clean.json").write_text(json.dumps(payload), encoding="utf-8")
+    second = consolidate.consolidate_transcript(tmp_path)
+
+    assert calls["n"] == 2
+    assert second["segments"][0]["text"] == "第二次"
+
+
+def test_consolidate_index_recomputes_when_prompt_provenance_missing(monkeypatch, tmp_path):
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps(
+        [{"scene_id": 0, "start": 0, "end": 5, "description": "d"}]), encoding="utf-8")
+    calls = {"n": 0}
+
+    def counting(payload):
+        calls["n"] += 1
+        name = "第一次" if calls["n"] == 1 else "第二次"
+        return _fake(f'{{"characters":[{{"name":"{name}"}}],"relationships":[],"plot_points":[],"entities":[]}}')
+
+    monkeypatch.setattr("consolidate.api_call", counting)
+    consolidate.consolidate_index(tmp_path)
+    meta = json.loads((tmp_path / "understanding_index.json.meta.json").read_text(encoding="utf-8"))
+    meta.pop("prompt_md5")
+    (tmp_path / "understanding_index.json.meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    second = consolidate.consolidate_index(tmp_path)
+
+    assert calls["n"] == 2
+    assert second["characters"][0]["name"] == "第二次"

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -4,12 +4,26 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-u
 import hashlib
 import json
 
-from brief import (build_agent_brief, _chunk_asr_for_writing, _load_clean_asr,
-                   _load_consolidation, _format_consolidation)
+from brief import (CONFIG, build_agent_brief, _chunk_asr_for_writing, _load_clean_asr,
+                   _load_consolidation, _format_consolidation, _clean_asr_prompt_fingerprint,
+                   _index_prompt_fingerprint)
 
 SCENES = [{"scene_id": 0, "start": 0.0, "end": 6.0, "description": "门口对峙"}]
 ASR = [{"start": 1.0, "end": 5.0, "text": "第一句对白。第二句反击。"}]
 SILENCE = [{"start": 0.0, "end": 1.0, "duration": 1.0, "has_speech": False}]
+
+
+def _write_index_with_meta(work_dir, index, scenes=SCENES):
+    (work_dir / "vlm_analysis.json").write_text(json.dumps(scenes), encoding="utf-8")
+    src_md5 = hashlib.md5((work_dir / "vlm_analysis.json").read_bytes()).hexdigest()
+    (work_dir / "understanding_index.json").write_text(json.dumps(index), encoding="utf-8")
+    (work_dir / "understanding_index.json.meta.json").write_text(json.dumps({
+        "schema_version": 1,
+        "source_md5": src_md5,
+        "scene_count": len(scenes),
+        "model": CONFIG.get("vlm_model", ""),
+        "prompt_md5": _index_prompt_fingerprint(),
+    }), encoding="utf-8")
 
 
 def test_brief_noop_without_consolidation(tmp_path):
@@ -24,12 +38,30 @@ def test_brief_noop_without_consolidation(tmp_path):
 
 
 def test_brief_folds_in_index_when_present(tmp_path):
-    (tmp_path / "understanding_index.json").write_text(json.dumps(
-        {"characters": [{"name": "张三", "description": "主角"}], "relationships": [],
-         "plot_points": ["开端"], "entities": ["匕首"]}), encoding="utf-8")
+    _write_index_with_meta(tmp_path, {"characters": [{"name": "张三", "description": "主角"}],
+                                      "relationships": [], "plot_points": ["开端"], "entities": ["匕首"]})
     text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path).read_text(encoding="utf-8")
     assert "Understanding index (from consolidate.py)" in text
     assert "张三" in text and "匕首" in text
+
+
+def test_brief_rejects_stale_index_without_matching_vlm_provenance(tmp_path):
+    stale_index = {"characters": [{"name": "旧角色", "description": "旧素材"}],
+                   "relationships": [], "plot_points": [], "entities": []}
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps(SCENES), encoding="utf-8")
+    (tmp_path / "understanding_index.json").write_text(json.dumps(stale_index), encoding="utf-8")
+    (tmp_path / "understanding_index.json.meta.json").write_text(json.dumps({
+        "schema_version": 1,
+        "source_md5": "deadbeef",
+        "scene_count": len(SCENES),
+        "model": CONFIG.get("vlm_model", ""),
+        "prompt_md5": _index_prompt_fingerprint(),
+    }), encoding="utf-8")
+
+    text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path).read_text(encoding="utf-8")
+
+    assert "Understanding index (from consolidate.py)" not in text
+    assert "旧角色" not in text
 
 
 def test_consolidation_loaders_are_safe_when_absent():
@@ -42,6 +74,8 @@ def test_clean_asr_accepted_when_fresh_provenance_timing_ok(tmp_path):
     src_md5 = hashlib.md5((tmp_path / "asr_result.json").read_bytes()).hexdigest()
     (tmp_path / "asr_clean.json").write_text(json.dumps(
         {"source_md5": src_md5,
+         "model": CONFIG.get("vlm_model", ""),
+         "prompt_md5": _clean_asr_prompt_fingerprint(),
          "segments": [{"start": 1.0, "end": 5.0, "text": "第一句对白。第二句反击。CLEANED"}]}), encoding="utf-8")
     got = _load_clean_asr(tmp_path, ASR)
     assert got is not None and got[0]["text"].endswith("CLEANED")
@@ -56,8 +90,73 @@ def test_clean_asr_rejected_on_bad_provenance_and_mistiming(tmp_path):
     # correct provenance but mis-timed span -> None (timing guard)
     src_md5 = hashlib.md5((tmp_path / "asr_result.json").read_bytes()).hexdigest()
     (tmp_path / "asr_clean.json").write_text(json.dumps(
-        {"source_md5": src_md5, "segments": [{"start": 99.0, "end": 100.0, "text": "x"}]}), encoding="utf-8")
+        {"source_md5": src_md5,
+         "model": CONFIG.get("vlm_model", ""),
+         "prompt_md5": _clean_asr_prompt_fingerprint(),
+         "segments": [{"start": 99.0, "end": 100.0, "text": "x"}]}), encoding="utf-8")
     assert _load_clean_asr(tmp_path, ASR) is None
     # absent asr_clean.json -> None
     (tmp_path / "asr_clean.json").unlink()
     assert _load_clean_asr(tmp_path, ASR) is None
+
+
+
+def test_brief_rejects_index_when_model_or_prompt_provenance_differs(monkeypatch, tmp_path):
+    _write_index_with_meta(tmp_path, {"characters": [{"name": "旧模型角色", "description": "旧模型"}],
+                                      "relationships": [], "plot_points": [], "entities": []})
+    monkeypatch.setitem(CONFIG, "vlm_model", "different-model")
+
+    text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path).read_text(encoding="utf-8")
+
+    assert "旧模型角色" not in text
+    assert "Understanding index (from consolidate.py)" not in text
+
+
+def test_clean_asr_rejected_when_model_or_prompt_provenance_differs(monkeypatch, tmp_path):
+    (tmp_path / "asr_result.json").write_text(json.dumps(ASR), encoding="utf-8")
+    src_md5 = hashlib.md5((tmp_path / "asr_result.json").read_bytes()).hexdigest()
+    (tmp_path / "asr_clean.json").write_text(json.dumps({
+        "source_md5": src_md5,
+        "model": "old-model",
+        "prompt_md5": _clean_asr_prompt_fingerprint(),
+        "segments": [{"start": 1.0, "end": 5.0, "text": "旧模型清洗。"}],
+    }), encoding="utf-8")
+
+    assert _load_clean_asr(tmp_path, ASR) is None
+
+    (tmp_path / "asr_clean.json").write_text(json.dumps({
+        "source_md5": src_md5,
+        "model": CONFIG.get("vlm_model", ""),
+        "prompt_md5": "deadbeef",
+        "segments": [{"start": 1.0, "end": 5.0, "text": "旧提示清洗。"}],
+    }), encoding="utf-8")
+
+    assert _load_clean_asr(tmp_path, ASR) is None
+
+
+def test_brief_ignores_stale_mimo_overview_when_disabled_or_chunk_mismatch(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "mimo_video_overview", False)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+    (tmp_path / "mimo_video_overview.json").write_text(json.dumps({
+        "input": "scene_chunks",
+        "content": "STALE MIMO OVERVIEW",
+        "chunks": [{"chunk_id": 0, "scene_id": 99, "start": 0.0, "end": 2.0, "content": "STALE"}],
+        "settings": {
+            "model": CONFIG.get("mimo_video_model") or CONFIG.get("mimo_model") or CONFIG.get("vlm_model"),
+            "mimo_video_fps": CONFIG.get("mimo_video_fps", 2.0),
+            "mimo_media_resolution": CONFIG.get("mimo_media_resolution", "default"),
+            "mimo_video_chunk_max_seconds": 2,
+            "mimo_video_chunk_min_seconds": 0.5,
+            "mimo_video_base64_max_mb": CONFIG.get("mimo_video_base64_max_mb", 45.0),
+            "mimo_video_prompt": CONFIG.get("mimo_video_prompt", ""),
+            "mimo_disable_thinking": CONFIG.get("mimo_disable_thinking", True),
+        },
+    }), encoding="utf-8")
+
+    disabled_text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path).read_text(encoding="utf-8")
+    assert "STALE MIMO OVERVIEW" not in disabled_text
+
+    monkeypatch.setitem(CONFIG, "mimo_video_overview", True)
+    mismatch_text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path).read_text(encoding="utf-8")
+    assert "STALE MIMO OVERVIEW" not in mismatch_text

--- a/tests/understanding/test_detect_fixes.py
+++ b/tests/understanding/test_detect_fixes.py
@@ -127,19 +127,24 @@ def test_detect_silence_does_not_leave_partial_audio_on_failure(monkeypatch, tmp
 
 
 def test_detect_silence_returns_empty_on_silencedetect_nonzero(monkeypatch, tmp_path):
-    # audio.wav already exists → extraction skipped, but silencedetect fails
+    # audio.wav already exists for the same source → extraction skipped, but silencedetect fails
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"video")
     (tmp_path / "audio.wav").write_bytes(b"RIFFxxxx")
+    detect._write_audio_meta(tmp_path, video)
     logs = []
     monkeypatch.setattr("detect.log", lambda msg: logs.append(msg))
     monkeypatch.setattr("detect.run_cmd", lambda cmd, **kw: _fail("filter error"))
 
-    out = detect_silence_periods(tmp_path / "v.mp4", tmp_path)
+    out = detect_silence_periods(video, tmp_path)
     assert out == []
     assert any("静音检测失败" in m for m in logs)
 
 
 def test_detect_silence_extracts_to_temp_then_atomic_moves(monkeypatch, tmp_path):
     # happy path: extraction writes temp, silencedetect succeeds with no silence
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"video")
     calls = []
 
     def fake_run(cmd, **kw):
@@ -154,7 +159,7 @@ def test_detect_silence_extracts_to_temp_then_atomic_moves(monkeypatch, tmp_path
     monkeypatch.setattr("detect.run_cmd", fake_run)
     monkeypatch.setattr("detect.get_video_duration", lambda path: 10.0)
 
-    out = detect_silence_periods(tmp_path / "v.mp4", tmp_path)
+    out = detect_silence_periods(video, tmp_path)
     assert out == []
     # extraction targeted a .tmp path (atomic move pattern), not audio.wav directly
     assert any(any(p.endswith("audio.wav.tmp") for p in c) for c in calls)
@@ -168,6 +173,8 @@ def test_detect_silence_extracts_to_temp_then_atomic_moves(monkeypatch, tmp_path
 def test_silence_audio_extract_states_wav_format(monkeypatch, tmp_path):
     """BUG: extracting to audio.wav.tmp hides the format from ffmpeg (muxer 'Invalid argument').
     The extraction command must pass -f wav explicitly."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"video")
     cmds = []
 
     def fake(cmd, **kw):
@@ -177,7 +184,33 @@ def test_silence_audio_extract_states_wav_format(monkeypatch, tmp_path):
         return _ok()
 
     monkeypatch.setattr("detect.run_cmd", fake)
-    detect_silence_periods(tmp_path / "v.mp4", tmp_path, asr_result=[])
+    detect_silence_periods(video, tmp_path, asr_result=[])
     extract = next((c for c in cmds if any("audio.wav.tmp" in x for x in c)), None)
     assert extract is not None, "no audio extraction command issued"
     assert "-f" in extract and "wav" in extract, f"extract cmd missing -f wav: {extract}"
+
+
+def test_detect_silence_reextracts_audio_when_source_video_changes(monkeypatch, tmp_path):
+    """audio.wav reuse must be tied to the source video, not merely file existence."""
+    old_video = tmp_path / "old.mp4"
+    new_video = tmp_path / "new.mp4"
+    old_video.write_bytes(b"old")
+    new_video.write_bytes(b"new")
+    (tmp_path / "audio.wav").write_bytes(b"old-audio")
+    detect._write_audio_meta(tmp_path, old_video)
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append([str(part) for part in cmd])
+        if any(str(part).endswith("audio.wav.tmp") for part in cmd):
+            (tmp_path / "audio.wav.tmp").write_bytes(b"new-audio")
+        return _ok(stderr="")
+
+    monkeypatch.setattr("detect.log", lambda msg: None)
+    monkeypatch.setattr("detect.run_cmd", fake_run)
+    monkeypatch.setattr("detect.get_video_duration", lambda path: 10.0)
+
+    detect_silence_periods(new_video, tmp_path, asr_result=[])
+
+    assert (tmp_path / "audio.wav").read_bytes() == b"new-audio"
+    assert any(any(part.endswith("audio.wav.tmp") for part in cmd) for cmd in calls)

--- a/tests/understanding/test_io_fixes.py
+++ b/tests/understanding/test_io_fixes.py
@@ -7,6 +7,7 @@ from subprocess import CompletedProcess
 import pytest  # noqa: F401
 import asr
 import extract
+import understand
 
 
 def test_segment_cut_failure_yields_empty_text_not_stale_transcription(monkeypatch, tmp_path):
@@ -91,6 +92,20 @@ def test_run_asr_builds_mimo_payload_and_parses_content(monkeypatch, tmp_path):
     assert audio["input_audio"]["data"].startswith("data:audio/wav;base64,")
 
 
+def test_run_asr_api_failure_raises_instead_of_silent_empty(monkeypatch, tmp_path):
+    """Transient ASR API failures must not become cached empty transcript text."""
+    wav = tmp_path / "seg.wav"
+    wav.write_bytes(b"RIFFfake-wav-bytes")
+    monkeypatch.setitem(asr.CONFIG, "mimo_asr_api_key", "tp-test")
+
+    def fail(payload):
+        raise RuntimeError("quota")
+
+    monkeypatch.setattr("asr.mimo_asr_api_call", fail)
+    with pytest.raises(RuntimeError, match="MiMo ASR 调用失败"):
+        asr._run_asr(wav)
+
+
 def test_run_asr_skips_oversize_segment(monkeypatch, tmp_path):
     """A segment whose base64 exceeds the MiMo cap is skipped, not sent (10MB API limit)."""
     wav = tmp_path / "big.wav"
@@ -141,3 +156,359 @@ def test_extract_frames_returns_only_current_run_frames(monkeypatch, tmp_path):
 
     assert len(frames) == 2
     assert [f.name for f in frames] == ["frame_00001.jpg", "frame_00002.jpg"]
+
+
+def test_understand_reextracts_frames_when_source_video_changes(monkeypatch, tmp_path):
+    """understand.py must not skip stale frames just because work_dir/frames exists."""
+    old_video = tmp_path / "old.mp4"
+    new_video = tmp_path / "new.mp4"
+    old_video.write_bytes(b"old-video-bytes")
+    new_video.write_bytes(b"new-video-bytes")
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    stale_frame = frames_dir / "frame_00001.jpg"
+    stale_frame.write_bytes(b"stale-frame")
+    understand._write_frames_manifest(tmp_path, old_video, 1.0, [stale_frame])
+
+    calls = []
+
+    def fake_extract(video_path, work_dir):
+        calls.append(Path(video_path).name)
+        stale_frame.write_bytes(b"fresh-frame")
+        return [stale_frame]
+
+    def fake_detect(video_path, work_dir, threshold=None):
+        scenes = [{"start": 0.0, "end": 10.0}]
+        (Path(work_dir) / "scenes.json").write_text(json.dumps(scenes), encoding="utf-8")
+        return scenes
+
+    monkeypatch.setitem(understand.CONFIG, "fps", 1.0)
+    monkeypatch.setitem(understand.CONFIG, "mimo_video_overview", False)
+    monkeypatch.setitem(understand.CONFIG, "api_key", "tp-test")
+    monkeypatch.setattr("understand.get_video_duration", lambda path: 10.0)
+    monkeypatch.setattr("understand.api_call", lambda payload: {"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr("understand.extract_frames", fake_extract)
+    monkeypatch.setattr("understand.detect_scenes", fake_detect)
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "understand.analyze_scenes",
+        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+    )
+    monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
+    monkeypatch.setattr(sys, "argv", ["understand.py", str(new_video), "--work-dir", str(tmp_path), "--skip-asr"])
+
+    understand.main()
+
+    assert calls == ["new.mp4"]
+    assert stale_frame.read_bytes() == b"fresh-frame"
+    assert understand._frames_cache_valid(new_video, tmp_path, 1.0)
+
+
+def test_understand_removes_stale_mimo_overview_before_failed_recompute(monkeypatch, tmp_path):
+    """A failed overview refresh must not leave a stale final overview for the brief."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    stale_overview = tmp_path / "mimo_video_overview.json"
+    stale_overview.write_text(json.dumps({"input": "scene_chunks", "content": "STALE"}), encoding="utf-8")
+    frame = tmp_path / "frames" / "frame_00001.jpg"
+    frame.parent.mkdir()
+    frame.write_bytes(b"frame")
+
+    def fake_detect(video_path, work_dir, threshold=None):
+        scenes = [{"scene_id": 0, "start": 0.0, "end": 10.0}]
+        (Path(work_dir) / "scenes.json").write_text(json.dumps(scenes), encoding="utf-8")
+        return scenes
+
+    def fail_overview(*args, **kwargs):
+        raise RuntimeError("overview refresh failed")
+
+    monkeypatch.setitem(understand.CONFIG, "fps", 1.0)
+    monkeypatch.setitem(understand.CONFIG, "api_key", "tp-test")
+    monkeypatch.setitem(understand.CONFIG, "mimo_video_overview", True)
+    monkeypatch.setitem(understand.CONFIG, "mimo_video_api_key", "tp-test")
+    monkeypatch.setattr("understand.get_video_duration", lambda path: 10.0)
+    monkeypatch.setattr("understand.api_call", lambda payload: {"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr("understand.extract_frames", lambda video_path, work_dir: [frame])
+    monkeypatch.setattr("understand.detect_scenes", fake_detect)
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "understand.analyze_scenes",
+        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+    )
+    monkeypatch.setattr("understand.analyze_video_overview", fail_overview)
+    monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
+    monkeypatch.setattr(sys, "argv", ["understand.py", str(video), "--work-dir", str(tmp_path), "--skip-asr"])
+
+    understand.main()
+
+    assert not stale_overview.exists()
+
+
+def _run_understand_for_cache_tests(monkeypatch, tmp_path, video, *, argv_extra=None):
+    frame = tmp_path / "frames" / "frame_00001.jpg"
+    frame.parent.mkdir(exist_ok=True)
+    frame.write_bytes(b"frame")
+
+    monkeypatch.setitem(understand.CONFIG, "fps", 1.0)
+    monkeypatch.setitem(understand.CONFIG, "api_key", "tp-test")
+    monkeypatch.setitem(understand.CONFIG, "mimo_video_api_key", "")
+    monkeypatch.setitem(understand.CONFIG, "mimo_video_overview", False)
+    monkeypatch.setattr("understand.get_video_duration", lambda path: 10.0)
+    monkeypatch.setattr("understand.api_call", lambda payload: {"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr("understand.extract_frames", lambda video_path, work_dir: [frame])
+    monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
+    argv = ["understand.py", str(video), "--work-dir", str(tmp_path), *(argv_extra or [])]
+    monkeypatch.setattr(sys, "argv", argv)
+    understand.main()
+
+
+def test_stage_cache_rejects_artifact_mutation_with_stale_sidecar(tmp_path):
+    artifact = tmp_path / "scenes.json"
+    artifact.write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8")
+    meta = {
+        "schema_version": 1,
+        "stage": "scenes",
+        "source_video_fingerprint": "source",
+        "settings": {},
+    }
+    understand._write_stage_meta(artifact, meta)
+
+    assert understand._stage_cache_valid(artifact, meta)
+
+    artifact.write_text(json.dumps([{"start": 0.0, "end": 5.0}]), encoding="utf-8")
+
+    assert not understand._stage_cache_valid(artifact, meta)
+
+
+def test_understand_recomputes_stage_when_artifact_bytes_change(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_detect(video_path, work_dir, threshold=None):
+        calls.append(len(calls) + 1)
+        scenes = [{"start": 0.0, "end": 10.0, "run": calls[-1]}]
+        (Path(work_dir) / "scenes.json").write_text(json.dumps(scenes), encoding="utf-8")
+        return scenes
+
+    monkeypatch.setattr("understand.detect_scenes", fake_detect)
+    monkeypatch.setattr("understand.transcribe_audio", lambda *a, **k: [])
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", lambda *a, **k: [])
+
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+    (tmp_path / "scenes.json").write_text(
+        json.dumps([{"start": 0.0, "end": 10.0, "run": "externally-mutated"}]),
+        encoding="utf-8",
+    )
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+
+    assert calls == [1, 2]
+    assert json.loads((tmp_path / "scenes.json").read_text(encoding="utf-8"))[0]["run"] == 2
+
+
+def test_understand_recomputes_scenes_when_scene_settings_change(monkeypatch, tmp_path):
+    """Scene cache freshness must include threshold/junk settings, not just video mtime."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_detect(video_path, work_dir, threshold=None):
+        calls.append(threshold)
+        scenes = [{"start": 0.0, "end": 10.0, "threshold": threshold}]
+        (Path(work_dir) / "scenes.json").write_text(json.dumps(scenes), encoding="utf-8")
+        return scenes
+
+    monkeypatch.setattr("understand.detect_scenes", fake_detect)
+    monkeypatch.setattr("understand.transcribe_audio", lambda *a, **k: [])
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", lambda *a, **k: [])
+
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video, argv_extra=["--scene-threshold", "0.1"])
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video, argv_extra=["--scene-threshold", "0.4"])
+
+    assert calls == [0.1, 0.4]
+    assert json.loads((tmp_path / "scenes.json").read_text(encoding="utf-8"))[0]["threshold"] == 0.4
+
+
+def test_understand_recomputes_asr_when_asr_settings_change(monkeypatch, tmp_path):
+    """ASR cache freshness must include ASR settings and source provenance."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_asr(video_path, work_dir):
+        calls.append(understand.CONFIG["asr_segment_seconds"])
+        result = [{"start": 0.0, "end": 1.0, "text": f"seg-{calls[-1]}"}]
+        (Path(work_dir) / "asr_result.json").write_text(json.dumps(result), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr("understand.detect_scenes", lambda video_path, work_dir, threshold=None: (Path(work_dir) / "scenes.json").write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8") and [{"start": 0.0, "end": 10.0}])
+    monkeypatch.setattr("understand.transcribe_audio", fake_asr)
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", lambda *a, **k: [])
+
+    monkeypatch.setitem(understand.CONFIG, "asr_segment_seconds", 30.0)
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+    monkeypatch.setitem(understand.CONFIG, "asr_segment_seconds", 12.0)
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+
+    assert calls == [30.0, 12.0]
+    assert json.loads((tmp_path / "asr_result.json").read_text(encoding="utf-8"))[0]["text"] == "seg-12.0"
+
+
+def test_understand_recomputes_silence_when_asr_content_changes(monkeypatch, tmp_path):
+    """Silence cache freshness must include ASR artifact bytes/provenance."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+    asr_payload = {"value": [{"start": 0.0, "end": 1.0, "text": "first"}]}
+
+    def fake_asr(video_path, work_dir):
+        (Path(work_dir) / "asr_result.json").write_text(json.dumps(asr_payload["value"]), encoding="utf-8")
+        return asr_payload["value"]
+
+    def fake_silence(video_path, work_dir, asr_result):
+        calls.append([seg["text"] for seg in asr_result])
+        result = [{"start": 0.0, "end": 1.0, "duration": 1.0, "has_speech": bool(calls[-1])}]
+        (Path(work_dir) / "silence_periods.json").write_text(json.dumps(result), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr("understand.detect_scenes", lambda video_path, work_dir, threshold=None: (Path(work_dir) / "scenes.json").write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8") and [{"start": 0.0, "end": 10.0}])
+    monkeypatch.setattr("understand.transcribe_audio", fake_asr)
+    monkeypatch.setattr("understand.detect_silence_periods", fake_silence)
+    monkeypatch.setattr("understand.analyze_scenes", lambda *a, **k: [])
+
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+    asr_payload["value"] = [{"start": 0.0, "end": 1.0, "text": "second"}]
+    (tmp_path / "asr_result.json").unlink()
+    (tmp_path / "asr_result.json.meta.json").unlink()
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+
+    assert calls == [["first"], ["second"]]
+
+
+def test_understand_recomputes_vlm_when_context_changes(monkeypatch, tmp_path):
+    """VLM cache freshness must include prompt/context/model/frame/scene provenance."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_vlm(scenes, frames, work_dir):
+        calls.append(understand.CONFIG.get("context_info", ""))
+        result = [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": calls[-1]}]
+        (Path(work_dir) / "vlm_analysis.json").write_text(json.dumps(result), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr("understand.detect_scenes", lambda video_path, work_dir, threshold=None: (Path(work_dir) / "scenes.json").write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8") and [{"start": 0.0, "end": 10.0}])
+    monkeypatch.setattr("understand.transcribe_audio", lambda *a, **k: [])
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", fake_vlm)
+
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video, argv_extra=["--context", "角色A"])
+    monkeypatch.setitem(understand.CONFIG, "context_info", "")
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video, argv_extra=["--context", "角色B"])
+
+    assert calls == ["角色A", "角色B"]
+    assert json.loads((tmp_path / "vlm_analysis.json").read_text(encoding="utf-8"))[0]["description"] == "角色B"
+
+
+def test_understand_recomputes_vlm_when_api_endpoint_changes(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_vlm(scenes, frames, work_dir):
+        calls.append(understand.CONFIG.get("api_url", ""))
+        result = [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": calls[-1]}]
+        (Path(work_dir) / "vlm_analysis.json").write_text(json.dumps(result), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr("understand.detect_scenes", lambda video_path, work_dir, threshold=None: (Path(work_dir) / "scenes.json").write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8") and [{"start": 0.0, "end": 10.0}])
+    monkeypatch.setattr("understand.transcribe_audio", lambda *a, **k: [])
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", fake_vlm)
+
+    monkeypatch.setitem(understand.CONFIG, "api_url", "https://one.example/v1/chat/completions")
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+    monkeypatch.setitem(understand.CONFIG, "api_url", "https://two.example/v1/chat/completions")
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+
+    assert calls == ["https://one.example/v1/chat/completions", "https://two.example/v1/chat/completions"]
+
+
+def test_understand_recomputes_vlm_when_thinking_behavior_changes(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_vlm(scenes, frames, work_dir):
+        calls.append(understand.CONFIG.get("mimo_disable_thinking"))
+        result = [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": str(calls[-1])}]
+        (Path(work_dir) / "vlm_analysis.json").write_text(json.dumps(result), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr("understand.detect_scenes", lambda video_path, work_dir, threshold=None: (Path(work_dir) / "scenes.json").write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8") and [{"start": 0.0, "end": 10.0}])
+    monkeypatch.setattr("understand.transcribe_audio", lambda *a, **k: [])
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", fake_vlm)
+
+    monkeypatch.setitem(understand.CONFIG, "mimo_disable_thinking", True)
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+    monkeypatch.setitem(understand.CONFIG, "mimo_disable_thinking", False)
+    _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+
+    assert calls == [True, False]
+
+
+def test_understand_asr_exception_does_not_cache_empty_transcript(monkeypatch, tmp_path):
+    """Unexpected ASR failures must fail fast and leave no reusable empty asr_result.json."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+
+    monkeypatch.setattr("understand.detect_scenes", lambda video_path, work_dir, threshold=None: (Path(work_dir) / "scenes.json").write_text(json.dumps([{"start": 0.0, "end": 10.0}]), encoding="utf-8") and [{"start": 0.0, "end": 10.0}])
+    monkeypatch.setattr("understand.transcribe_audio", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("quota")))
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr("understand.analyze_scenes", lambda *a, **k: [])
+
+    with pytest.raises(RuntimeError, match="ASR 失败"):
+        _run_understand_for_cache_tests(monkeypatch, tmp_path, video)
+
+    assert not (tmp_path / "asr_result.json").exists()
+    assert not (tmp_path / "asr_result.json.meta.json").exists()
+
+
+
+def test_understand_omits_stale_mimo_overview_when_overview_disabled(monkeypatch, tmp_path):
+    """Direct understand runs must not let an old overview leak into a new brief when disabled."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    stale_overview = tmp_path / "mimo_video_overview.json"
+    stale_overview.write_text(json.dumps({"input": "scene_chunks", "content": "STALE OVERVIEW"}), encoding="utf-8")
+    frame = tmp_path / "frames" / "frame_00001.jpg"
+    frame.parent.mkdir()
+    frame.write_bytes(b"frame")
+
+    def fake_detect(video_path, work_dir, threshold=None):
+        scenes = [{"scene_id": 0, "start": 0.0, "end": 10.0}]
+        (Path(work_dir) / "scenes.json").write_text(json.dumps(scenes), encoding="utf-8")
+        return scenes
+
+    monkeypatch.setitem(understand.CONFIG, "fps", 1.0)
+    monkeypatch.setitem(understand.CONFIG, "api_key", "tp-test")
+    monkeypatch.setitem(understand.CONFIG, "mimo_video_overview", False)
+    monkeypatch.setattr("understand.get_video_duration", lambda path: 10.0)
+    monkeypatch.setattr("understand.api_call", lambda payload: {"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr("understand.extract_frames", lambda video_path, work_dir: [frame])
+    monkeypatch.setattr("understand.detect_scenes", fake_detect)
+    monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "understand.analyze_scenes",
+        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+    )
+    monkeypatch.setattr(sys, "argv", ["understand.py", str(video), "--work-dir", str(tmp_path), "--skip-asr"])
+
+    understand.main()
+
+    assert not stale_overview.exists()
+    assert "STALE OVERVIEW" not in (tmp_path / "agent_narration_brief.md").read_text(encoding="utf-8")

--- a/tests/understanding/test_pure_understanding.py
+++ b/tests/understanding/test_pure_understanding.py
@@ -180,6 +180,18 @@ def test_content_fingerprint_cache_keys_ignore_path_and_mtime(tmp_path):
     assert step_cache_key(first, "vlm", {"model": "x"}) != step_cache_key(first, "vlm", {"model": "y"})
 
 
+def test_content_fingerprint_detects_middle_only_changes(tmp_path):
+    first = tmp_path / "a.mp4"
+    second = tmp_path / "b.mp4"
+    first.write_bytes(b"A" * 70000 + b"middle-one" + b"Z" * 70000)
+    second.write_bytes(b"A" * 70000 + b"middle-two" + b"Z" * 70000)
+
+    assert first.stat().st_size == second.stat().st_size
+    assert first.read_bytes()[:65536] == second.read_bytes()[:65536]
+    assert first.read_bytes()[-65536:] == second.read_bytes()[-65536:]
+    assert file_fingerprint(first) != file_fingerprint(second)
+
+
 def test_filter_junk_scenes_removes_black_or_white_transitions_but_keeps_fallback(monkeypatch):
     scenes = [
         {"start": 0.0, "end": 1.0},

--- a/tests/understanding/test_vlm_fixes.py
+++ b/tests/understanding/test_vlm_fixes.py
@@ -12,10 +12,13 @@ import pytest
 from lib import CONFIG
 from vlm import (
     _load_mimo_partial,
+    _mimo_cached_chunks_fingerprint,
+    _mimo_overview_payload_fingerprint,
     _mimo_chunk_cache_key,
     _save_mimo_partial,
     analyze_scenes,
     analyze_video_overview,
+    mimo_video_overview_cache_fresh,
     mimo_video_settings_fingerprint,
 )
 
@@ -105,7 +108,8 @@ def test_retry_text_keeps_frame_timestamp_header(monkeypatch, tmp_path):
 
     monkeypatch.setattr("vlm.api_call", fake_api_call)
 
-    analyze_scenes(scenes, [frame], tmp_path)
+    with pytest.raises(RuntimeError, match="VLM 分析失败"):
+        analyze_scenes(scenes, [frame], tmp_path)
 
     assert len(retry_texts) == 3
     # frame_00001.jpg @ fps=1.0 -> 1.0s ; header must appear on every attempt incl. retries
@@ -115,6 +119,40 @@ def test_retry_text_keeps_frame_timestamp_header(monkeypatch, tmp_path):
     # retry attempts also carry the explicit format reminder
     assert "请务必按格式输出，不要留空。" in retry_texts[1]
     assert "请务必按格式输出，不要留空。" in retry_texts[2]
+
+
+def test_scene_api_failure_does_not_write_placeholder_cache(monkeypatch, tmp_path):
+    """Transient VLM failures must fail the stage instead of caching placeholder analysis."""
+    frame = _make_frame(tmp_path)
+    scenes = [{"start": 0.0, "end": 1.0}]
+
+    monkeypatch.setitem(CONFIG, "fps", 1.0)
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_workers", 1)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    monkeypatch.setattr("vlm.api_call", lambda payload: (_ for _ in ()).throw(RuntimeError("quota")))
+
+    with pytest.raises(RuntimeError, match="VLM 分析失败"):
+        analyze_scenes(scenes, [frame], tmp_path)
+
+    assert not (tmp_path / "vlm_analysis.json").exists()
+
+
+def test_all_empty_scene_responses_do_not_write_placeholder_cache(monkeypatch, tmp_path):
+    """Repeated empty VLM responses are not a successful analysis cache."""
+    frame = _make_frame(tmp_path)
+    scenes = [{"start": 0.0, "end": 1.0}]
+
+    monkeypatch.setitem(CONFIG, "fps", 1.0)
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_workers", 1)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    monkeypatch.setattr("vlm.api_call", lambda payload: {"choices": [{"message": {"content": ""}}]})
+
+    with pytest.raises(RuntimeError, match="VLM 分析失败"):
+        analyze_scenes(scenes, [frame], tmp_path)
+
+    assert not (tmp_path / "vlm_analysis.json").exists()
 
 
 # ── BUG 5: 增量分片缓存往返 + 失败保留已付费分片 ───────────────────────────
@@ -135,6 +173,62 @@ def test_partial_cache_roundtrip_invalidates_on_settings_change(monkeypatch, tmp
     # changing a fingerprinted setting invalidates the whole partial
     monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 99)
     assert _load_mimo_partial(partial_path) == {}
+
+
+
+
+
+def test_partial_cache_rejects_payload_mutation(tmp_path):
+    """Partial cache metadata must not trust edited chunk JSON as paid fresh content."""
+    partial_path = tmp_path / "mimo_video_overview.partial.json"
+    chunk = {"chunk_id": 0, "scene_id": 7, "start": 0.0, "end": 2.0}
+    key = _mimo_chunk_cache_key(chunk)
+    done = {key: {"chunk_id": 0, "scene_id": 7, "content": "original paid chunk"}}
+
+    _save_mimo_partial(partial_path, done)
+    payload = json.loads(partial_path.read_text(encoding="utf-8"))
+    payload["chunks"][key]["content"] = "tampered but non-empty"
+    partial_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert _load_mimo_partial(partial_path) == {}
+
+
+def test_partial_cache_rejects_source_video_mismatch(monkeypatch, tmp_path):
+    """Incremental MiMo chunks from another source video must not be reused."""
+    old_video = tmp_path / "old.mp4"
+    new_video = tmp_path / "new.mp4"
+    old_video.write_bytes(b"old-video")
+    new_video.write_bytes(b"new-video")
+    scenes = [{"scene_id": 7, "start": 0.0, "end": 2.0}]
+    partial_path = tmp_path / "mimo_video_overview.partial.json"
+    chunk = {"chunk_id": 0, "scene_id": 7, "start": 0.0, "end": 2.0}
+    key = _mimo_chunk_cache_key(chunk)
+    done = {key: {"chunk_id": 0, "scene_id": 7, "content": "old paid chunk"}}
+
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+    _save_mimo_partial(partial_path, done, old_video, scenes)
+
+    assert _load_mimo_partial(partial_path, old_video, scenes) == done
+    assert _load_mimo_partial(partial_path, new_video, scenes) == {}
+
+
+def test_partial_cache_rejects_scene_chunk_mismatch(monkeypatch, tmp_path):
+    """Incremental MiMo chunks must be tied to the current scene/chunk plan."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    old_scenes = [{"scene_id": 7, "start": 0.0, "end": 2.0}]
+    new_scenes = [{"scene_id": 7, "start": 0.0, "end": 4.0}]
+    partial_path = tmp_path / "mimo_video_overview.partial.json"
+    chunk = {"chunk_id": 0, "scene_id": 7, "start": 0.0, "end": 2.0}
+    done = {_mimo_chunk_cache_key(chunk): {"chunk_id": 0, "scene_id": 7, "content": "old paid chunk"}}
+
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+    _save_mimo_partial(partial_path, done, video, old_scenes)
+
+    assert _load_mimo_partial(partial_path, video, old_scenes) == done
+    assert _load_mimo_partial(partial_path, video, new_scenes) == {}
 
 
 def test_failed_chunk_preserves_completed_chunks_and_resume_skips(monkeypatch, tmp_path):
@@ -258,8 +352,115 @@ def test_full_success_writes_canonical_file_without_partial(monkeypatch, tmp_pat
     overview = analyze_video_overview(video, tmp_path, [{"scene_id": 1, "start": 0.0, "end": 3.0}])
 
     assert overview["input"] == "scene_chunks"
+    assert overview["source_video_fingerprint"]
+    assert mimo_video_overview_cache_fresh(tmp_path / "mimo_video_overview.json", video, [{"scene_id": 1, "start": 0.0, "end": 3.0}])
     assert (tmp_path / "mimo_video_overview.json").exists()
     assert not (tmp_path / "mimo_video_overview.partial.json").exists()
+
+
+
+def test_final_overview_cache_rejects_payload_mutation(monkeypatch, tmp_path):
+    """The final MiMo overview skip path must reject byte/content edits to cached chunks."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video")
+
+    monkeypatch.setitem(CONFIG, "mimo_video_overview", True)
+    monkeypatch.setitem(CONFIG, "mimo_video_api_key", "secret")
+    monkeypatch.setitem(CONFIG, "mimo_video_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+
+    def fake_extract(video_path, chunk, output_path):
+        output_path.write_bytes(b"tiny-chunk")
+        return output_path
+
+    def fake_chunk(chunk_path, chunk):
+        return {
+            "chunk_id": chunk["chunk_id"],
+            "scene_id": chunk["scene_id"],
+            "start": chunk["start"],
+            "end": chunk["end"],
+            "model": "mimo-v2.5",
+            "content": f"分片{chunk['chunk_id']}",
+            "reasoning_content": "",
+            "usage": {},
+            "clip_path": f"mimo_video_chunks/{chunk_path.name}",
+        }
+
+    scenes = [{"scene_id": 1, "start": 0.0, "end": 3.0}]
+    monkeypatch.setattr("vlm._extract_video_chunk", fake_extract)
+    monkeypatch.setattr("vlm._analyze_mimo_video_chunk", fake_chunk)
+    analyze_video_overview(video, tmp_path, scenes)
+
+    overview_path = tmp_path / "mimo_video_overview.json"
+    payload = json.loads(overview_path.read_text(encoding="utf-8"))
+    payload["chunks"][0]["content"] = "tampered but non-empty"
+    overview_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    assert not mimo_video_overview_cache_fresh(overview_path, video, scenes)
+
+    payload["chunks_fingerprint"] = _mimo_cached_chunks_fingerprint(payload["chunks"])
+    overview_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    assert not mimo_video_overview_cache_fresh(overview_path, video, scenes)
+
+    payload["overview_fingerprint"] = _mimo_overview_payload_fingerprint(payload)
+    overview_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    assert mimo_video_overview_cache_fresh(overview_path, video, scenes)
+
+
+def test_final_overview_cache_invalidates_on_settings_source_or_chunks(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video")
+
+    monkeypatch.setitem(CONFIG, "mimo_video_overview", True)
+    monkeypatch.setitem(CONFIG, "mimo_video_api_key", "secret")
+    monkeypatch.setitem(CONFIG, "mimo_video_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+    original_prompt = CONFIG.get("mimo_video_prompt")
+
+    def fake_extract(video_path, chunk, output_path):
+        output_path.write_bytes(b"tiny-chunk")
+        return output_path
+
+    def fake_chunk(chunk_path, chunk):
+        return {
+            "chunk_id": chunk["chunk_id"],
+            "scene_id": chunk["scene_id"],
+            "start": chunk["start"],
+            "end": chunk["end"],
+            "model": "mimo-v2.5",
+            "content": f"分片{chunk['chunk_id']}",
+            "reasoning_content": "",
+            "usage": {},
+            "clip_path": f"mimo_video_chunks/{chunk_path.name}",
+        }
+
+    scenes = [{"scene_id": 1, "start": 0.0, "end": 3.0}]
+    monkeypatch.setattr("vlm._extract_video_chunk", fake_extract)
+    monkeypatch.setattr("vlm._analyze_mimo_video_chunk", fake_chunk)
+    analyze_video_overview(video, tmp_path, scenes)
+
+    overview_path = tmp_path / "mimo_video_overview.json"
+    assert mimo_video_overview_cache_fresh(overview_path, video, scenes)
+
+    monkeypatch.setitem(CONFIG, "mimo_video_prompt", "changed prompt")
+    assert not mimo_video_overview_cache_fresh(overview_path, video, scenes)
+
+    monkeypatch.setitem(CONFIG, "mimo_video_prompt", original_prompt)
+    original_url = CONFIG.get("mimo_video_api_url")
+    monkeypatch.setitem(CONFIG, "mimo_video_api_url", "https://changed.example/v1/chat/completions")
+    assert not mimo_video_overview_cache_fresh(overview_path, video, scenes)
+
+    monkeypatch.setitem(CONFIG, "mimo_video_api_url", original_url)
+    other_video = tmp_path / "other.mp4"
+    other_video.write_bytes(b"other-video")
+    assert not mimo_video_overview_cache_fresh(overview_path, other_video, scenes)
+
+    changed_scenes = [{"scene_id": 1, "start": 0.0, "end": 5.0}]
+    assert not mimo_video_overview_cache_fresh(overview_path, video, changed_scenes)
 
 
 def test_all_rejected_chunks_skip_overview(monkeypatch, tmp_path):
@@ -299,3 +500,70 @@ def test_is_mimo_chunk_usable():
     assert _is_mimo_chunk_usable("") is False
     assert _is_mimo_chunk_usable("The request was rejected because it was considered high risk") is False
     assert _is_mimo_chunk_usable("内容审核未通过") is False
+
+
+
+def test_mixed_unusable_chunks_do_not_write_fresh_overview(monkeypatch, tmp_path):
+    """A single empty/refused MiMo chunk must remain retryable, not become a fresh final overview."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video")
+    monkeypatch.setitem(CONFIG, "mimo_video_overview", True)
+    monkeypatch.setitem(CONFIG, "mimo_video_api_key", "secret")
+    monkeypatch.setitem(CONFIG, "mimo_video_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+
+    def fake_extract(video_path, chunk, output_path):
+        output_path.write_bytes(b"tiny-chunk")
+        return output_path
+
+    def mixed(chunk_path, chunk):
+        return {
+            "chunk_id": chunk["chunk_id"],
+            "scene_id": chunk["scene_id"],
+            "start": chunk["start"],
+            "end": chunk["end"],
+            "model": "mimo-v2.5",
+            "content": "" if chunk["chunk_id"] == 1 else f"分片{chunk['chunk_id']}",
+            "reasoning_content": "",
+            "usage": {},
+            "clip_path": f"mimo_video_chunks/{chunk_path.name}",
+        }
+
+    monkeypatch.setattr("vlm._extract_video_chunk", fake_extract)
+    monkeypatch.setattr("vlm._analyze_mimo_video_chunk", mixed)
+
+    scenes = [{"scene_id": 1, "start": 0.0, "end": 5.0}]
+    with pytest.raises(RuntimeError, match="部分分片无有效内容"):
+        analyze_video_overview(video, tmp_path, scenes)
+
+    assert not (tmp_path / "mimo_video_overview.json").exists()
+    partial = json.loads((tmp_path / "mimo_video_overview.partial.json").read_text(encoding="utf-8"))
+    assert len(partial["chunks"]) == 2
+    assert all(item["content"] for item in partial["chunks"].values())
+
+
+def test_final_overview_cache_rejects_unusable_cached_chunk(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video")
+    monkeypatch.setitem(CONFIG, "mimo_video_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_max_seconds", 2)
+    monkeypatch.setitem(CONFIG, "mimo_video_chunk_min_seconds", 0.5)
+    scenes = [{"scene_id": 1, "start": 0.0, "end": 3.0}]
+    chunks = [
+        {"chunk_id": 0, "scene_id": 1, "start": 0.0, "end": 2.0, "content": "有效"},
+        {"chunk_id": 1, "scene_id": 1, "start": 2.0, "end": 3.0, "content": ""},
+    ]
+    (tmp_path / "mimo_video_overview.json").write_text(json.dumps({
+        "input": "scene_chunks",
+        "content": "有效\n(MiMo 未返回内容)",
+        "chunks": chunks,
+        "chunks_fingerprint": _mimo_cached_chunks_fingerprint(chunks),
+        "overview_fingerprint": "stale",
+        "source_video_fingerprint": __import__("vlm").file_fingerprint(video),
+        "settings": mimo_video_settings_fingerprint(),
+    }), encoding="utf-8")
+
+    assert not mimo_video_overview_cache_fresh(tmp_path / "mimo_video_overview.json", video, scenes)

--- a/tests/voiceover/test_pure_voiceover.py
+++ b/tests/voiceover/test_pure_voiceover.py
@@ -4,7 +4,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-v
 import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
 from lib import CONFIG
-from voiceover import _build_tts_segment_result, _detect_tts_engine, _parse_rate_offset, _run_tts_engine, _tts_mimo, resolve_tts_engine, synthesize_tts
+import voiceover
+from voiceover import _build_tts_segment_result, _detect_tts_engine, _parse_rate_offset, _run_tts_engine, _synthesize_segment, _tts_mimo, resolve_tts_engine, synthesize_tts
 
 
 def test_parse_rate_offset():
@@ -29,12 +30,100 @@ def test_build_tts_segment_result_preserves_source_trace(tmp_path):
     assert result["source_clip_id"] == 2
 
 
-def test_synthesize_tts_handles_empty_narration(monkeypatch, tmp_path):
-    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "tp-test")
-    segments, engine = synthesize_tts([], tmp_path)
+def test_synthesize_segment_reuses_only_matching_cache(monkeypatch, tmp_path):
+    narration = [{"start": 0.0, "end": 2.0, "narration": "第一版。"}]
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+    calls = []
 
-    assert segments == []
+    def fake_run_tts(engine, text, output_wav, rate="+0%", pitch="+0Hz"):
+        calls.append(text)
+        output_wav.write_bytes(f"audio:{text}".encode("utf-8"))
+
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+    monkeypatch.setitem(CONFIG, "mimo_tts_model", "mimo-v2.5-tts")
+    monkeypatch.setitem(CONFIG, "mimo_tts_voice", "冰糖")
+    monkeypatch.setattr("voiceover._run_tts_engine", fake_run_tts)
+    monkeypatch.setattr("voiceover._get_audio_duration", lambda path: 1.0 if Path(path).exists() else 0.0)
+
+    first = _synthesize_segment(0, narration[0], narration, tts_dir, "mimo-tts")
+    second = _synthesize_segment(0, narration[0], narration, tts_dir, "mimo-tts")
+
+    assert calls == ["第一版。"]
+    assert first["narration"] == second["narration"] == "第一版。"
+
+    changed = [{"start": 0.0, "end": 2.0, "narration": "第二版。"}]
+    third = _synthesize_segment(0, changed[0], changed, tts_dir, "mimo-tts")
+
+    assert calls == ["第一版。", "第二版。"]
+    assert third["narration"] == "第二版。"
+    assert (tts_dir / "narr_000.wav").read_text(encoding="utf-8") == "audio:第二版。"
+
+
+def test_synthesize_segment_rejects_cache_when_wav_bytes_change(monkeypatch, tmp_path):
+    narration = [{"start": 0.0, "end": 2.0, "narration": "第一版。"}]
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+    calls = []
+
+    def fake_run_tts(engine, text, output_wav, rate="+0%", pitch="+0Hz"):
+        calls.append(text)
+        output_wav.write_bytes(f"audio:{text}:call{len(calls)}".encode("utf-8"))
+
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+    monkeypatch.setitem(CONFIG, "mimo_tts_model", "mimo-v2.5-tts")
+    monkeypatch.setitem(CONFIG, "mimo_tts_voice", "冰糖")
+    monkeypatch.setattr("voiceover._run_tts_engine", fake_run_tts)
+    monkeypatch.setattr("voiceover._get_audio_duration", lambda path: 1.0 if Path(path).exists() else 0.0)
+
+    _synthesize_segment(0, narration[0], narration, tts_dir, "mimo-tts")
+    (tts_dir / "narr_000.wav").write_bytes(b"externally-mutated-wav")
+    _synthesize_segment(0, narration[0], narration, tts_dir, "mimo-tts")
+
+    assert calls == ["第一版。", "第一版。"]
+    assert (tts_dir / "narr_000.wav").read_text(encoding="utf-8") == "audio:第一版。:call2"
+
+
+def test_synthesize_tts_reuses_complete_cache_without_mimo_key(monkeypatch, tmp_path):
+    narration = [{"start": 0.0, "end": 2.0, "narration": "离线复用。"}]
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "")
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+    monkeypatch.setattr("voiceover._get_audio_duration", lambda path: 1.25 if Path(path).exists() else 0.0)
+
+    wav = tts_dir / "narr_000.wav"
+    wav.write_bytes(b"cached-wav")
+    prepared = voiceover._prepare_tts_segment(0, narration[0], narration, tts_dir, "mimo-tts")
+    text, output_wav, rate, _pitch, cache_key = prepared
+    assert output_wav == wav
+    voiceover._write_tts_segment_cache(wav, cache_key, text, 1.25, _parse_rate_offset(rate))
+
+    def boom(*args, **kwargs):
+        raise AssertionError("cache-only rerun must not call MiMo TTS")
+
+    monkeypatch.setattr("voiceover._tts_mimo", boom)
+
+    segments, engine = synthesize_tts(narration, tmp_path)
+
     assert engine == "mimo-tts"
+    assert segments[0]["audio_path"] == str(wav)
+    assert segments[0]["narration"] == "离线复用。"
+
+
+def test_synthesize_tts_rejects_empty_narration(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "tp-test")
+
+    with pytest.raises(RuntimeError, match="没有可配音的解说段"):
+        synthesize_tts([], tmp_path)
+
+
+def test_synthesize_tts_rejects_cleaned_empty_narration(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "tp-test")
+
+    with pytest.raises(RuntimeError, match="没有可配音的有效文本"):
+        synthesize_tts([{"start": 0.0, "end": 1.0, "narration": "[stage direction]"}], tmp_path)
 
 
 def test_synthesize_tts_raises_on_failed_segment_by_default(monkeypatch, tmp_path):
@@ -91,6 +180,43 @@ def test_synthesize_tts_allows_partial_when_configured(monkeypatch, tmp_path):
 
     assert engine == "mimo-tts"
     assert [s["index"] for s in segments] == [0]
+
+
+def test_synthesize_tts_rejects_all_failed_segments_even_when_partial_allowed(monkeypatch, tmp_path):
+    narration = [{"start": 0.0, "end": 1.0, "narration": "唯一段。"}]
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("network timeout")
+
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "tp-test")
+    monkeypatch.setitem(CONFIG, "allow_partial_tts", True)
+    monkeypatch.setattr("voiceover._synthesize_segment", fail)
+
+    with pytest.raises(RuntimeError, match="没有生成任何有效解说音频"):
+        synthesize_tts(narration, tmp_path)
+
+
+def test_cleanup_partial_outputs_only_replaces_audio_suffix(tmp_path):
+    work = tmp_path / "job.wav"
+    tts_dir = work / "tts_segments"
+    tts_dir.mkdir(parents=True)
+    output_wav = tts_dir / "narr_000.wav"
+    output_wav.write_bytes(b"partial-wav")
+    expected_mp3 = tts_dir / "narr_000.mp3"
+    expected_mp3.write_bytes(b"partial-mp3")
+    cache = Path(str(output_wav) + ".cache.json")
+    cache.write_text("{}", encoding="utf-8")
+
+    unrelated = tmp_path / "job.mp3" / "tts_segments" / "narr_000.mp3"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_bytes(b"do-not-delete")
+
+    voiceover._cleanup_partial_tts_outputs(output_wav)
+
+    assert not output_wav.exists()
+    assert not expected_mp3.exists()
+    assert not cache.exists()
+    assert unrelated.read_bytes() == b"do-not-delete"
 
 
 def test_detect_tts_engine_requires_mimo_key(monkeypatch):
@@ -168,3 +294,71 @@ def test_mimo_tts_writes_decoded_audio(monkeypatch, tmp_path):
     assert payload["audio"] == {"format": "wav", "voice": "冰糖"}
     assert payload["messages"][1] == {"role": "assistant", "content": "这是小米 MiMo 配音。"}
     assert "语速略慢" in payload["messages"][0]["content"]
+
+
+
+def test_voiceover_cli_prefers_mapped_narration_when_present(monkeypatch, tmp_path):
+    """Cut mode remaps narration to the output timeline; a direct run must voice the
+    mapped file (the documented default) rather than the source-timeline narration."""
+    import json
+
+    (tmp_path / "narration.json").write_text(
+        json.dumps([{"start": 0.0, "end": 1.0, "narration": "full source。"}]),
+        encoding="utf-8",
+    )
+    (tmp_path / "narration_mapped.json").write_text(
+        json.dumps([{"start": 0.0, "end": 1.0, "narration": "cut mapped。"}]),
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_synthesize(narration, work_dir):
+        seen["narration"] = narration
+        return ([{
+            "index": 0,
+            "start": narration[0]["start"],
+            "end": narration[0]["end"],
+            "narration": narration[0]["narration"],
+            "audio_path": str(Path(work_dir) / "tts_segments" / "narr_000.wav"),
+            "audio_duration": 0.5,
+        }], "mimo-tts")
+
+    monkeypatch.setattr("voiceover.synthesize_tts", fake_synthesize)
+    monkeypatch.setattr(sys, "argv", ["voiceover.py", "--work-dir", str(tmp_path)])
+
+    voiceover.main()
+
+    meta = json.loads((tmp_path / "tts_meta.json").read_text(encoding="utf-8"))
+    assert seen["narration"][0]["narration"] == "cut mapped。"
+    assert meta["narration"] == "narration_mapped.json"
+
+
+def test_voiceover_cli_accepts_allow_partial_tts(monkeypatch, tmp_path):
+    narration = [
+        {"start": 0.0, "end": 1.0, "narration": "第一段。"},
+        {"start": 1.0, "end": 2.0, "narration": "第二段。"},
+    ]
+    (tmp_path / "narration.json").write_text(__import__("json").dumps(narration), encoding="utf-8")
+
+    def fake_synthesize_segment(i, seg, narration_data, tts_dir, engine):
+        if i == 1:
+            raise RuntimeError("network timeout")
+        return {
+            "index": i,
+            "start": seg["start"],
+            "end": seg["end"],
+            "narration": seg["narration"],
+            "audio_path": str(tts_dir / f"narr_{i:03d}.wav"),
+            "audio_duration": 0.5,
+        }
+
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "tp-test")
+    monkeypatch.setitem(CONFIG, "allow_partial_tts", False)
+    monkeypatch.setattr("voiceover._synthesize_segment", fake_synthesize_segment)
+    monkeypatch.setattr(sys, "argv", ["voiceover.py", "--work-dir", str(tmp_path), "--allow-partial-tts"])
+
+    voiceover.main()
+
+    meta = __import__("json").loads((tmp_path / "tts_meta.json").read_text(encoding="utf-8"))
+    assert len(meta["segments"]) == 1
+    assert CONFIG["allow_partial_tts"] is True


### PR DESCRIPTION
## What this is

Starting from `618a116` (current `main`), an automated pass (gpt-5.5) produced **12 commits** all themed on "artifact reuse / provenance / staleness / resume hardening" (net **+1902 / −295** in production code, plus ~2.3k lines of tests). This branch reviews that work commit-by-commit, **keeps the genuine bug fixes, and drops the over-built or regressive parts** — then self-tests the result.

Branched off `main`, not stacked on the 12 commits, so the diff here is the curated end state.

## Kept — genuine fixes

The high-value theme is **"refuse to cache or ship a failure as success."** These are real footguns the orchestrator's resume gate cannot catch (an empty-but-present artifact looks valid forever):

- **ASR** API failure now raises instead of writing an empty `asr_result.json` — previously a transient failure cached `[]` and every later run shipped a transcript-free recap.
- **VLM** per-scene failure aborts instead of caching a `"(VLM 分析失败)"` placeholder into `vlm_analysis.json`; MiMo overview filters content-moderation-rejected chunks.
- **voiceover / assemble** abort on empty / all-skipped narration instead of emitting a narration-free "recap"; the empty `narration.wav` is unlinked before aborting.

Plus smaller correctness/crash fixes: `anullsrc` fallback for silent-source video, Path-safe `_cut` suffixing, zero-fade duck guard, `SOURCE_VIDEO` env-leak gating, validated clip-plan range reads, full-sha256 `file_fingerprint` (identical across every skill's `lib.py`), byte-proven reuse for `edited_source.mp4` / per-segment TTS / `audio.wav` / understanding sidecars, and atomic 剪映 draft writes.

## Dropped / reverted — unnecessary or harmful

- **assemble render-identity collision machinery** (the single biggest add, ~215 lines). It wrote `recap_<stem>_<hash>.mp4` and **froze the stale `recap_<stem>.mp4`** whenever the narration changed — so the primary *iterate-on-narration* loop spawned a new file each run while the canonical name showed an old render. Restored to the stable alias overwritten in place. `assembly_manifest.json` is now a slim record (final path + cut-mode source fingerprint); also removes per-run full-file hashing of the MP4/inputs and the `.manifest.json` sidecar.
- **recap.py `phase_a_environment`**: a 32-key CONFIG snapshot built up over three commits, then reduced to an `isinstance()` presence check — written but never compared. Dead.
- **recap.py 10-artifact fingerprint layer**: re-hashed every Phase-A artifact to catch a hand-edited intermediate, which is outside the "rerun the same command" resume contract and redundant with the source+settings gate (Phase B never re-runs understanding, so endpoint/model env drift cannot change artifacts already on disk).
- **voiceover default narration**: restore the documented `narration_mapped.json` fallback so a direct cut-mode run voices the output-timeline narration.

Net effect: same masked-failure protection, **−182 lines** of provenance machinery vs. the raw pass, and the iterate loop refreshes one file again.

## Testing

- **Unit suite green:** `python3 scripts/test.py` → 232 passed across all 6 skill groups (understanding 87 · cut 12 · voiceover 24 · assemble 61 · script 29 · orchestrator 19). `ruff check .` clean. `brief.py` ⇄ `narration.py` byte-parity preserved.
- **Live MiMo smoke** (real TTS + real ffmpeg, on `demo/demo.mp4`): voiceover synthesized 2 MiMo-TTS segments; assemble rendered a recap with ducking + loudnorm (−14 LUFS) + source-subtitle masking. Running assemble **twice** produced exactly **one** `recap_demo.mp4` (in-place overwrite confirmed, no `_<hash>` copy, no sidecar), with a slim `assembly_manifest.json` (`source_video: null` in full mode — env-leak gating intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
