### PR TITLE
fix(plugin.json): author must be an object, not a string

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "video-recap-skills",
   "version": "0.1.0",
   "description": "Turn any video into a Chinese-narration recap on ffmpeg + one Xiaomi MiMo API key: understanding (ASR + VLM) -> narration -> cut -> voiceover -> assemble. A bundle of independent skills + a thin orchestrator. Runs on macOS, Linux, and Windows.",
-  "author": "PiteChen"
+  "author": { "name": "PiteChen" }
 }


### PR DESCRIPTION
Claude Code's plugin manifest schema requires `author` to be an object with a `name` field (matching the format used
  in anthropics/claude-plugins-official marketplace.json). Currently the bare string `"PiteChen"` fails validation:

      Failed to install: Plugin ... has an invalid manifest file.
      Validation errors: author: Invalid input: expected object, received string

  Repro:
    /plugin marketplace add <a local marketplace pointing at this repo>
    /plugin install video-recap-skills@<that marketplace>
    → install aborts at manifest validation.

  Fix: wrap the value in `{ "name": "PiteChen" }`. Optional `email` can be added later.