### PR TITLE
Warmer narration + cut-mode picture sync (fix two recap-quality complaints)

### DIFF
--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -305,6 +305,58 @@ def map_narration_to_clips(narration, validated_plan, min_duration=0.3):
     return mapped
 
 
+def lint_mapped_narration(mapped, original_count, output_duration, *, min_spm=6.0, max_gap_seconds=12.0, drop_ratio_limit=0.3):
+    """Advisory re-lint of narration AFTER it is mapped onto the cut OUTPUT timeline.
+
+    The mapper silently drops beats whose midpoint is outside every kept clip and clamps
+    boundary-crossers, so a narration authored against the full source can pass the
+    source-time validate yet leave the cut sparse or describing footage the viewer never
+    sees. This surfaces that on the real output timeline (loud log + narration_mapped_lint.json);
+    it never blocks the render — a sparse recap can be intentional.
+    """
+    mapped = sorted(mapped or [], key=lambda s: float(s.get("start", 0.0)))
+    mapped_count = len(mapped)
+    original_count = int(original_count or 0)
+    dropped = max(0, original_count - mapped_count)
+    drop_ratio = dropped / original_count if original_count else 0.0
+    out_dur = float(output_duration or 0.0)
+    spm = mapped_count / (out_dur / 60) if out_dur > 0 else 0.0
+    gaps = [float(b["start"]) - float(a["end"]) for a, b in zip(mapped, mapped[1:])]
+    max_gap = max(gaps) if gaps else 0.0
+    covered = sum(max(0.0, float(b["end"]) - float(b["start"])) for b in mapped)
+    coverage = covered / out_dur if out_dur > 0 else 0.0
+
+    warnings = []
+    if drop_ratio >= drop_ratio_limit:
+        warnings.append({
+            "code": "many_beats_dropped",
+            "message": "大量解说段落落在保留片段之外被丢弃——请按保留的片段写解说，而不是整段原片。",
+            "dropped": dropped, "original": original_count, "drop_ratio": round(drop_ratio, 2),
+        })
+    if mapped_count >= 2 and spm and spm < min_spm:
+        warnings.append({
+            "code": "low_density_output",
+            "message": "映射后的解说在成片里偏稀疏——在保留片段内补充解说 beat。",
+            "segments_per_minute": round(spm, 2), "min_segments_per_minute": min_spm,
+        })
+    if max_gap > max_gap_seconds:
+        warnings.append({
+            "code": "long_gap_output",
+            "message": "成片里有一长段没有解说。",
+            "max_gap_seconds": round(max_gap, 2), "max_gap_limit_seconds": max_gap_seconds,
+        })
+    return {
+        "mapped_count": mapped_count,
+        "dropped": dropped,
+        "drop_ratio": round(drop_ratio, 2),
+        "output_duration": round(out_dur, 2),
+        "segments_per_minute": round(spm, 2),
+        "max_gap_seconds": round(max_gap, 2),
+        "coverage": round(coverage, 2),
+        "warnings": warnings,
+    }
+
+
 def _has_audio_stream(video_path):
     cmd = [
         "ffprobe", "-v", "error", "-select_streams", "a:0",
@@ -420,6 +472,11 @@ def main():
         (work_dir / "narration_mapped.json").write_text(
             json.dumps(mapped, ensure_ascii=False, indent=2), encoding="utf-8")
         log(f"映射解说 {len(mapped)} 段 → narration_mapped.json")
+        report = lint_mapped_narration(mapped, len(narration), validated_plan["total_duration"])
+        (work_dir / "narration_mapped_lint.json").write_text(
+            json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        for w in report["warnings"]:
+            log(f"  ⚠️ 剪后解说同步: {w['message']} [{w['code']}]")
     log(f"剪辑模式: {len(validated_plan['clips'])} 个片段 → {validated_plan['total_duration']:.1f}s")
 
 

--- a/skills/video-script/SKILL.md
+++ b/skills/video-script/SKILL.md
@@ -102,6 +102,14 @@ the shortened timeline. Validate with `--mode cut`.
 {"target_duration": "10m", "clips": [{"start": 12.0, "end": 38.0, "reason": "冲突开端"}]}
 ```
 
+**剪辑模式写作要点（解说要对上剪后的画面，不是原片）：**
+- **按成片时长写**：解说的 beat 数量对齐**目标成片**（brief 头部已按目标时长算好），不是原片时长。中点落在任何保留片段之外的 beat 会被丢弃——别在被剪掉的段落上写解说。
+- **每段落在单个片段内**：一个 beat 的 `[start, end]` 不要跨片段边界，否则会被裁到片段长度，配音就会念到剪掉的画面（`--mode cut` 会以 `crosses_clip_boundary` 警告）。
+- **按成片顺序讲**：beat 按它们所属片段在成片里出现的先后排序，让解说在剪后画面上连成一条线。
+- **重复源区间**：clips 复用了重叠的源区间时，给 beat 标 `source_clip_id`，确保映射到正确片段。
+
+> 片名/题材明确但缺乏剧情上下文时，先按 [背景调研指南](../video-understanding/references/research-guide.md) 写 `background_research.json` 再写解说——否则解说只能"看图说话"。brief 在 substrate 偏薄时会把密度目标降为上限而非配额：宁可少写、写实，也不要为凑数堆画面描述。
+
 ## What this skill does NOT do
 - Does NOT run ASR/VLM or analyze the video — it consumes the understanding index.
 - Does NOT synthesize audio or render video.

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -492,6 +492,17 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                         "Repeated/overlapping clips require source_clip_id",
                         start=start, end=end,
                     ))
+                if len(matches) == 1:
+                    clip = matches[0]
+                    clip_start = float(clip.get("source_start", clip.get("start", start)))
+                    clip_end = float(clip.get("source_end", clip.get("end", end)))
+                    if start < clip_start or end > clip_end:
+                        warnings.append(_lint_issue(
+                            "warning", idx, "crosses_clip_boundary",
+                            "Narration extends beyond its clip; it will be trimmed to the clip and may describe footage that was cut",
+                            start=start, end=end,
+                            clip_start=round(clip_start, 3), clip_end=round(clip_end, 3),
+                        ))
                 if seg.get("source_clip_id") is not None:
                     try:
                         int(seg.get("source_clip_id"))
@@ -862,12 +873,15 @@ def _format_background_research(research):
     return lines
 
 
-def assess_understanding_substrate(scenes_analysis, asr_result):
+def assess_understanding_substrate(scenes_analysis, asr_result, *, has_story_context=False):
     """Measure how much real signal the writing agent has to work with.
 
-    Recap quality collapses to generic 看图说话 when ASR is empty and the VLM
-    emitted no frame_facts (proven by the demo-vs-qyn artifact comparison), yet
-    the pipeline otherwise produces a brief and runs to completion silently.
+    Recap quality collapses to generic 看图说话 when the agent has no story spine and
+    only literal frame descriptions to paraphrase. A spine is substantial dialogue
+    (ASR) OR researched/given story context — frame-fact VOLUME alone (a visually busy
+    but storyless clip, e.g. an anime whose dialogue ASR could not read) is NOT a spine,
+    so it must not grade as "rich"; otherwise the sparse-substrate warning, the research
+    directive, and the density relief never fire for exactly that cold-narration case.
     """
     scenes = scenes_analysis or []
     asr_chars = sum(len(str(seg.get("text", "")).strip()) for seg in (asr_result or []))
@@ -877,9 +891,10 @@ def assess_understanding_substrate(scenes_analysis, asr_result):
 
     has_asr = asr_chars >= 20
     has_facts = scenes_with_facts > 0
+    has_story_spine = asr_chars >= 200 or bool(has_story_context)
     if not has_asr and not has_facts and avg_desc < 25:
         level = "empty"
-    elif (has_asr or has_facts) and (scenes_with_facts >= max(1, len(scenes) // 2) or asr_chars >= 200):
+    elif (has_asr or has_facts) and has_story_spine:
         level = "rich"
     else:
         level = "thin"
@@ -889,6 +904,7 @@ def assess_understanding_substrate(scenes_analysis, asr_result):
         "scene_count": len(scenes),
         "scenes_with_frame_facts": scenes_with_facts,
         "avg_description_len": avg_desc,
+        "has_story_context": bool(has_story_context),
     }
 
 
@@ -1250,6 +1266,80 @@ def _load_mimo_overview_for_brief(work_dir, scenes_analysis, enabled=None, video
         return {}
     return overview if _mimo_overview_matches_current_inputs(overview, scenes_analysis, video_path=video_path) else {}
 
+def _parse_target_seconds(value):
+    """Parse a cut-mode target duration ("30m" / "600" / "1h5m" / "00:30:00") to seconds.
+
+    Mirrors video-cut's parser closely enough to size the brief; returns None on anything
+    unparseable so the brief simply falls back to the source duration.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if value > 0 else None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    try:
+        if ":" in text:
+            parts = [float(p) for p in text.split(":")]
+            if any(p < 0 for p in parts):
+                return None
+            if len(parts) == 2:
+                seconds = parts[0] * 60 + parts[1]
+            elif len(parts) == 3:
+                seconds = parts[0] * 3600 + parts[1] * 60 + parts[2]
+            else:
+                return None
+            return seconds if seconds > 0 else None
+        factors = {"ms": 0.001, "s": 1, "m": 60, "h": 3600}
+        seconds = 0.0
+        matched = False
+        pos = 0
+        for m in re.finditer(r"([0-9]+(?:\.[0-9]+)?)(ms|s|m|h)?", text):
+            if m.start() != pos:
+                break
+            pos = m.end()
+            matched = True
+            seconds += float(m.group(1)) * factors[m.group(2) or "s"]
+        if not matched or pos != len(text):
+            return None
+        return seconds if seconds > 0 else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _format_research_directive(work_dir, substrate):
+    """A loud, actionable research-first directive when the agent has a title/context but
+    no background_research.json, or when the substrate is too thin to write real commentary.
+
+    The narration's quality ceiling is how much story context the agent has: with only
+    frame descriptions it can only narrate pixels. This pushes the agent to research the
+    title first (see references/research-guide.md) instead of silently writing 看图说话.
+    """
+    if (Path(work_dir) / "background_research.json").exists():
+        return []  # already researched; _format_background_research surfaces it
+    context = str(CONFIG.get("context_info") or "").strip()
+    thin = substrate.get("level") in ("thin", "empty") if substrate else False
+    if not context and not thin:
+        return []
+    why = "the substrate is thin" if thin else "you have a title/context but no background_research.json"
+    return [
+        "## ⚑ Research the story FIRST (do this before writing narration)",
+        "",
+        f"Reason: {why}. Engaging recap commentary (motive, stakes, relationships) needs story",
+        "context the frames alone do not carry — without it the narration can only describe pixels.",
+        "1. Pull the title/keywords from `--context`, the filename, or the user's description"
+        + (f" (context: {context})." if context else "."),
+        "2. Use any available web-search/browser tool to look up synopsis, characters, and",
+        "   relationships (see `references/research-guide.md`).",
+        "3. Write `work_dir/background_research.json`, then re-read this brief and write narration",
+        "   that names people and reads the picture through the plot.",
+        "4. If no tool/network or nothing found: skip — keep beats sparse and strictly grounded in",
+        "   the visible ASR/frame evidence rather than inventing drama.",
+        "",
+    ]
+
+
 def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
     """Write a compact brief that tells the agent exactly how to author recap artifacts."""
     effective_rate = CONFIG["speech_rate"] * CONFIG["speech_safety_margin"]
@@ -1260,7 +1350,23 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     max_gap = CONFIG.get("max_narration_gap_seconds", 11.0)
     edit_mode = CONFIG.get("edit_mode", "full")
     target_duration = CONFIG.get("target_duration") or "(not set)"
-    target_count = max(1, round(video_duration / 60 * target_spm))
+    # Cut mode sizes narration to the OUTPUT (the kept clips), not the full source:
+    # a 2h source otherwise asks for ~1150 beats that the cut drops, leaving narration
+    # describing footage the viewer never sees.
+    output_seconds = video_duration
+    if edit_mode == "cut":
+        target_seconds = _parse_target_seconds(CONFIG.get("target_duration"))
+        if target_seconds:
+            output_seconds = min(video_duration, target_seconds)
+    target_count = max(1, round(output_seconds / 60 * target_spm))
+
+    has_story_context = (Path(work_dir) / "background_research.json").exists()
+    substrate = assess_understanding_substrate(scenes_analysis, asr_result, has_story_context=has_story_context)
+    thin_substrate = substrate.get("level") in ("thin", "empty")
+    beat_count_phrase = f"at most ~{target_count}" if thin_substrate else f"roughly {target_count}"
+    output_label = f"{output_seconds / 60:.0f}min" if output_seconds >= 60 else f"{output_seconds:.0f}s"
+    source_label = f"{video_duration / 60:.0f}min" if video_duration >= 60 else f"{video_duration:.0f}s"
+
     lines = [
         "# Agent Narration Brief",
         "",
@@ -1272,15 +1378,34 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         f"- Source video duration: {video_duration:.1f}s",
         f"- Target duration (cut mode): {target_duration}",
         f"- Effective speech budget: {effective_rate:.2f} Chinese chars/sec after {breath_sec:.2f}s pause allowance",
-        f"- Narration density target: ~{target_spm:.1f} segments/min (minimum {min_spm:.1f}); no gap longer than {max_gap:.0f}s",
-        f"- Aim for roughly {target_count} short beats across the timeline, kept continuous over a ducked original-audio bed",
+    ]
+    if thin_substrate:
+        lines.append(
+            f"- Narration density: substrate is {substrate['level']} — do NOT chase a beat count. "
+            f"Write fewer, grounded beats; skipping a stretch beats narrating pixels "
+            f"(~{target_spm:.1f}/min is a ceiling here, not a quota)."
+        )
+    else:
+        lines.append(
+            f"- Narration density target: ~{target_spm:.1f} segments/min (minimum {min_spm:.1f}); no gap longer than {max_gap:.0f}s"
+        )
+    if edit_mode == "cut":
+        lines.append(
+            f"- Aim for {beat_count_phrase} short beats across the ~{output_label} CUT OUTPUT "
+            f"(sized to the kept clips, NOT the {source_label} source), over a ducked bed"
+        )
+    else:
+        lines.append(
+            f"- Aim for {beat_count_phrase} short beats across the timeline, kept continuous over a ducked original-audio bed"
+        )
+    lines.extend([
         f"- Default pause between beats: {target_pause_ms}ms",
         f"- Context: {CONFIG.get('context_info') or '(none)'}",
         "",
-    ]
+    ])
 
-    substrate = assess_understanding_substrate(scenes_analysis, asr_result)
     lines.extend(_format_substrate_warning(substrate))
+    lines.extend(_format_research_directive(work_dir, substrate))
     lines.extend(_format_background_research(_load_background_research(work_dir)))
     lines.extend(_format_consolidation(_load_consolidation(work_dir, scenes_analysis)))
 
@@ -1305,24 +1430,37 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         ])
 
     if edit_mode == "cut":
+        cut_target_example = target_duration if target_duration != "(not set)" else "30m"
         lines.extend([
             "## Required files for cut mode",
             "",
-            "First write `clip_plan.json` to choose source footage, then write `narration.json` using ORIGINAL source timestamps inside those clips.",
-            "The CLI maps source timestamps to the edited timeline after concatenating clips.",
+            f"Goal: a ~{output_label} recap cut from a {source_label} source. "
+            "The narration must match the CUT output, not the full source.",
+            "First write `clip_plan.json` to choose source footage, then write `narration.json` using ORIGINAL "
+            "source timestamps that fall INSIDE those clips. The CLI concatenates the clips and maps your source "
+            "timestamps onto the shortened timeline.",
+            "",
+            "Cut-mode authoring rules:",
+            "- Size narration to the OUTPUT: aim for the cut-output beat count above, NOT one beat per source minute. "
+            "A beat whose midpoint lands outside every kept clip is DROPPED.",
+            "- Keep each beat INSIDE one clip: do not let a beat's [start, end] cross a clip boundary, or it is clipped "
+            "to that clip and the voiceover ends up describing footage that was cut away.",
+            "- Tell the story in OUTPUT order: order beats by the order their clips will play so the recap reads as one "
+            "continuous arc over the kept footage.",
+            "- If clips reuse overlapping source ranges, tag the beat with `source_clip_id` so it maps to the intended clip.",
             "",
             "### clip_plan.json shape",
             "",
             "```json",
             "{",
-            "  \"target_duration\": \"10m\",",
+            f"  \"target_duration\": \"{cut_target_example}\",",
             "  \"clips\": [",
             "    {\"start\": 12.0, \"end\": 38.0, \"reason\": \"关键冲突开端\"}",
             "  ]",
             "}",
             "```",
             "",
-            "### narration.json shape (source timestamps)",
+            "### narration.json shape (source timestamps inside the kept clips)",
             "",
             "```json",
             "[",
@@ -1345,8 +1483,8 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "",
         "## Writing rules (dense continuous-bed recap style)",
         "",
-        "1. Narrate continuously across the whole timeline as short punchy beats, keeping the original audio alive underneath as a ducked bed.",
-        f"2. Hit the density target: ~{target_spm:.1f} beats/min (at least {min_spm:.1f}); never leave a gap longer than {max_gap:.0f}s without narration.",
+        "1. Narrate continuously across the recap as short punchy beats over a ducked original-audio bed; in cut mode that means across the kept clips, in output order — not the full source timeline.",
+        "2. Follow the density line near the top of this brief: it already accounts for thin substrate and cut output. Keep a beat at least every few seconds inside a narrated stretch, but never pad with filler just to hit a number.",
         "3. Default `overlaps_speech` to true. The CLI auto-marks a beat as non-overlapping only when it actually lands inside a real silent window.",
         "4. Keep each beat short: roughly one short sentence (1-2 subtitle lines). Shorter is safer for TTS and reads better.",
         "5. Do not describe what the viewer can already see; explain intent, stakes, subtext, relationships, and story logic.",

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -492,6 +492,17 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                         "Repeated/overlapping clips require source_clip_id",
                         start=start, end=end,
                     ))
+                if len(matches) == 1:
+                    clip = matches[0]
+                    clip_start = float(clip.get("source_start", clip.get("start", start)))
+                    clip_end = float(clip.get("source_end", clip.get("end", end)))
+                    if start < clip_start or end > clip_end:
+                        warnings.append(_lint_issue(
+                            "warning", idx, "crosses_clip_boundary",
+                            "Narration extends beyond its clip; it will be trimmed to the clip and may describe footage that was cut",
+                            start=start, end=end,
+                            clip_start=round(clip_start, 3), clip_end=round(clip_end, 3),
+                        ))
                 if seg.get("source_clip_id") is not None:
                     try:
                         int(seg.get("source_clip_id"))
@@ -862,12 +873,15 @@ def _format_background_research(research):
     return lines
 
 
-def assess_understanding_substrate(scenes_analysis, asr_result):
+def assess_understanding_substrate(scenes_analysis, asr_result, *, has_story_context=False):
     """Measure how much real signal the writing agent has to work with.
 
-    Recap quality collapses to generic 看图说话 when ASR is empty and the VLM
-    emitted no frame_facts (proven by the demo-vs-qyn artifact comparison), yet
-    the pipeline otherwise produces a brief and runs to completion silently.
+    Recap quality collapses to generic 看图说话 when the agent has no story spine and
+    only literal frame descriptions to paraphrase. A spine is substantial dialogue
+    (ASR) OR researched/given story context — frame-fact VOLUME alone (a visually busy
+    but storyless clip, e.g. an anime whose dialogue ASR could not read) is NOT a spine,
+    so it must not grade as "rich"; otherwise the sparse-substrate warning, the research
+    directive, and the density relief never fire for exactly that cold-narration case.
     """
     scenes = scenes_analysis or []
     asr_chars = sum(len(str(seg.get("text", "")).strip()) for seg in (asr_result or []))
@@ -877,9 +891,10 @@ def assess_understanding_substrate(scenes_analysis, asr_result):
 
     has_asr = asr_chars >= 20
     has_facts = scenes_with_facts > 0
+    has_story_spine = asr_chars >= 200 or bool(has_story_context)
     if not has_asr and not has_facts and avg_desc < 25:
         level = "empty"
-    elif (has_asr or has_facts) and (scenes_with_facts >= max(1, len(scenes) // 2) or asr_chars >= 200):
+    elif (has_asr or has_facts) and has_story_spine:
         level = "rich"
     else:
         level = "thin"
@@ -889,6 +904,7 @@ def assess_understanding_substrate(scenes_analysis, asr_result):
         "scene_count": len(scenes),
         "scenes_with_frame_facts": scenes_with_facts,
         "avg_description_len": avg_desc,
+        "has_story_context": bool(has_story_context),
     }
 
 
@@ -1250,6 +1266,80 @@ def _load_mimo_overview_for_brief(work_dir, scenes_analysis, enabled=None, video
         return {}
     return overview if _mimo_overview_matches_current_inputs(overview, scenes_analysis, video_path=video_path) else {}
 
+def _parse_target_seconds(value):
+    """Parse a cut-mode target duration ("30m" / "600" / "1h5m" / "00:30:00") to seconds.
+
+    Mirrors video-cut's parser closely enough to size the brief; returns None on anything
+    unparseable so the brief simply falls back to the source duration.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if value > 0 else None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    try:
+        if ":" in text:
+            parts = [float(p) for p in text.split(":")]
+            if any(p < 0 for p in parts):
+                return None
+            if len(parts) == 2:
+                seconds = parts[0] * 60 + parts[1]
+            elif len(parts) == 3:
+                seconds = parts[0] * 3600 + parts[1] * 60 + parts[2]
+            else:
+                return None
+            return seconds if seconds > 0 else None
+        factors = {"ms": 0.001, "s": 1, "m": 60, "h": 3600}
+        seconds = 0.0
+        matched = False
+        pos = 0
+        for m in re.finditer(r"([0-9]+(?:\.[0-9]+)?)(ms|s|m|h)?", text):
+            if m.start() != pos:
+                break
+            pos = m.end()
+            matched = True
+            seconds += float(m.group(1)) * factors[m.group(2) or "s"]
+        if not matched or pos != len(text):
+            return None
+        return seconds if seconds > 0 else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _format_research_directive(work_dir, substrate):
+    """A loud, actionable research-first directive when the agent has a title/context but
+    no background_research.json, or when the substrate is too thin to write real commentary.
+
+    The narration's quality ceiling is how much story context the agent has: with only
+    frame descriptions it can only narrate pixels. This pushes the agent to research the
+    title first (see references/research-guide.md) instead of silently writing 看图说话.
+    """
+    if (Path(work_dir) / "background_research.json").exists():
+        return []  # already researched; _format_background_research surfaces it
+    context = str(CONFIG.get("context_info") or "").strip()
+    thin = substrate.get("level") in ("thin", "empty") if substrate else False
+    if not context and not thin:
+        return []
+    why = "the substrate is thin" if thin else "you have a title/context but no background_research.json"
+    return [
+        "## ⚑ Research the story FIRST (do this before writing narration)",
+        "",
+        f"Reason: {why}. Engaging recap commentary (motive, stakes, relationships) needs story",
+        "context the frames alone do not carry — without it the narration can only describe pixels.",
+        "1. Pull the title/keywords from `--context`, the filename, or the user's description"
+        + (f" (context: {context})." if context else "."),
+        "2. Use any available web-search/browser tool to look up synopsis, characters, and",
+        "   relationships (see `references/research-guide.md`).",
+        "3. Write `work_dir/background_research.json`, then re-read this brief and write narration",
+        "   that names people and reads the picture through the plot.",
+        "4. If no tool/network or nothing found: skip — keep beats sparse and strictly grounded in",
+        "   the visible ASR/frame evidence rather than inventing drama.",
+        "",
+    ]
+
+
 def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
     """Write a compact brief that tells the agent exactly how to author recap artifacts."""
     effective_rate = CONFIG["speech_rate"] * CONFIG["speech_safety_margin"]
@@ -1260,7 +1350,23 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     max_gap = CONFIG.get("max_narration_gap_seconds", 11.0)
     edit_mode = CONFIG.get("edit_mode", "full")
     target_duration = CONFIG.get("target_duration") or "(not set)"
-    target_count = max(1, round(video_duration / 60 * target_spm))
+    # Cut mode sizes narration to the OUTPUT (the kept clips), not the full source:
+    # a 2h source otherwise asks for ~1150 beats that the cut drops, leaving narration
+    # describing footage the viewer never sees.
+    output_seconds = video_duration
+    if edit_mode == "cut":
+        target_seconds = _parse_target_seconds(CONFIG.get("target_duration"))
+        if target_seconds:
+            output_seconds = min(video_duration, target_seconds)
+    target_count = max(1, round(output_seconds / 60 * target_spm))
+
+    has_story_context = (Path(work_dir) / "background_research.json").exists()
+    substrate = assess_understanding_substrate(scenes_analysis, asr_result, has_story_context=has_story_context)
+    thin_substrate = substrate.get("level") in ("thin", "empty")
+    beat_count_phrase = f"at most ~{target_count}" if thin_substrate else f"roughly {target_count}"
+    output_label = f"{output_seconds / 60:.0f}min" if output_seconds >= 60 else f"{output_seconds:.0f}s"
+    source_label = f"{video_duration / 60:.0f}min" if video_duration >= 60 else f"{video_duration:.0f}s"
+
     lines = [
         "# Agent Narration Brief",
         "",
@@ -1272,15 +1378,34 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         f"- Source video duration: {video_duration:.1f}s",
         f"- Target duration (cut mode): {target_duration}",
         f"- Effective speech budget: {effective_rate:.2f} Chinese chars/sec after {breath_sec:.2f}s pause allowance",
-        f"- Narration density target: ~{target_spm:.1f} segments/min (minimum {min_spm:.1f}); no gap longer than {max_gap:.0f}s",
-        f"- Aim for roughly {target_count} short beats across the timeline, kept continuous over a ducked original-audio bed",
+    ]
+    if thin_substrate:
+        lines.append(
+            f"- Narration density: substrate is {substrate['level']} — do NOT chase a beat count. "
+            f"Write fewer, grounded beats; skipping a stretch beats narrating pixels "
+            f"(~{target_spm:.1f}/min is a ceiling here, not a quota)."
+        )
+    else:
+        lines.append(
+            f"- Narration density target: ~{target_spm:.1f} segments/min (minimum {min_spm:.1f}); no gap longer than {max_gap:.0f}s"
+        )
+    if edit_mode == "cut":
+        lines.append(
+            f"- Aim for {beat_count_phrase} short beats across the ~{output_label} CUT OUTPUT "
+            f"(sized to the kept clips, NOT the {source_label} source), over a ducked bed"
+        )
+    else:
+        lines.append(
+            f"- Aim for {beat_count_phrase} short beats across the timeline, kept continuous over a ducked original-audio bed"
+        )
+    lines.extend([
         f"- Default pause between beats: {target_pause_ms}ms",
         f"- Context: {CONFIG.get('context_info') or '(none)'}",
         "",
-    ]
+    ])
 
-    substrate = assess_understanding_substrate(scenes_analysis, asr_result)
     lines.extend(_format_substrate_warning(substrate))
+    lines.extend(_format_research_directive(work_dir, substrate))
     lines.extend(_format_background_research(_load_background_research(work_dir)))
     lines.extend(_format_consolidation(_load_consolidation(work_dir, scenes_analysis)))
 
@@ -1305,24 +1430,37 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         ])
 
     if edit_mode == "cut":
+        cut_target_example = target_duration if target_duration != "(not set)" else "30m"
         lines.extend([
             "## Required files for cut mode",
             "",
-            "First write `clip_plan.json` to choose source footage, then write `narration.json` using ORIGINAL source timestamps inside those clips.",
-            "The CLI maps source timestamps to the edited timeline after concatenating clips.",
+            f"Goal: a ~{output_label} recap cut from a {source_label} source. "
+            "The narration must match the CUT output, not the full source.",
+            "First write `clip_plan.json` to choose source footage, then write `narration.json` using ORIGINAL "
+            "source timestamps that fall INSIDE those clips. The CLI concatenates the clips and maps your source "
+            "timestamps onto the shortened timeline.",
+            "",
+            "Cut-mode authoring rules:",
+            "- Size narration to the OUTPUT: aim for the cut-output beat count above, NOT one beat per source minute. "
+            "A beat whose midpoint lands outside every kept clip is DROPPED.",
+            "- Keep each beat INSIDE one clip: do not let a beat's [start, end] cross a clip boundary, or it is clipped "
+            "to that clip and the voiceover ends up describing footage that was cut away.",
+            "- Tell the story in OUTPUT order: order beats by the order their clips will play so the recap reads as one "
+            "continuous arc over the kept footage.",
+            "- If clips reuse overlapping source ranges, tag the beat with `source_clip_id` so it maps to the intended clip.",
             "",
             "### clip_plan.json shape",
             "",
             "```json",
             "{",
-            "  \"target_duration\": \"10m\",",
+            f"  \"target_duration\": \"{cut_target_example}\",",
             "  \"clips\": [",
             "    {\"start\": 12.0, \"end\": 38.0, \"reason\": \"关键冲突开端\"}",
             "  ]",
             "}",
             "```",
             "",
-            "### narration.json shape (source timestamps)",
+            "### narration.json shape (source timestamps inside the kept clips)",
             "",
             "```json",
             "[",
@@ -1345,8 +1483,8 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "",
         "## Writing rules (dense continuous-bed recap style)",
         "",
-        "1. Narrate continuously across the whole timeline as short punchy beats, keeping the original audio alive underneath as a ducked bed.",
-        f"2. Hit the density target: ~{target_spm:.1f} beats/min (at least {min_spm:.1f}); never leave a gap longer than {max_gap:.0f}s without narration.",
+        "1. Narrate continuously across the recap as short punchy beats over a ducked original-audio bed; in cut mode that means across the kept clips, in output order — not the full source timeline.",
+        "2. Follow the density line near the top of this brief: it already accounts for thin substrate and cut output. Keep a beat at least every few seconds inside a narrated stretch, but never pad with filler just to hit a number.",
         "3. Default `overlaps_speech` to true. The CLI auto-marks a beat as non-overlapping only when it actually lands inside a real silent window.",
         "4. Keep each beat short: roughly one short sentence (1-2 subtitle lines). Shorter is safer for TTS and reads better.",
         "5. Do not describe what the viewer can already see; explain intent, stakes, subtext, relationships, and story logic.",

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -3,7 +3,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-cut' / 'scripts'))
 import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
-from cut import build_edited_source_video, map_narration_to_clips, normalize_clip_plan, parse_duration_seconds, source_time_to_output_time
+from cut import build_edited_source_video, lint_mapped_narration, map_narration_to_clips, normalize_clip_plan, parse_duration_seconds, source_time_to_output_time
+
+
+def test_lint_mapped_narration_flags_dropped_and_sparse():
+    """Post-map re-lint must surface beats dropped by the mapper and a sparse cut output
+    (the otherwise-invisible half of cut-mode desync)."""
+    mapped = [
+        {"start": 5.0, "end": 8.0, "narration": "一。"},
+        {"start": 50.0, "end": 53.0, "narration": "二。"},
+    ]
+    report = lint_mapped_narration(mapped, original_count=8, output_duration=60.0)
+    codes = {w["code"] for w in report["warnings"]}
+    assert "many_beats_dropped" in codes          # 6/8 dropped
+    assert "low_density_output" in codes          # 2 beats over 60s
+    assert "long_gap_output" in codes             # 42s gap between the two beats
+    assert report["dropped"] == 6
+    assert report["drop_ratio"] == 0.75
+
+    dense = [{"start": float(i * 6), "end": float(i * 6 + 4), "narration": "一句。"} for i in range(10)]
+    healthy = lint_mapped_narration(dense, original_count=10, output_duration=60.0)
+    assert healthy["warnings"] == []
 
 
 def test_parse_duration_seconds_accepts_common_forms():

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -106,6 +106,70 @@ def test_lint_narration_density_metrics_and_warnings(monkeypatch):
     assert cut_report["metrics"] == {}
 
 
+def test_build_agent_brief_cut_mode_sizes_to_output(monkeypatch, tmp_path):
+    """Cut mode must size the beat target to the OUTPUT length, not the source.
+
+    Regression for the 2h->30min complaint: the brief used to ask for ~source/60*spm
+    beats across the whole source timeline, ~75% of which the cut then dropped.
+    """
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "1m")
+    monkeypatch.setitem(CONFIG, "target_segments_per_minute", 10.0)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    scenes = [{"scene_id": i, "start": i * 60.0, "end": i * 60.0 + 60.0, "description": "画面"} for i in range(10)]
+    text = build_agent_brief(scenes, [], [], 600.0, tmp_path).read_text(encoding="utf-8")
+    assert "CUT OUTPUT" in text
+    assert "10 short beats" in text       # 1min output * 10/min = 10 beats (sized to output)
+    assert "100 short beats" not in text   # the old source-sized (buggy) count
+    assert "Keep each beat INSIDE one clip" in text
+    assert '"target_duration": "1m"' in text
+
+
+def test_build_agent_brief_thin_substrate_relaxes_density(monkeypatch, tmp_path):
+    """Thin/empty substrate must turn the density target into a ceiling, not a quota,
+    so the agent is not forced to fill beats with 看图说话."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "full")
+    monkeypatch.setitem(CONFIG, "target_duration", "")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    scenes = [{"scene_id": i, "start": i * 6.0, "end": i * 6.0 + 6.0, "description": "画面"} for i in range(4)]
+    text = build_agent_brief(scenes, [], [], 24.0, tmp_path).read_text(encoding="utf-8")
+    assert "do NOT chase a beat count" in text
+    assert "ceiling here, not a quota" in text
+    assert "segments/min (minimum" not in text  # the strict quota line is replaced when thin
+
+
+def test_build_agent_brief_research_directive_when_context_without_research(monkeypatch, tmp_path):
+    """A title/context with no background_research.json must trigger a loud research-first
+    directive (the root of 'cold' narration: no story context -> only pixels to narrate)."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "full")
+    monkeypatch.setitem(CONFIG, "target_duration", "")
+    monkeypatch.setitem(CONFIG, "context_info", "这是《庆余年》第一集")
+    scenes = [{"scene_id": 0, "start": 0.0, "end": 6.0, "description": "范闲登场与人对峙暗藏机锋"}]
+    asr = [{"start": 1.0, "end": 5.0, "text": "一句对白。"}]
+    text = build_agent_brief(scenes, asr, [], 6.0, tmp_path).read_text(encoding="utf-8")
+    assert "Research the story FIRST" in text
+    assert "庆余年" in text  # the context is echoed into the directive
+
+    (tmp_path / "background_research.json").write_text('{"synopsis": "范闲查案"}', encoding="utf-8")
+    text2 = build_agent_brief(scenes, asr, [], 6.0, tmp_path).read_text(encoding="utf-8")
+    assert "Research the story FIRST" not in text2  # already researched -> directive gone
+
+
+def test_lint_narration_cut_mode_warns_on_clip_boundary_crossing():
+    """A beat that spills past its clip is silently trimmed by the mapper and ends up
+    over cut-away footage -> warn so the agent tightens it inside the clip."""
+    plan = {"clips": [{"clip_id": 0, "source_start": 10.0, "source_end": 20.0}]}
+    crossing = lint_narration([
+        {"start": 12.0, "end": 25.0, "narration": "跨过片段边界的解说。"},  # mid 18.5 in clip, end 25 > 20
+    ], [{"scene_id": 0, "start": 0.0, "end": 30.0}], clip_plan=plan, mode="cut")
+    assert "crosses_clip_boundary" in {i["code"] for i in crossing["warnings"]}
+
+    inside = lint_narration([
+        {"start": 12.0, "end": 18.0, "narration": "完全在片段内。"},
+    ], [{"scene_id": 0, "start": 0.0, "end": 30.0}], clip_plan=plan, mode="cut")
+    assert "crosses_clip_boundary" not in {i["code"] for i in inside["warnings"]}
+
+
 def test_align_narration_to_quiet_sets_overlap_flag_without_moving_beats(monkeypatch):
     """New contract: keep the agent's timing; only (re)compute overlaps_speech."""
     scenes = [{"scene_id": 0, "start": 0.0, "end": 12.0}]
@@ -252,15 +316,54 @@ def test_assess_understanding_substrate_levels():
         [{"scene_id": 0, "start": 0.0, "end": 3.0, "description": "短"}], []
     )
     assert empty["level"] == "empty"
-    rich = assess_understanding_substrate(
-        [
-            {"scene_id": i, "start": float(i), "end": float(i + 1),
-             "description": "画面描述" * 6, "frame_facts": {"1.0": ["动作"]}}
-            for i in range(4)
-        ],
-        [{"start": 0.0, "end": 3.0, "text": "对白" * 60}],
-    )
+
+    facts_scenes = [
+        {"scene_id": i, "start": float(i), "end": float(i + 1),
+         "description": "画面描述" * 6, "frame_facts": {"1.0": ["动作"]}}
+        for i in range(4)
+    ]
+    # Rich requires a story SPINE: substantial dialogue (ASR >= 200 chars) ...
+    rich = assess_understanding_substrate(facts_scenes, [{"start": 0.0, "end": 3.0, "text": "对白" * 120}])
     assert rich["level"] == "rich"
+    # ... or researched/given story context lifts a frame-fact-rich clip to rich.
+    storyful = assess_understanding_substrate(facts_scenes, [], has_story_context=True)
+    assert storyful["level"] == "rich"
+    # Frame-fact-rich but STORYLESS (no dialogue, no context) is thin, NOT rich, so the
+    # cold-narration safeguards (sparse warning, research directive, density relief) fire.
+    # This is the canonical anime case the old volume-only classifier mislabeled "rich".
+    storyless = assess_understanding_substrate(facts_scenes, [])
+    assert storyless["level"] == "thin"
+
+
+def test_parse_target_seconds_table():
+    """_parse_target_seconds must be total (never raise) and parse the documented forms."""
+    from narration import _parse_target_seconds
+    assert _parse_target_seconds("1:30") == 90.0
+    assert _parse_target_seconds("00:30:00") == 1800.0
+    assert _parse_target_seconds("30m") == 1800.0
+    assert _parse_target_seconds("1h5m") == 3900.0
+    assert _parse_target_seconds("600") == 600.0
+    assert _parse_target_seconds(90) == 90.0
+    for bad in ("", None, "abc", "0", "-5", "10x", "1:-30", "1:2:3:4", "  ", "nan", "inf"):
+        assert _parse_target_seconds(bad) is None
+
+
+def test_build_agent_brief_storyless_rich_video_relaxes_and_prompts_research(monkeypatch, tmp_path):
+    """End-to-end for the anime complaint: a frame-fact-rich but storyless video (no
+    dialogue, no research) must now be treated as thin so the density relaxes and the
+    research directive fires — instead of being graded 'rich' and shipping cold."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "full")
+    monkeypatch.setitem(CONFIG, "target_duration", "")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    scenes = [
+        {"scene_id": i, "start": float(i * 6), "end": float(i * 6 + 6),
+         "description": "人物在画面里走动" * 3, "frame_facts": {str(i * 6): ["走动"]}}
+        for i in range(6)
+    ]
+    text = build_agent_brief(scenes, [], [], 36.0, tmp_path).read_text(encoding="utf-8")
+    assert "do NOT chase a beat count" in text          # density relaxed (FIX D)
+    assert "Research the story FIRST" in text            # research directive (FIX E)
+    assert "segments/min (minimum" not in text           # strict quota line suppressed
 
 
 def test_cut_validate_prefers_raw_plan_when_validated_is_stale(tmp_path):

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -160,3 +160,17 @@ def test_brief_ignores_stale_mimo_overview_when_disabled_or_chunk_mismatch(monke
     monkeypatch.setitem(CONFIG, "mimo_video_overview", True)
     mismatch_text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path).read_text(encoding="utf-8")
     assert "STALE MIMO OVERVIEW" not in mismatch_text
+
+
+def test_build_agent_brief_cut_mode_sizes_to_output(monkeypatch, tmp_path):
+    """Cut mode sizes the beat target to the OUTPUT, not the source (brief.py copy)."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "1m")
+    monkeypatch.setitem(CONFIG, "target_segments_per_minute", 10.0)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    scenes = [{"scene_id": i, "start": i * 60.0, "end": i * 60.0 + 60.0, "description": "画面"} for i in range(10)]
+    text = build_agent_brief(scenes, [], [], 600.0, tmp_path).read_text(encoding="utf-8")
+    assert "CUT OUTPUT" in text
+    assert "10 short beats" in text
+    assert "100 short beats" not in text
+    assert "Keep each beat INSIDE one clip" in text


### PR DESCRIPTION
## The complaints

Two real user reports:
1. > 最后的成品会很冰冷的、很简单的描述解说画面 — the recap narration just describes what's on screen instead of telling the story. The user noted their prompt was thin ("只是解说一下这个动漫").
2. > 一部电影压缩到 30 分钟，感觉解说对不上画面 — in cut mode the narration desyncs from the picture.

I root-caused both against the actual code (and an adversarial multi-agent review), then fixed them and added regression tests.

## Complaint 1 — "cold" narration

The narration text is written by the agent; it can only narrate pixels when it has no **story spine**, and the brief was actively pushing it there:

- **Substrate misclassification (the key bug).** `assess_understanding_substrate` graded a frame-fact-rich but *storyless* clip (e.g. an anime whose dialogue ASR couldn't read) as `rich` purely on volume — so the sparse-substrate safeguards never fired for exactly the case that goes cold. Now `rich` requires a real spine: substantial dialogue (ASR ≥ 200 chars) **or** researched/given story context; frame-fact volume alone grades `thin`.
- **Self-contradicting density.** When substrate is thin the brief still demanded `~9.6 beats/min`, contradicting its own "be sparse" banner and *forcing* the agent to fill beats with picture-description. Thin substrate now relaxes the density target to a **ceiling, not a quota**, and a loud **research-first directive** is surfaced near the top of the brief when there's a title/context but no `background_research.json`.

Net: a storyless clip now grades `thin` → density relief + research directive fire (verified live), instead of silently shipping cold pixel-narration.

## Complaint 2 — cut-mode desync

- **Beat target sized to the source, not the output (the key bug).** `build_agent_brief` computed the beat count from the **source** duration, so a 2h source told the agent to write **~1150 beats** across the original timeline even though only ~30min is kept; the mapper then silently dropped ~75% and clamped boundary-crossers. Cut mode now sizes the target to the **output** (`min(source, target_duration)`): a 2h→30min cut asks for **~288 beats**, not ~1150.
- **Clearer cut authoring rules.** The cut-mode brief section (and SKILL.md) now state: size to the output, keep each beat inside one clip, order by output — and use the real `target_duration`.
- **New `crosses_clip_boundary` lint** when a beat spills past its clip (it would be trimmed onto cut-away footage).
- **New post-map re-lint** (`lint_mapped_narration` → `narration_mapped_lint.json`): surfaces beats dropped by the mapper, low density, and long gaps on the **real output timeline** — the otherwise-invisible half of the desync. Advisory (loud), never blocks the render.

## Testing

- Full suite green: `python3 scripts/test.py` → **239 passed** across all 6 groups; ruff clean; brief.py⇄narration.py byte-parity preserved (edited in lockstep). Also reproduced the no-ffmpeg CI run locally (assemble skips its 3 ffmpeg tests).
- **6 new regression tests**: cut-output sizing, thin-substrate density relief, research directive, `crosses_clip_boundary`, the story-spine classifier (storyless→thin), `_parse_target_seconds` table, and the post-map `lint_mapped_narration`.
- **Live verified**: a frame-fact-rich storyless clip now grades `thin` and fires the relief + directive; a real `cut.py` run with out-of-clip beats logs `many_beats_dropped` (drop_ratio 0.67) and writes the mapped-lint report.

## Known follow-ups (not in this PR)

- `VLM_DEPTH_PROMPT` leans toward literal on-screen description; the per-scene brief still lists raw `frame_facts` first — reordering spine-first would help Complaint 1 further (needs a live VLM pass to validate).
- The source-time clip-fit lint runs before clip normalization, so a non-zero `--clip-padding` could shift the checked edges; the post-map lint covers the real output regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
