### PR TITLE
v0.2.0: agentic re-architecture + continuous-bed mix + long-video robustness

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "video-recap-skills",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Turn any video into a Chinese-narration recap on ffmpeg + one Xiaomi MiMo API key: understanding (ASR + VLM) -> narration -> cut -> voiceover -> assemble. A bundle of independent skills + a thin orchestrator. Runs on macOS, Linux, and Windows.",
   "author": { "name": "PiteChen" }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.2.0] - 2026-06-16
+
+A quality-focused release that re-architects cut mode and the narration mix so the
+recap feels like a recap, not captions over a clip.
+
+### Changed
+
+- **Cut mode is now cut-first / narrate-second (two pauses).** The orchestrator renders
+  `edited_source.mp4` from `clip_plan.json` first, then asks the agent to write
+  `narration.json` against that real output timeline. Narration and picture stay in sync
+  by construction — the old source→output remap that could silently drop or clamp beats is
+  gone. Full mode is unchanged (single pause).
+- **Continuous original-audio bed.** The original is ducked into one continuous low bed
+  under the narration instead of swelling back up between sentences. Inter-beat gaps shorter
+  than `duck_bridge_seconds` (default 12s, just above the max narration gap) stay ducked;
+  only the lead-in and lead-out return to full volume. Tune with `DUCK_BRIDGE_SECONDS`.
+- **Narration density is a guide, not a quota.** The brief frames beats/min as a target to
+  aim for, explicitly telling the agent never to pad with filler or pixel-description to hit
+  a number — fewer "cold", caption-like recaps.
+- **`--consolidate` story index is on by default**, with a backward-compatible manifest shim
+  so existing `work_dir`s still resume. Use `--no-consolidate` to opt out.
+- **Research directive only fires when the substrate is thin/empty** (not on every titled
+  run), and the orchestrator surfaces a research hint in the pause banner.
+
+### Added
+
+- **Cut-desync floor:** narration is linted against the normalized clip plan, with a blocking
+  preflight that fails before TTS on heavy drop / too-sparse / long-gap output; `--allow-sparse-cut`
+  ships an intentional montage anyway.
+- **Phase ledger (`recap_phase.json`)** for deterministic cut-mode resume; a stale narration
+  from a changed `clip_plan` can no longer resume into TTS.
+- **`duck_bridge_seconds`** config knob (env `DUCK_BRIDGE_SECONDS`).
+
+### Fixed
+
+- **Long-video understanding rides out MiMo cluster rate limits.** A full episode fans out
+  into ~90 ASR + ~185 VLM calls; the MiMo endpoints now retry up to 10× with a 60s backoff
+  cap (plus a 10s floor when the server sends no `Retry-After`), and an optional
+  `ASR_THROTTLE_SECONDS` spaces sequential ASR — so a transient 429 no longer aborts the run.
+- **Resume cannot reuse stale artifacts.** Cached-artifact reuse now proves it matches the
+  current source bytes / settings and rejects stale provenance, so a changed input or config
+  can no longer silently resume on an out-of-date intermediate.
+
+## [0.1.0]
+
+- Initial release: turn any video into a Chinese-narration recap on `ffmpeg` + one Xiaomi
+  MiMo API key. Five independent skills (understanding, script, cut, voiceover, assemble)
+  plus a thin orchestrator; optional 剪映 draft export.

--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,7 @@ A Claude Code plugin: five small, independent skills plus a thin orchestrator. E
 flowchart LR
     research["Story research"] --> understand
     video(["Video"]) --> understand["Understand<br/>scenes·ASR·VLM"] --> script["Script<br/>agent"] --> voiceover["Voiceover<br/>MiMo TTS"] --> assemble["Assemble<br/>mux·subtitles"] --> output(["Recap"])
-    script -. cut mode .-> cut["Cut"] -.-> voiceover
+    understand -. cut mode: cut first .-> cut["Cut<br/>render first"] -.-> script
     classDef io fill:#eef6ff,stroke:#4f86c6,color:#1f2937;
     classDef opt fill:#f3f4f6,stroke:#9ca3af,color:#374151;
     class video,output io;
@@ -37,8 +37,8 @@ flowchart LR
 
 - **One key, runs anywhere.** ASR, VLM, and TTS all go through [Xiaomi MiMo](https://platform.xiaomimimo.com); the only local dependency is `ffmpeg` — no GPU, no model files, no extra service, on macOS / Linux / Windows.
 - **Research before analysis.** Put the plot and characters into `background_research.json` first, and the VLM names people on screen instead of labelling everyone "黑衣男子".
-- **Original audio survives, dynamic mix.** Narration is mixed over a ducked original; between sentences the original and BGM swell back up so there's no dead air.
-- **Cut and review.** `--edit-mode cut` turns a long video into a shorter narrated edit; an LLM review pass flags hallucinations, weak hooks, and a missing throughline before TTS.
+- **Original audio survives, continuous bed.** Narration is mixed over the original ducked into one continuous low bed; the short gaps between sentences no longer let the original pop back up (tunable via `duck_bridge_seconds`) — only the lead-in, lead-out, and pauses longer than that threshold return to full volume.
+- **Cut and review.** `--edit-mode cut` is cut-first/narrate-second: it renders the cut from `clip_plan.json`, then you narrate against that real output timeline, so narration and picture stay in sync by construction. An LLM review pass flags hallucinations, weak hooks, and a missing throughline before TTS.
 - **Keep editing in 剪映.** Optionally export a multi-track 剪映 draft; the core render only needs `ffmpeg` and never depends on 剪映.
 
 ## Installation
@@ -82,7 +82,7 @@ It analyzes the video, writes the narration against that context, and produces `
 Turn /path/to/long.mp4 into a ~10-minute cut-down recap and burn the subtitles in.
 ```
 
-Behind the scenes the orchestrator chains the stages, pausing so the agent can write `narration.json`. Before the first run, check your setup:
+Behind the scenes the orchestrator chains the stages, pausing so the agent can write the narration (cut mode pauses twice: first write `clip_plan.json` to pick the footage, then — once the cut is rendered — write `narration.json` against that output). Before the first run, check your setup:
 
 ```bash
 python3 skills/video-recap/scripts/recap.py --doctor
@@ -94,9 +94,9 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 | Skill | Does | In → Out (the `work_dir` contract) |
 |---|---|---|
-| **video-understanding** | scene detect · frame extract · ASR (`mimo-v2.5-asr`) · VLM (`mimo-v2.5`) · fuse timeline · build brief (+ optional `--consolidate` index) | `video` → `scenes / asr_result / vlm_analysis / silence_periods / timeline_fusion / agent_narration_brief.md` |
+| **video-understanding** | scene detect · frame extract · ASR (`mimo-v2.5-asr`) · VLM (`mimo-v2.5`) · fuse timeline · build brief (`--consolidate` index on by default) | `video` → `scenes / asr_result / vlm_analysis / silence_periods / timeline_fusion / agent_narration_brief.md` |
 | **video-script** | writing rules (SKILL.md) + review (LLM-as-judge) + lint/validate | `brief + index` → `narration.json` |
-| **video-cut** | clip plan → cut source + remap narration (cut mode) | `clip_plan.json + video` → `edited_source.mp4 + narration_mapped.json` |
+| **video-cut** | clip plan → render the cut (cut-first/narrate-second; narration is written on the output timeline, no remap) | `clip_plan.json + video` → `edited_source.mp4` |
 | **video-voiceover** | synthesize narration audio (MiMo TTS, `mimo-v2.5-tts`) | `narration.json` → `tts_segments/ + tts_meta.json` |
 | **video-assemble** | mux · duck original audio · render subtitles · multi-track timeline (optional 剪映 export) | `video + tts_meta` → `recap_<name>.mp4 + subtitles.srt/.ass + timeline.json` |
 | **video-recap** | orchestrator + `--doctor` | `video` → `recap_<name>.mp4` |
@@ -111,7 +111,7 @@ Run tests with `python3 scripts/test.py`. Do not run bare `pytest` at the reposi
 - `work_dir/narration.json`: the narration script (`narration_lint.json` timing diagnostics, `narration_review.md` review notes)
 - `work_dir/agent_narration_brief.md`: timing and scene brief for the agent
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`: understanding artifacts
-- `work_dir/clip_plan.json` · `edited_source.mp4` · `narration_mapped.json`: cut-mode artifacts
+- `work_dir/clip_plan.json` · `edited_source.mp4` · `recap_phase.json`: cut-mode artifacts (narration is written on the output timeline; `recap_phase.json` records cut/narrate progress for deterministic resume)
 - `work_dir/timeline.json` · `work_dir/assembly_manifest.json` · `tts_segments/` · `tts_meta.json`: multi-track timeline, slim render record, and TTS audio
 
 ## References

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff
 flowchart LR
     research["背景调研"] --> understand
     video(["视频"]) --> understand["理解<br/>场景·ASR·VLM"] --> script["写稿<br/>Agent"] --> voiceover["配音<br/>MiMo TTS"] --> assemble["组装<br/>混音·字幕"] --> output(["Recap"])
-    script -. 剪辑模式 .-> cut["剪辑"] -.-> voiceover
+    understand -. 剪辑模式：先剪后配 .-> cut["剪辑<br/>先剪成片"] -.-> script
     classDef io fill:#eef6ff,stroke:#4f86c6,color:#1f2937;
     classDef opt fill:#f3f4f6,stroke:#9ca3af,color:#374151;
     class video,output io;
@@ -37,8 +37,8 @@ flowchart LR
 
 - **一个 key 跑全程。** ASR、VLM、TTS 全走[小米 MiMo](https://platform.xiaomimimo.com)，本地只装 `ffmpeg`。
 - **先调研再分析。** 先把剧情人物查清楚写进 `background_research.json`。
-- **原声不丢，动态混音。** 解说压低原声后混进去；句子间隙自动让原声和 BGM 顶上来。
-- **能剪、能审。** `--edit-mode cut` 把长视频压成更短的解说剪辑；出稿前一道 LLM 评审挑幻觉、钩子、主线的毛病。
+- **原声不丢，连续铺底。** 解说把原声压成一条连续的低音铺底再混进去；句与句之间的短间隙不再让原声窜起来（桥接阈值 `duck_bridge_seconds` 可调），只有片头引入、片尾收束、以及超过该阈值的长停顿才放回满音量原声。
+- **能剪、能审。** `--edit-mode cut` 先剪后配——先按 `clip_plan.json` 把长视频剪成成片，再对着剪好的成片时间轴写解说，解说与画面天然对齐、不会错位；出稿前一道 LLM 评审挑幻觉、钩子、主线的毛病。
 - **接着在剪映里改。** 可选导出多轨剪映草稿；核心渲染只靠 `ffmpeg`，不装剪映也照常出片。
 
 ## 安装
@@ -82,7 +82,7 @@ export MIMO_TOKEN_PLAN_CLUSTER=cn
 把 /path/to/long.mp4 剪成十分钟左右的解说短片，字幕压进画面。
 ```
 
-背后是编排器把几个阶段串起来跑，中间停下来让 Agent 写 `narration.json`。第一次跑前先自检环境：
+背后是编排器把几个阶段串起来跑，中间停下来让 Agent 写解说（剪辑模式会停两次：先写 `clip_plan.json` 挑片段，剪成成片后再对着成片写 `narration.json`）。第一次跑前先自检环境：
 
 ```bash
 python3 skills/video-recap/scripts/recap.py --doctor
@@ -94,9 +94,9 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 | Skill | 职责 | 输入 → 输出（`work_dir` 契约） |
 |---|---|---|
-| **video-understanding** | 场景检测 · 抽帧 · ASR（`mimo-v2.5-asr`）· VLM（`mimo-v2.5`）· 时间轴融合 · 生成 brief（可选 `--consolidate` 索引） | `视频` → `scenes / asr_result / vlm_analysis / silence_periods / timeline_fusion / agent_narration_brief.md` |
+| **video-understanding** | 场景检测 · 抽帧 · ASR（`mimo-v2.5-asr`）· VLM（`mimo-v2.5`）· 时间轴融合 · 生成 brief（`--consolidate` 索引默认开） | `视频` → `scenes / asr_result / vlm_analysis / silence_periods / timeline_fusion / agent_narration_brief.md` |
 | **video-script** | 写作规则（SKILL.md）+ 评审（LLM 评委）+ lint/校验 | `brief + 索引` → `narration.json` |
-| **video-cut** | 片段计划 → 拼剪源 + 重映射解说（剪辑模式） | `clip_plan.json + 视频` → `edited_source.mp4 + narration_mapped.json` |
+| **video-cut** | 片段计划 → 拼剪成片（剪辑模式先剪后配，解说按成片时间轴写，无需重映射） | `clip_plan.json + 视频` → `edited_source.mp4` |
 | **video-voiceover** | 合成解说音频（MiMo TTS，`mimo-v2.5-tts`） | `narration.json` → `tts_segments/ + tts_meta.json` |
 | **video-assemble** | 混音 · 压低原声 · 渲染字幕 · 多轨时间线（可选导出剪映） | `视频 + tts_meta` → `recap_<名>.mp4 + subtitles.srt/.ass + timeline.json` |
 | **video-recap** | 编排器 + `--doctor` | `视频` → `recap_<名>.mp4` |
@@ -111,7 +111,7 @@ python3 skills/video-recap/scripts/recap.py --doctor
 - `work_dir/narration.json`：解说脚本（`narration_lint.json` 时间诊断、`narration_review.md` 评审意见）
 - `work_dir/agent_narration_brief.md`：给 Agent 的时间和场景 brief
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`：理解产物
-- `work_dir/clip_plan.json` · `edited_source.mp4` · `narration_mapped.json`：剪辑模式产物
+- `work_dir/clip_plan.json` · `edited_source.mp4` · `recap_phase.json`：剪辑模式产物（解说在成片时间轴上写，`recap_phase.json` 记录剪/配进度供断点续跑）
 - `work_dir/timeline.json` · `work_dir/assembly_manifest.json` · `tts_segments/` · `tts_meta.json`：多轨时间线、渲染记录与 TTS 音频
 
 ## 参考文档

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -206,7 +206,8 @@ def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
         ducking = {"idle": CONFIG.get("idle_orig_volume", 0.85),
                    "speech": CONFIG.get("speech_ducking_volume", 0.2),
                    "quiet": CONFIG.get("zone_ducking_volume", 0.12),
-                   "fade": fade}
+                   "fade": fade,
+                   "bridge": CONFIG.get("duck_bridge_seconds", 12.0)}
     timeline = build_timeline(canvas, duration_s, video_clips,
                               narration_segments, bgm=bgm, ducking=ducking)
     out = Path(work_dir) / "timeline.json"
@@ -274,6 +275,7 @@ def assembly_settings_fingerprint():
         "audio_mix": {
             "ducking_mode": CONFIG.get("ducking_mode", "fixed"),
             "duck_fade_seconds": CONFIG.get("duck_fade_seconds", 0.25),
+            "duck_bridge_seconds": CONFIG.get("duck_bridge_seconds", 12.0),
             "ducking_narr_weight": CONFIG.get("ducking_narr_weight", 1.5),
             "ducking_orig_volume": CONFIG.get("ducking_orig_volume", 0.5),
             "idle_orig_volume": CONFIG.get("idle_orig_volume", 0.85),
@@ -512,41 +514,71 @@ def _duck_ramp(s, e, fade):
     return f"min(1,max(0,min(t-{s:.2f},{e:.2f}-t)/{fade:.2f}))"
 
 
-def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade):
-    """Per-beat ducking automation for the ORIGINAL track.
-
-    Holds the original at `idle` in the gaps (no narration) so the source audio keeps
-    the recap from going dead-air between sentences, and ramps it down under each
-    placed narration window — to speech_vol where the beat overlaps source dialogue,
-    quiet_vol where it sits in a quiet window. Returns a volume= expression, or None
-    when no beat carries placement info (caller falls back to a constant)."""
-    terms = []
+def _placement_windows(tts_segments, level_for):
+    """Collect [(start, end, level)] placement windows for the placed beats, using
+    `level_for(seg)` to pick each beat's duck level. Skips non-dicts and empty spans."""
+    windows = []
     for seg in tts_segments:
         if not isinstance(seg, dict):
             continue
         s, e = _seg_place_window(seg)
         if e - s <= 0:
             continue
-        level = speech_vol if seg.get("overlaps_speech", True) else quiet_vol
-        terms.append(f"+({level - idle:.3f})*{_duck_ramp(s, e, fade)}")
-    if not terms:
+        windows.append((s, e, level_for(seg)))
+    return windows
+
+
+def _coalesce_duck_windows(windows, bridge):
+    """Merge placement windows whose gap is smaller than `bridge` into one held span,
+    so the duck stays low across short inter-beat gaps (a continuous bed) instead of the
+    original swelling back to idle between sentences. Each merged span keeps the
+    most-ducked (lowest) level of its members. Genuine gaps >= bridge survive as separate
+    dips, so the original still breathes there. `windows` is [(start, end, level)]."""
+    rel = sorted(([float(s), float(e), float(g)] for s, e, g in windows if e > s),
+                 key=lambda w: w[0])
+    if not rel:
+        return []
+    merged = [rel[0][:]]
+    for s, e, g in rel[1:]:
+        if s - merged[-1][1] < bridge:
+            merged[-1][1] = max(merged[-1][1], e)
+            merged[-1][2] = min(merged[-1][2], g)
+        else:
+            merged.append([s, e, g])
+    return merged
+
+
+def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=None):
+    """Per-beat ducking automation for the ORIGINAL track.
+
+    Ramps the original down under each placed narration window — to speech_vol where the
+    beat overlaps source dialogue, quiet_vol where it sits in a quiet window — and HOLDS
+    that duck across inter-beat gaps shorter than `bridge` so the source dialogue does not
+    pop back up between sentences. Only gaps >= bridge swell back to `idle` (lead-in/out
+    and deliberate long pauses). Returns a volume= expression, or None when no beat carries
+    placement info (caller falls back to a constant)."""
+    if bridge is None:
+        bridge = 2 * float(fade or 0)
+    windows = _placement_windows(
+        tts_segments, lambda seg: speech_vol if seg.get("overlaps_speech", True) else quiet_vol)
+    merged = _coalesce_duck_windows(windows, bridge)
+    if not merged:
         return None
+    terms = [f"+({level - idle:.3f})*{_duck_ramp(s, e, fade)}" for s, e, level in merged]
     return f"max(0,min(1,{idle}{''.join(terms)}))"
 
 
-def _bgm_envelope(tts_segments, base, duck, fade):
+def _bgm_envelope(tts_segments, base, duck, fade, bridge=None):
     """Per-beat ducking automation for the BGM track: hold the bed at `base`, dip to
-    `duck` under every narration window so the voice stays clear. None if no beats."""
-    terms = []
-    for seg in tts_segments:
-        if not isinstance(seg, dict):
-            continue
-        s, e = _seg_place_window(seg)
-        if e - s <= 0:
-            continue
-        terms.append(f"+({duck - base:.3f})*{_duck_ramp(s, e, fade)}")
-    if not terms:
+    `duck` under each narration window (held across gaps < `bridge`) so the voice stays
+    clear. None if no beats."""
+    if bridge is None:
+        bridge = 2 * float(fade or 0)
+    windows = _placement_windows(tts_segments, lambda seg: duck)
+    merged = _coalesce_duck_windows(windows, bridge)
+    if not merged:
         return None
+    terms = [f"+({lvl - base:.3f})*{_duck_ramp(s, e, fade)}" for s, e, lvl in merged]
     return f"max(0,min(1,{base}{''.join(terms)}))"
 
 
@@ -579,7 +611,8 @@ def _build_audio_filter_complex(
     bgm_chain = ""
     if has_bgm:
         base = CONFIG.get("bgm_volume", 0.18)
-        bgm_expr = _bgm_envelope(tts_segments, base, CONFIG.get("bgm_ducking_volume", 0.10), fade)
+        bgm_expr = _bgm_envelope(tts_segments, base, CONFIG.get("bgm_ducking_volume", 0.10), fade,
+                                 bridge=CONFIG.get("duck_bridge_seconds", 12.0))
         if bgm_expr:
             bgm_chain = f"{bgm_in}volume='{bgm_expr}':eval=frame,aresample=48000[bgm];"
         else:
@@ -607,11 +640,12 @@ def _build_audio_filter_complex(
     idle = CONFIG.get("idle_orig_volume", 0.85)
     speech_vol = CONFIG.get("speech_ducking_volume", 0.2)
     quiet_vol = CONFIG.get("zone_ducking_volume", 0.12)
-    expr = _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade)
+    bridge = CONFIG.get("duck_bridge_seconds", 12.0)
+    expr = _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=bridge)
     if expr:
         n_overlap = sum(1 for s in tts_segments if isinstance(s, dict) and s.get("overlaps_speech", True))
         n_quiet = sum(1 for s in tts_segments if isinstance(s, dict) and not s.get("overlaps_speech", True))
-        log(f"gap-fill ducking: 间隙原声={idle}, 对白段={speech_vol}({n_overlap}), 安静段={quiet_vol}({n_quiet})")
+        log(f"gap-fill ducking: 间隙原声={idle}, 对白段={speech_vol}({n_overlap}), 安静段={quiet_vol}({n_quiet}), 桥接间隙<{bridge}s")
         orig = f"{original_in}volume='{expr}':eval=frame,aresample=48000[orig];"
     else:
         # No placement info at all: hold the original at a constant level.

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -203,6 +203,7 @@ CONFIG = {
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
     "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
     "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "duck_bridge_seconds": env_float("DUCK_BRIDGE_SECONDS", 12.0, minimum=0.0),  # 相邻解说段间隔小于此值则压低保持连续铺底，不让原声在句间窜起来。默认 12s 略高于 max_narration_gap_seconds(11s)，于是整段解说期间原声都是一条压低的连续铺底，只有片头引入/片尾收束才放回原声；调小可让段落间隙放回原声喘息
     "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
     "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
     "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)

--- a/skills/video-assemble/scripts/timeline.py
+++ b/skills/video-assemble/scripts/timeline.py
@@ -4,8 +4,9 @@ A `Timeline` is a small, serializable representation of the finished recap as a
 set of tracks — exactly like a cut-tool project:
 
   - one **video** track: the source clip(s), each carrying its own *original
-    audio* with a per-clip volume automation (the gap-fill ducking: up in the
-    gaps between sentences, down under narration);
+    audio* with a per-clip volume automation (the ducking: a continuous low bed
+    under narration, held across short inter-sentence gaps, back up only at the
+    lead-in/out and genuine long gaps);
   - one **narration** audio track: the placed TTS beats;
   - an optional **bgm** audio track: a looped music bed with its own ducking;
   - one **subtitle** (text) track: the narration lines.
@@ -25,7 +26,7 @@ def _kf(t_s, gain):
     return {"t": round(float(t_s), 4), "gain": round(float(gain), 4)}
 
 
-def ducking_keyframes(windows, idle, duck, fade, span_start, span_end):
+def ducking_keyframes(windows, idle, duck, fade, span_start, span_end, bridge=None):
     """Volume automation for a track that holds at `idle` and dips to `duck`
     under each narration window, with `fade`-second linear ramps.
 
@@ -33,17 +34,19 @@ def ducking_keyframes(windows, idle, duck, fade, span_start, span_end):
     Returns timeline-absolute [{t, gain}] keyframes clamped to [span_start,
     span_end]; empty when there is nothing to automate (caller uses a flat gain).
     """
+    if bridge is None:
+        bridge = 2 * fade
     rel = sorted((max(span_start, w[0]), min(span_end, w[1]))
                  for w in windows if w[1] > span_start and w[0] < span_end and w[1] > w[0])
     if not rel:
         return []
-    # Coalesce windows closer than the combined ramp time (2*fade): with no room to
-    # ramp back to idle and down again between them, the duck must stay held —
-    # otherwise the original would pump up and back down under near-continuous speech.
-    # Genuine gaps (>= 2*fade) survive as a plateau, so the original still swells there.
+    # Coalesce windows whose gap is below `bridge`: with no room to ramp back to idle and
+    # down again between them, the duck must stay held — otherwise the original would pump
+    # up and back down between sentences. Genuine gaps (>= bridge) survive as a plateau, so
+    # the original still swells there.
     merged = [list(rel[0])]
     for s, e in rel[1:]:
-        if s - merged[-1][1] < 2 * fade:
+        if s - merged[-1][1] < bridge:
             merged[-1][1] = max(merged[-1][1], e)
         else:
             merged.append([s, e])
@@ -66,43 +69,56 @@ def ducking_keyframes(windows, idle, duck, fade, span_start, span_end):
     return [_kf(t, g) for t, g in out]
 
 
-def variable_ducking_keyframes(windows, idle, fade, span_start, span_end):
+def _coalesce_windows(rel, bridge):
+    """Merge sorted (start, end, level) windows whose gap is below `bridge` into one held
+    span at the most-ducked (min) level. This is the SAME coalescing the ffmpeg render path
+    uses (assemble._coalesce_duck_windows), so the exported 剪映 draft matches the rendered
+    mix exactly even when a bridged span mixes speech (louder) and quiet (deeper) beats."""
+    if not rel:
+        return []
+    merged = [list(rel[0])]
+    for s, e, level in rel[1:]:
+        if s - merged[-1][1] < bridge:
+            merged[-1][1] = max(merged[-1][1], e)
+            merged[-1][2] = min(merged[-1][2], level)
+        else:
+            merged.append([s, e, level])
+    return merged
+
+
+def variable_ducking_keyframes(windows, idle, fade, span_start, span_end, bridge=None):
     """Volume automation with a per-window duck gain.
 
-    `windows` is [(start_s, end_s, duck_gain)]. Unlike `ducking_keyframes`,
-    this preserves the canonical renderer's speech-vs-quiet ducking levels for
-    timeline/JianYing export instead of flattening every narration beat to the
-    same target gain.
+    `windows` is [(start_s, end_s, duck_gain)]. Windows whose gap is below `bridge` coalesce
+    into one held span at the most-ducked level (matching the renderer), so the original stays
+    ducked across short inter-sentence gaps instead of swelling back to idle; only the
+    lead-in/out and genuine gaps >= bridge return to idle. Defaults bridge to 2*fade.
     """
+    if bridge is None:
+        bridge = 2 * fade
     rel = sorted(
         (max(span_start, float(w[0])), min(span_end, float(w[1])), float(w[2]))
         for w in windows
         if float(w[1]) > span_start and float(w[0]) < span_end and float(w[1]) > float(w[0])
     )
-    if not rel:
+    merged = _coalesce_windows(rel, bridge)
+    if not merged:
         return []
 
     pts = [(span_start, idle)]
-    for idx, (s, e, gain) in enumerate(rel):
-        prev_end = rel[idx - 1][1] if idx else None
-        next_start = rel[idx + 1][0] if idx + 1 < len(rel) else None
-        close_to_prev = prev_end is not None and s - prev_end < 2 * fade
-        close_to_next = next_start is not None and next_start - e < 2 * fade
-
-        if not close_to_prev:
-            pts.append((max(span_start, s - fade), idle))
-        pts.append((s, gain))
-        pts.append((e, gain))
-        if not close_to_next:
-            pts.append((min(span_end, e + fade), idle))
+    for s, e, level in merged:
+        # hold the duck across the merged span; ramp in just before, release just after
+        pts.append((max(span_start, s - fade), idle))
+        pts.append((s, level))
+        pts.append((e, level))
+        pts.append((min(span_end, e + fade), idle))
     pts.append((span_end, idle))
 
     pts.sort(key=lambda p: p[0])
     out = []
     for t, g in pts:
         if out and abs(out[-1][0] - t) < 1e-4:
-            # At adjacent windows, prefer the lower gain to avoid a one-frame
-            # swell between back-to-back narration beats.
+            # coincident points (overlapping ramps): prefer the lower gain, no swell
             out[-1] = (t, min(out[-1][1], g))
         else:
             out.append((t, g))
@@ -121,8 +137,9 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
     narration_segments: placed beats [{"source_path", "timeline_start",
                  "timeline_end", "text", "overlaps_speech", "gain"?}].
     bgm: optional {"source_path", "volume", "ducking_volume"}.
-    ducking: {"idle", "speech", "quiet", "fade"} for the original-audio
-             automation; None disables original ducking (flat original).
+    ducking: {"idle", "speech", "quiet", "fade", "bridge"?} for the original-audio
+             automation; None disables original ducking (flat original). `bridge` holds
+             the duck across inter-beat gaps shorter than it (defaults to 2*fade).
     """
     windows = [(float(s["timeline_start"]), float(s["timeline_end"]))
                for s in narration_segments
@@ -144,7 +161,8 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
         audio = {"role": "original", "volume_keyframes": []}
         if ducking is not None:
             audio["volume_keyframes"] = variable_ducking_keyframes(
-                duck_windows, ducking["idle"], ducking["fade"], ts, te)
+                duck_windows, ducking["idle"], ducking["fade"], ts, te,
+                bridge=ducking.get("bridge"))
             audio["base_gain"] = round(float(ducking["idle"]), 4)
         else:
             audio["base_gain"] = 1.0
@@ -182,7 +200,8 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
         base = float(bgm.get("volume", 0.18))
         duck = float(bgm.get("ducking_volume", 0.10))
         fade = float(bgm.get("fade") or (ducking or {}).get("fade", 0.25))
-        kfs = ducking_keyframes(windows, base, duck, fade, 0.0, duration_s)
+        kfs = ducking_keyframes(windows, base, duck, fade, 0.0, duration_s,
+                                bridge=(ducking or {}).get("bridge"))
         tracks.append({
             "kind": "audio", "name": "bgm", "role": "bgm", "loop": True,
             "segments": [{

--- a/skills/video-cut/SKILL.md
+++ b/skills/video-cut/SKILL.md
@@ -2,12 +2,12 @@
 name: video-cut
 user-invocable: false
 description: >
- Cut a long video down to selected source ranges (montage / clip assembly) and remap
- timestamped narration onto the shortened timeline. Use when an agent has chosen which
- original-video segments to keep (a clip plan) and needs a single concatenated source
- video plus narration mapped to the new (output) time. Part of the video-recap bundle:
- consumes clip_plan.json + the source video, produces edited_source.mp4 +
- narration_mapped.json. 触发词: 视频剪辑, 剪辑式解说, video cut, clip plan, 拼剪.
+ Cut a long video down to selected source ranges (montage / clip assembly). Part of the
+ video-recap bundle: in the orchestrated (two-pass) flow, consumes clip_plan.json + the
+ source video, produces edited_source.mp4; the agent then writes narration.json against
+ the output timeline. When invoked standalone WITHOUT --no-narration-map, also remaps an
+ existing narration.json → narration_mapped.json (legacy single-pass path).
+ 触发词: 视频剪辑, 剪辑式解说, video cut, clip plan, 拼剪.
 ---
 
 ## What this does
@@ -15,7 +15,8 @@ description: >
 Takes an agent-authored **clip plan** (which source ranges to keep, in order) and:
 1. Validates + enriches it into `clip_plan_validated.json` (clip ids, source/output times, total duration, overlap checks).
 2. Concatenates those source ranges into a single `edited_source.mp4`.
-3. Maps narration written in **original-video time** onto the cut **output** timeline → `narration_mapped.json`.
+3. **(Orchestrated path — default)** Stops here; the agent writes `narration.json` against the output timeline (0 .. total seconds). Invoked by `recap.py` with `--no-narration-map`.
+4. **(Legacy single-pass path)** When invoked directly **without** `--no-narration-map`: maps narration written in original-video time onto the cut output timeline → `narration_mapped.json`.
 
 It is stateless: given the same inputs it reproduces the same outputs. Caching is just
 "reuse `edited_source.mp4` if it is newer than `clip_plan.json`".
@@ -31,7 +32,7 @@ It is stateless: given the same inputs it reproduces the same outputs. Caching i
 `start`/`end` are **original-video seconds** (aliases `source_start`/`source_end` or `in`/`out` accepted).
 Optionally `target_duration` at the object top level (e.g. `"10m"`).
 
-`work_dir/narration.json` (optional) — segments with original-video `start`/`end` + `narration` text.
+`work_dir/narration.json` (optional, legacy single-pass path only) — segments with original-video `start`/`end` + `narration` text, consumed only when `--no-narration-map` is NOT passed.
 Each segment may carry `source_clip_id` to disambiguate when overlapping clips are allowed.
 
 ## Run
@@ -45,13 +46,13 @@ python3 scripts/cut.py <video> --work-dir <work_dir> \
 
 - `clip_plan_validated.json` — normalized clips with `clip_id`, `source_start/end`, `output_start/end`, `duration`.
 - `edited_source.mp4` — the concatenated source video (the new shortened timeline).
-- `narration_mapped.json` — narration with `start`/`end` rewritten to output time and `source_clip_id` set.
+- `narration_mapped.json` — **(legacy single-pass path only)** narration with `start`/`end` rewritten to output time and `source_clip_id` set. NOT produced in the orchestrated flow (`recap.py --no-narration-map`).
 
-Downstream (voiceover + assemble) treat `edited_source.mp4` as the video and `narration_mapped.json` as the narration.
+In the orchestrated flow, downstream (voiceover + assemble) treat `edited_source.mp4` as the video and `narration.json` (written by the agent against the output timeline) as the narration.
 
 ## Notes
 
-- Timestamps in `clip_plan.json` and `narration.json` are always **original-video time**; this tool does the source→output remap.
+- In the legacy single-pass path, timestamps in `clip_plan.json` and `narration.json` are **original-video time**; this tool does the source→output remap. In the orchestrated path, `narration.json` is written by the agent directly in **output-timeline time** — no remap is performed.
 - Overlapping/duplicate source ranges raise an error unless `--allow-overlap` is set; with overlap, narration should set `source_clip_id`.
 - Segments that fall outside every kept clip are dropped (logged).
 

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -299,6 +299,11 @@ def map_narration_to_clips(narration, validated_plan, min_duration=0.3):
         item["source_clip_id"] = clip["clip_id"]
         item["start"] = output_start
         item["end"] = output_end
+        # Tag beats trimmed to a clip edge: their TEXT was written for a longer span and may
+        # now describe footage that was cut away (a stale-text desync the lint surfaces).
+        item["clamped"] = bool(
+            clipped_source_start > source_start + 1e-3 or clipped_source_end < source_end - 1e-3
+        )
         mapped.append(item)
 
     mapped.sort(key=lambda seg: seg["start"])
@@ -311,8 +316,9 @@ def lint_mapped_narration(mapped, original_count, output_duration, *, min_spm=6.
     The mapper silently drops beats whose midpoint is outside every kept clip and clamps
     boundary-crossers, so a narration authored against the full source can pass the
     source-time validate yet leave the cut sparse or describing footage the viewer never
-    sees. This surfaces that on the real output timeline (loud log + narration_mapped_lint.json);
-    it never blocks the render — a sparse recap can be intentional.
+    sees. This surfaces that on the real output timeline (narration_mapped_lint.json) and
+    returns a `blocking` verdict (heavy drop / too sparse / long gap) that the cut stage
+    enforces unless --allow-sparse-cut. Clamped-but-kept beats are surfaced as advisory only.
     """
     mapped = sorted(mapped or [], key=lambda s: float(s.get("start", 0.0)))
     mapped_count = len(mapped)
@@ -345,6 +351,14 @@ def lint_mapped_narration(mapped, original_count, output_duration, *, min_spm=6.
             "message": "成片里有一长段没有解说。",
             "max_gap_seconds": round(max_gap, 2), "max_gap_limit_seconds": max_gap_seconds,
         })
+    clamped = [b for b in mapped if isinstance(b, dict) and b.get("clamped")]
+    if clamped:
+        warnings.append({
+            "code": "clamped_beats",
+            "message": "有解说段被裁到片段边界，文本可能在描述被剪掉的画面——核对并改写这些行。",
+            "count": len(clamped),
+        })
+    blocking_codes = {"many_beats_dropped", "low_density_output", "long_gap_output"}
     return {
         "mapped_count": mapped_count,
         "dropped": dropped,
@@ -353,7 +367,9 @@ def lint_mapped_narration(mapped, original_count, output_duration, *, min_spm=6.
         "segments_per_minute": round(spm, 2),
         "max_gap_seconds": round(max_gap, 2),
         "coverage": round(coverage, 2),
+        "clamped_count": len(clamped),
         "warnings": warnings,
+        "blocking": any(w["code"] in blocking_codes for w in warnings),
     }
 
 
@@ -437,6 +453,11 @@ def main():
     parser.add_argument("--target-duration", default=None, help="target output duration, e.g. 10m / 600 / 00:10:00")
     parser.add_argument("--clip-padding", type=float, default=0.0, help="seconds to pad each clip on both ends")
     parser.add_argument("--allow-overlap", action="store_true", help="allow overlapping/duplicate source ranges")
+    parser.add_argument("--normalize-only", action="store_true",
+                        help="only normalize the clip plan -> clip_plan_validated.json (no render/map); "
+                             "lets validate lint the SAME padded/pruned plan the mapper uses")
+    parser.add_argument("--allow-sparse-cut", action="store_true",
+                        help="do not block on heavy narration drop / sparse output (e.g. an intentional montage)")
     args = parser.parse_args()
 
     work_dir = Path(args.work_dir)
@@ -456,6 +477,10 @@ def main():
         validated_plan["raw_plan_fingerprint"] = value_fingerprint(raw_plan)
     (work_dir / "clip_plan_validated.json").write_text(
         json.dumps(validated_plan, ensure_ascii=False, indent=2), encoding="utf-8")
+    if args.normalize_only:
+        print(json.dumps({"status": "normalized", "clips": len(validated_plan["clips"]),
+                          "total_duration": validated_plan["total_duration"]}, ensure_ascii=False))
+        return
 
     edited_source_path = work_dir / "edited_source.mp4"
     if should_reuse_edited_source(edited_source_path, validated_plan, args.video):
@@ -477,6 +502,10 @@ def main():
             json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
         for w in report["warnings"]:
             log(f"  ⚠️ 剪后解说同步: {w['message']} [{w['code']}]")
+        if report.get("blocking") and not args.allow_sparse_cut:
+            raise SystemExit(
+                "剪后解说与保留片段对不上：丢弃过多或成片过稀疏。改 narration.json / clip_plan.json "
+                "让解说落在保留片段内后重跑，或加 --allow-sparse-cut 接受当前映射。详见 narration_mapped_lint.json")
     log(f"剪辑模式: {len(validated_plan['clips'])} 个片段 → {validated_plan['total_duration']:.1f}s")
 
 

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -456,6 +456,9 @@ def main():
     parser.add_argument("--normalize-only", action="store_true",
                         help="only normalize the clip plan -> clip_plan_validated.json (no render/map); "
                              "lets validate lint the SAME padded/pruned plan the mapper uses")
+    parser.add_argument("--no-narration-map", action="store_true",
+                        help="render edited_source.mp4 but do NOT map narration.json onto the cut "
+                             "(cut-first/narrate-second: narration is authored in OUTPUT time, no mapping)")
     parser.add_argument("--allow-sparse-cut", action="store_true",
                         help="do not block on heavy narration drop / sparse output (e.g. an intentional montage)")
     args = parser.parse_args()
@@ -489,7 +492,7 @@ def main():
         build_edited_source_video(args.video, validated_plan, work_dir, edited_source_path)
 
     narration_path = Path(args.narration) if args.narration else work_dir / "narration.json"
-    if narration_path.exists():
+    if narration_path.exists() and not args.no_narration_map:
         narration = json.loads(narration_path.read_text(encoding="utf-8"))
         mapped = map_narration_to_clips(narration, validated_plan)
         if not mapped:

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -18,8 +18,9 @@ bundle ships no root `CLAUDE.md` (so it never collides with your project/global 
 | Narration density | `TARGET_SEGMENTS_PER_MINUTE` | `9.6` | min `MIN_SEGMENTS_PER_MINUTE=6.24` |
 | Narration speed | `NARRATION_SPEED` | `1.2` | global atempo on the voiceover; default leans snappy for short-form, set `1.0` for long-form/documentary |
 | Mask source subs | `MASK_SOURCE_SUBTITLES` / `SOURCE_SUBTITLE_MASK_RATIO` | on / `0.14` | covers burned-in source subtitles (bottom band) so only the recap's subtitles show; set `MASK_SOURCE_SUBTITLES=false` for sources without hardcoded subs |
-| Original ducking | `IDLE_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `0.85` / `0.2` | the original swells to `IDLE` in the gaps between sentences (so the recap never goes dead-air / choppy) and ducks to `SPEECH` under narration. `DUCKING_ORIG_VOLUME` (`0.3`) is only the fallback when beats carry no placement info |
+| Original ducking | `IDLE_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `0.85` / `0.2` | the original is held as a **continuous low bed** under narration: inter-beat gaps shorter than `duck_bridge_seconds` stay ducked (no swelling back up between sentences). Only the lead-in, lead-out, and genuine gaps >= `duck_bridge_seconds` return to the `IDLE` level. Ducks to `SPEECH` under each narration beat. `DUCKING_ORIG_VOLUME` (`0.3`) is only the fallback when beats carry no placement info |
 | Duck fade | `DUCK_FADE_SECONDS` | `0.25` | ramp time for each duck transition, so the original fades down/up without clicks |
+| Duck bridge | `DUCK_BRIDGE_SECONDS` | `12` | inter-beat gaps shorter than this stay ducked (continuous bed); gaps >= this return to the idle original. Default 12 s is just above `max_narration_gap_seconds` (11 s) — lower it to let section gaps resurface sooner |
 | Background music | `BGM_PATH` / `BGM_VOLUME` / `BGM_DUCKING_VOLUME` | off / `0.18` / `0.10` | optional looped music bed mixed as its own track; point `BGM_PATH` at any audio file. It ducks to `BGM_DUCKING_VOLUME` under narration |
 | Final loudness | `FINAL_LOUDNORM` / `TARGET_LUFS` | `true` / `-14` | end-of-pipeline normalize |
 | Style | `--style` | `纪录片` | |
@@ -28,7 +29,7 @@ bundle ships no root `CLAUDE.md` (so it never collides with your project/global 
 | Scene threshold | `--scene-threshold` | `0.1` | scene-cut sensitivity |
 | VLM workers | `VLM_WORKERS` | `8` | lower to 1 if a proxy/WAF rate-limits |
 | Subtitle size | `SUBTITLE_FONT_SIZE` / `SUBTITLE_MARGIN_V` | `42` / `48` | look & placement |
-| 整理 / index | `--consolidate` / `--consolidate-asr` | off | build the understanding index (and optionally clean ASR) |
+| 整理 / index | `--no-consolidate` / `--consolidate-asr` | on | build the understanding index (and optionally clean ASR); use `--no-consolidate` to skip |
 | 剪映 export (optional) | `--export-jianying` / `EXPORT_JIANYING` | off | after rendering, also write a 剪映/JianYing draft from `timeline.json`. Decoupled — the core render never needs it |
 | 剪映 draft dir | `JIANYING_DRAFT_DIR` | work_dir | parent folder for the exported draft (point it at 剪映's drafts root to open in-app) |
 | 剪映 bundle media | `JIANYING_BUNDLE_MEDIA` / `--jianying-no-bundle-media` | **on** | copies media into the draft folder so it is self-contained. **Required on macOS** — 剪映 is sandboxed and cannot read external paths, so an unbundled draft opens with all media offline. Use `--jianying-no-bundle-media` only if 剪映 can reach the original paths |

--- a/skills/video-recap/references/timeline-and-jianying.md
+++ b/skills/video-recap/references/timeline-and-jianying.md
@@ -36,8 +36,9 @@ inspection and what the **optional** 剪映 exporter consumes. Times are plain
 - **video** — the source clip(s). In cut mode (with explicit `--source-video`)
   each `clip_plan` entry references the real source range; otherwise a single clip
   spans the rendered input. The clip's `audio` carries the **original-audio ducking
-  automation** (gap-fill: held at `base_gain` between sentences, dipped under each
-  narration window).
+  automation** (continuous bed: dipped under each narration beat; inter-beat gaps shorter
+  than `duck_bridge_seconds` stay ducked — no swell back to `base_gain` between sentences;
+  only lead-in, lead-out, and genuine gaps >= `duck_bridge_seconds` return to `base_gain`).
 - **narration** — the placed TTS beats, one segment each.
 - **bgm** — present only with `BGM_PATH`; a looped bed with its own ducking automation.
 - **subtitle** — the narration lines.

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -224,6 +224,12 @@ def main():
         cont = _continuation_command(video, work_dir, args)
         print("=" * 50)
         need = f"{narration_json}" + (f" 和 {clip_plan_json}" if cut else "")
+        # The brief fires a research directive only when the substrate is thin/empty and no
+        # background_research.json exists yet. Amplify it here so the agent researches the
+        # title BEFORE writing, instead of shipping cold "看图说话".
+        if brief.exists() and "Research the story FIRST" in brief.read_text(encoding="utf-8"):
+            print("[video-recap] ⚑ 理解素材偏薄：先按 brief 顶部「Research the story FIRST」调研并写 "
+                  "background_research.json，再写解说，避免看图说话。")
         print(f"[video-recap] ⏸  阅读 {brief}（按 video-script 规则）后写入 {need}")
         print(f"[video-recap]    写完后重跑继续: {cont}")
         print("=" * 50)

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -23,6 +23,7 @@ from pathlib import Path
 BUNDLE = Path(__file__).resolve().parents[2]  # the skills/ directory
 RUN_MANIFEST = "recap_run_manifest.json"
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
+PHASE_LEDGER = "recap_phase.json"
 
 
 def _entry(skill, script):
@@ -119,6 +120,45 @@ def _read_assembly_output(work_dir):
     if isinstance(manifest, dict) and manifest.get("final_output"):
         return Path(manifest["final_output"])
     return None
+
+
+def _file_md5(path):
+    path = Path(path)
+    return hashlib.md5(path.read_bytes()).hexdigest() if path.exists() else None
+
+
+def _read_phase_ledger(work_dir):
+    """Phase ledger (cut mode): which artifacts exist and the clip_plan/narration they match.
+
+    Lets resume be driven by recorded phase state rather than bare file existence — the
+    prerequisite for the cut-first/narrate-second two-pause flow, and the guard that keeps a
+    narration written for one clip_plan from silently driving a different cut into TTS.
+    """
+    ledger = _load_json(Path(work_dir) / PHASE_LEDGER)
+    return ledger if isinstance(ledger, dict) else None
+
+
+def _write_phase_ledger(work_dir, **fields):
+    ledger = _read_phase_ledger(work_dir) or {}
+    ledger.update(fields)
+    (Path(work_dir) / PHASE_LEDGER).write_text(
+        json.dumps(ledger, ensure_ascii=False, indent=2), encoding="utf-8")
+    return ledger
+
+
+def _cut_narration_is_stale(ledger, current_clip_plan_fp, current_narration_fp):
+    """Stale iff the clip_plan changed since the ledger was written but the narration did NOT
+    — i.e. the agent re-cut without re-writing the narration, so it describes the old cut.
+    If BOTH changed (narration re-authored for the new clips) it is fresh."""
+    if not ledger:
+        return False
+    recorded_cp = ledger.get("clip_plan_fingerprint")
+    recorded_narr = ledger.get("narration_fingerprint")
+    return bool(
+        recorded_cp is not None
+        and recorded_cp != current_clip_plan_fp
+        and recorded_narr == current_narration_fp
+    )
 
 
 def _continuation_command(video, work_dir, args):
@@ -249,6 +289,16 @@ def main():
             f"  - {details}"
         )
     if cut:
+        # Phase ledger: refuse to drive a stale narration (written for a previous clip_plan)
+        # into the cut/TTS. If clip_plan changed but narration did not, it describes the old cut.
+        cp_fp = _file_md5(clip_plan_json)
+        narr_fp = _file_md5(narration_json)
+        if _cut_narration_is_stale(_read_phase_ledger(work_dir), cp_fp, narr_fp):
+            raise SystemExit(
+                "clip_plan.json 已改变，但 narration.json 没有相应更新：解说仍是对旧剪辑写的，"
+                "会与剪后画面对不上。请按新的保留片段重写 narration.json（或删除它重新进入暂停）。")
+        _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp,
+                            narration_fingerprint=narr_fp, narration_written=True)
         # Normalize the clip plan FIRST (cheap, no render) so validate lints the SAME
         # padded/pruned clips the mapper uses — otherwise validate sees the raw plan and
         # can pass a beat the mapper later silently drops.

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -146,19 +146,14 @@ def _write_phase_ledger(work_dir, **fields):
     return ledger
 
 
-def _cut_narration_is_stale(ledger, current_clip_plan_fp, current_narration_fp):
-    """Stale iff the clip_plan changed since the ledger was written but the narration did NOT
-    — i.e. the agent re-cut without re-writing the narration, so it describes the old cut.
-    If BOTH changed (narration re-authored for the new clips) it is fresh."""
+def _cut_narration_is_stale(ledger, current_clip_plan_fp):
+    """Two-pass cut: the narration is authored against the rendered cut shown at the A2 pause,
+    i.e. against the clip_plan recorded in the ledger. If clip_plan changed since (a re-cut)
+    while that narration is still present, it describes the OLD cut — stale."""
     if not ledger:
         return False
     recorded_cp = ledger.get("clip_plan_fingerprint")
-    recorded_narr = ledger.get("narration_fingerprint")
-    return bool(
-        recorded_cp is not None
-        and recorded_cp != current_clip_plan_fp
-        and recorded_narr == current_narration_fp
-    )
+    return bool(recorded_cp is not None and recorded_cp != current_clip_plan_fp)
 
 
 def _continuation_command(video, work_dir, args):
@@ -243,9 +238,9 @@ def main():
     narration_json = work_dir / "narration.json"
     clip_plan_json = work_dir / "clip_plan.json"
 
-    need_script = not narration_json.exists() or (cut and not clip_plan_json.exists())
-    if need_script:
-        # Phase A: understand -> brief, then pause for the agent to write narration.json (+ clip_plan.json)
+    edited_source = work_dir / "edited_source.mp4"
+
+    def _understand():
         uargs = [str(video), "--work-dir", str(work_dir), "--style", args.style]
         if args.context:
             uargs += ["--context", args.context]
@@ -263,61 +258,71 @@ def main():
         if args.consolidate_asr:
             uargs.append("--consolidate-asr")
         _run("video-understanding", "understand.py", *uargs)
-        _write_run_manifest(work_dir, video, args)
+
+    def _pause(need_text):
         brief = work_dir / "agent_narration_brief.md"
         cont = _continuation_command(video, work_dir, args)
         print("=" * 50)
-        need = f"{narration_json}" + (f" 和 {clip_plan_json}" if cut else "")
         # The brief fires a research directive only when the substrate is thin/empty and no
-        # background_research.json exists yet. Amplify it here so the agent researches the
-        # title BEFORE writing, instead of shipping cold "看图说话".
+        # background_research.json exists yet; amplify it so the agent researches BEFORE writing.
         if brief.exists() and "Research the story FIRST" in brief.read_text(encoding="utf-8"):
             print("[video-recap] ⚑ 理解素材偏薄：先按 brief 顶部「Research the story FIRST」调研并写 "
                   "background_research.json，再写解说，避免看图说话。")
-        print(f"[video-recap] ⏸  阅读 {brief}（按 video-script 规则）后写入 {need}")
+        print(f"[video-recap] ⏸  阅读 {brief}（按 video-script 规则）后写入 {need_text}")
         print(f"[video-recap]    写完后重跑继续: {cont}")
         print("=" * 50)
-        return
 
-    # Phase B: produce
-    mismatches = _manifest_mismatches(work_dir, video, args)
-    if mismatches:
-        details = "\n  - ".join(mismatches)
-        raise SystemExit(
-            "work_dir 与当前 recap 输入不匹配，拒绝复用既有 narration/clip_plan；"
-            "请使用新的 --work-dir，或删除旧产物后重新运行 Phase A。\n"
-            f"  - {details}"
-        )
-    if cut:
-        # Phase ledger: refuse to drive a stale narration (written for a previous clip_plan)
-        # into the cut/TTS. If clip_plan changed but narration did not, it describes the old cut.
-        cp_fp = _file_md5(clip_plan_json)
-        narr_fp = _file_md5(narration_json)
-        if _cut_narration_is_stale(_read_phase_ledger(work_dir), cp_fp, narr_fp):
+    def _reject_stale_manifest():
+        mismatches = _manifest_mismatches(work_dir, video, args)
+        if mismatches:
+            details = "\n  - ".join(mismatches)
             raise SystemExit(
-                "clip_plan.json 已改变，但 narration.json 没有相应更新：解说仍是对旧剪辑写的，"
-                "会与剪后画面对不上。请按新的保留片段重写 narration.json（或删除它重新进入暂停）。")
-        _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp,
-                            narration_fingerprint=narr_fp, narration_written=True)
-        # Normalize the clip plan FIRST (cheap, no render) so validate lints the SAME
-        # padded/pruned clips the mapper uses — otherwise validate sees the raw plan and
-        # can pass a beat the mapper later silently drops.
-        ncargs = [str(video), "--work-dir", str(work_dir), "--normalize-only"]
-        if args.target_duration:
-            ncargs += ["--target-duration", args.target_duration]
-        _run("video-cut", "cut.py", *ncargs)
-    _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", args.edit_mode)
-    assemble_video_path = video
-    if cut:
-        cargs = [str(video), "--work-dir", str(work_dir)]
-        if args.target_duration:
-            cargs += ["--target-duration", args.target_duration]
-        if args.allow_sparse_cut:
-            cargs.append("--allow-sparse-cut")
-        _run("video-cut", "cut.py", *cargs)
-        assemble_video_path = work_dir / "edited_source.mp4"
+                "work_dir 与当前 recap 输入不匹配，拒绝复用既有 narration/clip_plan；"
+                "请使用新的 --work-dir，或删除旧产物后重新运行 Phase A。\n"
+                f"  - {details}")
 
-    narration_for_tts = work_dir / ("narration_mapped.json" if cut else "narration.json")
+    if not cut:
+        # Full mode: a single pause (understand -> agent writes narration.json -> produce).
+        if not narration_json.exists():
+            _understand()
+            _write_run_manifest(work_dir, video, args)
+            _pause(f"{narration_json}")
+            return
+        _reject_stale_manifest()
+        _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", "full")
+        narration_for_tts = narration_json
+        assemble_video_path = video
+    else:
+        # Cut mode: cut-first / narrate-second (two pauses), so narration is authored against the
+        # REAL output timeline — map_narration_to_clips is never used and cannot drop/clamp/desync.
+        if not clip_plan_json.exists():
+            # PASS 1: understand -> agent writes clip_plan.json ONLY.
+            _understand()
+            _write_run_manifest(work_dir, video, args)
+            _pause(f"{clip_plan_json}（只写剪辑计划；解说下一步对着剪好的成片写）")
+            return
+        _reject_stale_manifest()
+        cp_fp = _file_md5(clip_plan_json)
+        # Render the cut from clip_plan (no narration mapping — narration is OUTPUT-time).
+        crender = [str(video), "--work-dir", str(work_dir), "--no-narration-map"]
+        if args.target_duration:
+            crender += ["--target-duration", args.target_duration]
+        _run("video-cut", "cut.py", *crender)
+        if not narration_json.exists():
+            # PASS 2: rebuild the brief (now an OUTPUT-timeline variant) and pause for narration.
+            _understand()
+            _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp, edited_source_rendered=True)
+            _pause(f"{narration_json}（用成片 OUTPUT 时间轴写解说，对着 {edited_source}）")
+            return
+        if _cut_narration_is_stale(_read_phase_ledger(work_dir), cp_fp):
+            raise SystemExit(
+                "clip_plan.json 已改变，但 narration.json 仍是对旧剪辑写的，会与剪后画面对不上。"
+                "请删除 narration.json，重跑后按新成片重新写解说。")
+        _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp,
+                            narration_fingerprint=_file_md5(narration_json), narration_written=True)
+        _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", "cut_output")
+        narration_for_tts = narration_json
+        assemble_video_path = edited_source
     vargs = ["--work-dir", str(work_dir), "--narration", str(narration_for_tts)]
     if args.mimo_tts_voice:
         vargs += ["--mimo-voice", args.mimo_tts_voice]

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -86,6 +86,20 @@ def _load_json(path):
         return None
 
 
+def _settings_for_compare(settings):
+    """Settings that, if changed, invalidate reusing an existing work_dir on resume.
+
+    `consolidate`/`consolidate_asr` are EXCLUDED: they only ADD an optional understanding
+    artifact and never re-run Phase A on a Phase-B resume, so a stored manifest carrying the
+    old default (or missing the key entirely, pre-dating it) must still resume — otherwise
+    flipping `--consolidate`'s default ON would hard-fail every in-flight work_dir.
+    """
+    s = dict(settings or {})
+    s.pop("consolidate", None)
+    s.pop("consolidate_asr", None)
+    return s
+
+
 def _manifest_mismatches(work_dir, video, args):
     expected = _run_manifest_payload(video, args)
     actual = _load_run_manifest(work_dir)
@@ -95,7 +109,7 @@ def _manifest_mismatches(work_dir, video, args):
     for key in ("source_video", "source_video_fingerprint"):
         if actual.get(key) != expected.get(key):
             mismatches.append(f"{key}: expected {expected.get(key)!r}, got {actual.get(key)!r}")
-    if actual.get("settings") != expected.get("settings"):
+    if _settings_for_compare(actual.get("settings")) != _settings_for_compare(expected.get("settings")):
         mismatches.append("settings: 当前 CLI/env 参数与 Phase A manifest 不匹配")
     return mismatches
 
@@ -123,8 +137,8 @@ def _continuation_command(video, work_dir, args):
         parts.append("--skip-asr")
     if args.mimo_video_overview:
         parts.append("--mimo-video-overview")
-    if args.consolidate:
-        parts.append("--consolidate")
+    if not args.consolidate:  # default is ON now; only the opt-out needs to round-trip
+        parts.append("--no-consolidate")
     if args.consolidate_asr:
         parts.append("--consolidate-asr")
     if getattr(args, "mimo_tts_voice", None):
@@ -155,7 +169,8 @@ def main():
     ap.add_argument("--target-duration", default=os.environ.get("TARGET_DURATION") or None)
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
-    ap.add_argument("--consolidate", action="store_true", help="build understanding index (Pass B)")
+    ap.add_argument("--consolidate", action=argparse.BooleanOptionalAction, default=True,
+                    help="build the understanding story index (Pass B); default ON, --no-consolidate to skip")
     ap.add_argument("--consolidate-asr", action="store_true", help="also clean ASR (Pass A)")
     ap.add_argument("--mimo-tts-voice", default=None, help="MiMo TTS voice")
     ap.add_argument("--allow-partial-tts", action="store_true",
@@ -200,8 +215,7 @@ def main():
             uargs.append("--skip-asr")
         if args.mimo_video_overview:
             uargs.append("--mimo-video-overview")
-        if args.consolidate:
-            uargs.append("--consolidate")
+        uargs.append("--consolidate" if args.consolidate else "--no-consolidate")
         if args.consolidate_asr:
             uargs.append("--consolidate-asr")
         _run("video-understanding", "understand.py", *uargs)

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -133,6 +133,8 @@ def _continuation_command(video, work_dir, args):
         parts += ["--edit-mode", args.edit_mode]
     if args.target_duration:
         parts += ["--target-duration", args.target_duration]
+    if getattr(args, "allow_sparse_cut", False):
+        parts.append("--allow-sparse-cut")
     if args.skip_asr:
         parts.append("--skip-asr")
     if args.mimo_video_overview:
@@ -167,6 +169,8 @@ def main():
     ap.add_argument("--style", default="纪录片")
     ap.add_argument("--edit-mode", default=os.environ.get("EDIT_MODE", "full"), choices=["full", "cut"])
     ap.add_argument("--target-duration", default=os.environ.get("TARGET_DURATION") or None)
+    ap.add_argument("--allow-sparse-cut", action="store_true",
+                    help="cut mode: accept a sparse/heavily-dropped narration mapping instead of failing the cut preflight")
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
     ap.add_argument("--consolidate", action=argparse.BooleanOptionalAction, default=True,
@@ -244,12 +248,22 @@ def main():
             "请使用新的 --work-dir，或删除旧产物后重新运行 Phase A。\n"
             f"  - {details}"
         )
+    if cut:
+        # Normalize the clip plan FIRST (cheap, no render) so validate lints the SAME
+        # padded/pruned clips the mapper uses — otherwise validate sees the raw plan and
+        # can pass a beat the mapper later silently drops.
+        ncargs = [str(video), "--work-dir", str(work_dir), "--normalize-only"]
+        if args.target_duration:
+            ncargs += ["--target-duration", args.target_duration]
+        _run("video-cut", "cut.py", *ncargs)
     _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", args.edit_mode)
     assemble_video_path = video
     if cut:
         cargs = [str(video), "--work-dir", str(work_dir)]
         if args.target_duration:
             cargs += ["--target-duration", args.target_duration]
+        if args.allow_sparse_cut:
+            cargs.append("--allow-sparse-cut")
         _run("video-cut", "cut.py", *cargs)
         assemble_video_path = work_dir / "edited_source.mp4"
 

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1309,25 +1309,24 @@ def _parse_target_seconds(value):
 
 
 def _format_research_directive(work_dir, substrate):
-    """A loud, actionable research-first directive when the agent has a title/context but
-    no background_research.json, or when the substrate is too thin to write real commentary.
+    """A loud, actionable research-first directive — but ONLY when the substrate is too thin
+    for real commentary (no dialogue/story spine) and no background_research.json exists yet.
 
-    The narration's quality ceiling is how much story context the agent has: with only
-    frame descriptions it can only narrate pixels. This pushes the agent to research the
-    title first (see references/research-guide.md) instead of silently writing 看图说话.
+    The narration's quality ceiling is how much story context the agent has: with only frame
+    descriptions it can only narrate pixels, so research the title FIRST (see
+    references/research-guide.md). Fires only for thin/empty substrate — NOT merely because a
+    title was given — so a dialogue-rich titled run is never nagged.
     """
     if (Path(work_dir) / "background_research.json").exists():
         return []  # already researched; _format_background_research surfaces it
+    if not (substrate and substrate.get("level") in ("thin", "empty")):
+        return []  # rich enough to write from dialogue/spine; do not nag
     context = str(CONFIG.get("context_info") or "").strip()
-    thin = substrate.get("level") in ("thin", "empty") if substrate else False
-    if not context and not thin:
-        return []
-    why = "the substrate is thin" if thin else "you have a title/context but no background_research.json"
     return [
         "## ⚑ Research the story FIRST (do this before writing narration)",
         "",
-        f"Reason: {why}. Engaging recap commentary (motive, stakes, relationships) needs story",
-        "context the frames alone do not carry — without it the narration can only describe pixels.",
+        "Reason: the understanding substrate is thin — no dialogue/story spine, only frame",
+        "descriptions, so without research the narration can only describe pixels.",
         "1. Pull the title/keywords from `--context`, the filename, or the user's description"
         + (f" (context: {context})." if context else "."),
         "2. Use any available web-search/browser tool to look up synopsis, characters, and",

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -547,7 +547,7 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
         if spm and spm < min_spm:
             warnings.append(_lint_issue(
                 "warning", None, "low_density",
-                "Narration density is below the continuous-bed target; add more short beats",
+                "Narration density is below the continuous-bed guide; add beats only where they add meaning, never filler",
                 segments_per_minute=round(spm, 2), min_segments_per_minute=min_spm,
                 target_segments_per_minute=target_spm,
             ))
@@ -1387,7 +1387,9 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         )
     else:
         lines.append(
-            f"- Narration density target: ~{target_spm:.1f} segments/min (minimum {min_spm:.1f}); no gap longer than {max_gap:.0f}s"
+            f"- Narration density: aim for ~{target_spm:.1f} beats/min for the continuous-bed feel "
+            f"(min ~{min_spm:.1f}, no silent gap over {max_gap:.0f}s) — a GUIDE, not a quota: never pad with "
+            f"filler or pixel-description to hit a number; a meaningful beat beats a filler beat."
         )
     if edit_mode == "cut":
         lines.append(

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1339,6 +1339,32 @@ def _format_research_directive(work_dir, substrate):
     ]
 
 
+def _format_output_clip_list(work_dir):
+    """List the kept clips on the OUTPUT timeline (cut-first/narrate-second pass 2), so the
+    agent narrates against the real rendered cut instead of the source timeline."""
+    path = Path(work_dir) / "clip_plan_validated.json"
+    if not path.exists():
+        return []
+    try:
+        plan = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return []
+    clips = (plan.get("clips") if isinstance(plan, dict) else plan) or []
+    out = ["## Kept clips on the OUTPUT timeline", ""]
+    for c in clips:
+        if not isinstance(c, dict):
+            continue
+        try:
+            os_, oe = float(c.get("output_start")), float(c.get("output_end"))
+            ss, se = float(c.get("source_start")), float(c.get("source_end"))
+        except (TypeError, ValueError):
+            continue
+        reason = str(c.get("reason", "")).strip()
+        out.append(f"- output {os_:.1f}–{oe:.1f}s ← source {ss:.1f}–{se:.1f}s" + (f" — {reason}" if reason else ""))
+    out.append("")
+    return out if len(out) > 2 else []
+
+
 def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
     """Write a compact brief that tells the agent exactly how to author recap artifacts."""
     effective_rate = CONFIG["speech_rate"] * CONFIG["speech_safety_margin"]
@@ -1432,43 +1458,47 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
 
     if edit_mode == "cut":
         cut_target_example = target_duration if target_duration != "(not set)" else "30m"
-        lines.extend([
-            "## Required files for cut mode",
-            "",
-            f"Goal: a ~{output_label} recap cut from a {source_label} source. "
-            "The narration must match the CUT output, not the full source.",
-            "First write `clip_plan.json` to choose source footage, then write `narration.json` using ORIGINAL "
-            "source timestamps that fall INSIDE those clips. The CLI concatenates the clips and maps your source "
-            "timestamps onto the shortened timeline.",
-            "",
-            "Cut-mode authoring rules:",
-            "- Size narration to the OUTPUT: aim for the cut-output beat count above, NOT one beat per source minute. "
-            "A beat whose midpoint lands outside every kept clip is DROPPED.",
-            "- Keep each beat INSIDE one clip: do not let a beat's [start, end] cross a clip boundary, or it is clipped "
-            "to that clip and the voiceover ends up describing footage that was cut away.",
-            "- Tell the story in OUTPUT order: order beats by the order their clips will play so the recap reads as one "
-            "continuous arc over the kept footage.",
-            "- If clips reuse overlapping source ranges, tag the beat with `source_clip_id` so it maps to the intended clip.",
-            "",
-            "### clip_plan.json shape",
-            "",
-            "```json",
-            "{",
-            f"  \"target_duration\": \"{cut_target_example}\",",
-            "  \"clips\": [",
-            "    {\"start\": 12.0, \"end\": 38.0, \"reason\": \"关键冲突开端\"}",
-            "  ]",
-            "}",
-            "```",
-            "",
-            "### narration.json shape (source timestamps inside the kept clips)",
-            "",
-            "```json",
-            "[",
-            "  {\"start\": 14.0, \"end\": 19.0, \"narration\": \"解说文本。\", \"pause_after_ms\": 250, \"overlaps_speech\": true}",
-            "]",
-            "```",
-        ])
+        if not (Path(work_dir) / "edited_source.mp4").exists():
+            # PASS 1 of 2 (cut-first): pick the footage. Narration comes AFTER the cut is
+            # rendered, so it can be written against the real OUTPUT timeline — no source->output
+            # mapping, no silent drop/clamp, no desync.
+            lines.extend([
+                "## Cut mode — step 1 of 2: write `clip_plan.json` ONLY",
+                "",
+                f"Goal: a ~{output_label} recap cut from a {source_label} source. First choose the footage; the CLI",
+                "then renders the cut and asks you to narrate against that real output. Do NOT write narration.json yet.",
+                "Select clips for plot causality, key dialogue, reveals, and emotional turns; avoid filler and repeats.",
+                "",
+                "### clip_plan.json shape (original source timestamps)",
+                "",
+                "```json",
+                "{",
+                f"  \"target_duration\": \"{cut_target_example}\",",
+                "  \"clips\": [",
+                "    {\"start\": 12.0, \"end\": 38.0, \"reason\": \"关键冲突开端\"}",
+                "  ]",
+                "}",
+                "```",
+            ])
+        else:
+            # PASS 2 of 2: the cut is rendered (edited_source.mp4); narrate in OUTPUT time.
+            lines.extend(_format_output_clip_list(work_dir))
+            lines.extend([
+                "## Cut mode — step 2 of 2: write `narration.json` in OUTPUT time",
+                "",
+                f"The cut is rendered as `edited_source.mp4` (~{output_label}). Write narration timed to THAT output",
+                "timeline (0 .. total), NOT the original source — your timestamps play exactly where you put them, with",
+                "no mapping and no dropping. Use the kept-clip OUTPUT ranges above to know what is on screen when, tell",
+                "one continuous arc across the cut, and aim for the density guide in the header.",
+                "",
+                "### narration.json shape (OUTPUT timestamps, 0..total)",
+                "",
+                "```json",
+                "[",
+                "  {\"start\": 2.0, \"end\": 7.0, \"narration\": \"解说文本。\", \"pause_after_ms\": 250, \"overlaps_speech\": true}",
+                "]",
+                "```",
+            ])
     else:
         lines.extend([
             "## Required JSON shape",

--- a/skills/video-script/scripts/validate.py
+++ b/skills/video-script/scripts/validate.py
@@ -52,7 +52,7 @@ def _load_cut_clip_plan(work_dir):
 def main():
     ap = argparse.ArgumentParser(description="Validate + align agent-written narration.json.")
     ap.add_argument("--work-dir", required=True)
-    ap.add_argument("--mode", default="full", choices=["full", "cut"])
+    ap.add_argument("--mode", default="full", choices=["full", "cut", "cut_output"])
     args = ap.parse_args()
 
     work_dir = Path(args.work_dir)
@@ -63,15 +63,17 @@ def main():
         raise SystemExit(f"缺少 {narration_path}；请先按 video-script 规则写解说词")
     vlm_analysis = _load(work_dir / "vlm_analysis.json")
     silence_periods = _load(work_dir / "silence_periods.json") or []
-    clip_plan = None
-    if args.mode == "cut":
+    if args.mode == "cut_output":
+        # Two-pass cut: narration is authored in OUTPUT time against edited_source.mp4 — there is
+        # no clip_plan to fall into and no source-time scene/quiet data to align to. Lint timing /
+        # budget / overlap / density on the output timeline only; never realign or rewrite it.
+        validate_narration_or_raise(narration, None, clip_plan=None, mode="full", work_dir=work_dir)
+    elif args.mode == "cut":
         clip_plan = _load_cut_clip_plan(work_dir)
-
-    validate_narration_or_raise(narration, vlm_analysis, clip_plan=clip_plan,
-                                mode=args.mode, work_dir=work_dir)
-    if args.mode == "cut":
+        validate_narration_or_raise(narration, vlm_analysis, clip_plan=clip_plan, mode="cut", work_dir=work_dir)
         narration = _validate_narration_budget(narration, vlm_analysis)
     else:
+        validate_narration_or_raise(narration, vlm_analysis, clip_plan=None, mode="full", work_dir=work_dir)
         narration = _align_narration_to_quiet(narration, vlm_analysis, silence_periods)
         narration_path.write_text(json.dumps(narration, ensure_ascii=False, indent=2), encoding="utf-8")
 

--- a/skills/video-understanding/scripts/asr.py
+++ b/skills/video-understanding/scripts/asr.py
@@ -1,5 +1,7 @@
 import base64
 import json
+import os
+import time
 from pathlib import Path
 
 from lib import CONFIG
@@ -122,9 +124,16 @@ def _segment_and_transcribe(audio_wav, segments_dir, total_duration, segment_len
     """分段转录长音频"""
     if segment_length is None:
         segment_length = max(5, int(CONFIG.get("asr_segment_seconds", 30) or 30))
+    # 长视频 ASR 是顺序调用；可选节流让调用间隔开，降低踩到集群限流的频率（默认 0=不节流）
+    try:
+        throttle = max(0.0, float(os.environ.get("ASR_THROTTLE_SECONDS", "0") or 0))
+    except ValueError:
+        throttle = 0.0
     results = []
 
     for i, start in enumerate(range(0, int(total_duration), segment_length)):
+        if throttle and i:
+            time.sleep(throttle)
         end = min(start + segment_length, total_duration)
         seg_wav = segments_dir / f"seg_{i:03d}.wav"
 

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1309,25 +1309,24 @@ def _parse_target_seconds(value):
 
 
 def _format_research_directive(work_dir, substrate):
-    """A loud, actionable research-first directive when the agent has a title/context but
-    no background_research.json, or when the substrate is too thin to write real commentary.
+    """A loud, actionable research-first directive — but ONLY when the substrate is too thin
+    for real commentary (no dialogue/story spine) and no background_research.json exists yet.
 
-    The narration's quality ceiling is how much story context the agent has: with only
-    frame descriptions it can only narrate pixels. This pushes the agent to research the
-    title first (see references/research-guide.md) instead of silently writing 看图说话.
+    The narration's quality ceiling is how much story context the agent has: with only frame
+    descriptions it can only narrate pixels, so research the title FIRST (see
+    references/research-guide.md). Fires only for thin/empty substrate — NOT merely because a
+    title was given — so a dialogue-rich titled run is never nagged.
     """
     if (Path(work_dir) / "background_research.json").exists():
         return []  # already researched; _format_background_research surfaces it
+    if not (substrate and substrate.get("level") in ("thin", "empty")):
+        return []  # rich enough to write from dialogue/spine; do not nag
     context = str(CONFIG.get("context_info") or "").strip()
-    thin = substrate.get("level") in ("thin", "empty") if substrate else False
-    if not context and not thin:
-        return []
-    why = "the substrate is thin" if thin else "you have a title/context but no background_research.json"
     return [
         "## ⚑ Research the story FIRST (do this before writing narration)",
         "",
-        f"Reason: {why}. Engaging recap commentary (motive, stakes, relationships) needs story",
-        "context the frames alone do not carry — without it the narration can only describe pixels.",
+        "Reason: the understanding substrate is thin — no dialogue/story spine, only frame",
+        "descriptions, so without research the narration can only describe pixels.",
         "1. Pull the title/keywords from `--context`, the filename, or the user's description"
         + (f" (context: {context})." if context else "."),
         "2. Use any available web-search/browser tool to look up synopsis, characters, and",

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -547,7 +547,7 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
         if spm and spm < min_spm:
             warnings.append(_lint_issue(
                 "warning", None, "low_density",
-                "Narration density is below the continuous-bed target; add more short beats",
+                "Narration density is below the continuous-bed guide; add beats only where they add meaning, never filler",
                 segments_per_minute=round(spm, 2), min_segments_per_minute=min_spm,
                 target_segments_per_minute=target_spm,
             ))
@@ -1387,7 +1387,9 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         )
     else:
         lines.append(
-            f"- Narration density target: ~{target_spm:.1f} segments/min (minimum {min_spm:.1f}); no gap longer than {max_gap:.0f}s"
+            f"- Narration density: aim for ~{target_spm:.1f} beats/min for the continuous-bed feel "
+            f"(min ~{min_spm:.1f}, no silent gap over {max_gap:.0f}s) — a GUIDE, not a quota: never pad with "
+            f"filler or pixel-description to hit a number; a meaningful beat beats a filler beat."
         )
     if edit_mode == "cut":
         lines.append(

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1339,6 +1339,32 @@ def _format_research_directive(work_dir, substrate):
     ]
 
 
+def _format_output_clip_list(work_dir):
+    """List the kept clips on the OUTPUT timeline (cut-first/narrate-second pass 2), so the
+    agent narrates against the real rendered cut instead of the source timeline."""
+    path = Path(work_dir) / "clip_plan_validated.json"
+    if not path.exists():
+        return []
+    try:
+        plan = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return []
+    clips = (plan.get("clips") if isinstance(plan, dict) else plan) or []
+    out = ["## Kept clips on the OUTPUT timeline", ""]
+    for c in clips:
+        if not isinstance(c, dict):
+            continue
+        try:
+            os_, oe = float(c.get("output_start")), float(c.get("output_end"))
+            ss, se = float(c.get("source_start")), float(c.get("source_end"))
+        except (TypeError, ValueError):
+            continue
+        reason = str(c.get("reason", "")).strip()
+        out.append(f"- output {os_:.1f}–{oe:.1f}s ← source {ss:.1f}–{se:.1f}s" + (f" — {reason}" if reason else ""))
+    out.append("")
+    return out if len(out) > 2 else []
+
+
 def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
     """Write a compact brief that tells the agent exactly how to author recap artifacts."""
     effective_rate = CONFIG["speech_rate"] * CONFIG["speech_safety_margin"]
@@ -1432,43 +1458,47 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
 
     if edit_mode == "cut":
         cut_target_example = target_duration if target_duration != "(not set)" else "30m"
-        lines.extend([
-            "## Required files for cut mode",
-            "",
-            f"Goal: a ~{output_label} recap cut from a {source_label} source. "
-            "The narration must match the CUT output, not the full source.",
-            "First write `clip_plan.json` to choose source footage, then write `narration.json` using ORIGINAL "
-            "source timestamps that fall INSIDE those clips. The CLI concatenates the clips and maps your source "
-            "timestamps onto the shortened timeline.",
-            "",
-            "Cut-mode authoring rules:",
-            "- Size narration to the OUTPUT: aim for the cut-output beat count above, NOT one beat per source minute. "
-            "A beat whose midpoint lands outside every kept clip is DROPPED.",
-            "- Keep each beat INSIDE one clip: do not let a beat's [start, end] cross a clip boundary, or it is clipped "
-            "to that clip and the voiceover ends up describing footage that was cut away.",
-            "- Tell the story in OUTPUT order: order beats by the order their clips will play so the recap reads as one "
-            "continuous arc over the kept footage.",
-            "- If clips reuse overlapping source ranges, tag the beat with `source_clip_id` so it maps to the intended clip.",
-            "",
-            "### clip_plan.json shape",
-            "",
-            "```json",
-            "{",
-            f"  \"target_duration\": \"{cut_target_example}\",",
-            "  \"clips\": [",
-            "    {\"start\": 12.0, \"end\": 38.0, \"reason\": \"关键冲突开端\"}",
-            "  ]",
-            "}",
-            "```",
-            "",
-            "### narration.json shape (source timestamps inside the kept clips)",
-            "",
-            "```json",
-            "[",
-            "  {\"start\": 14.0, \"end\": 19.0, \"narration\": \"解说文本。\", \"pause_after_ms\": 250, \"overlaps_speech\": true}",
-            "]",
-            "```",
-        ])
+        if not (Path(work_dir) / "edited_source.mp4").exists():
+            # PASS 1 of 2 (cut-first): pick the footage. Narration comes AFTER the cut is
+            # rendered, so it can be written against the real OUTPUT timeline — no source->output
+            # mapping, no silent drop/clamp, no desync.
+            lines.extend([
+                "## Cut mode — step 1 of 2: write `clip_plan.json` ONLY",
+                "",
+                f"Goal: a ~{output_label} recap cut from a {source_label} source. First choose the footage; the CLI",
+                "then renders the cut and asks you to narrate against that real output. Do NOT write narration.json yet.",
+                "Select clips for plot causality, key dialogue, reveals, and emotional turns; avoid filler and repeats.",
+                "",
+                "### clip_plan.json shape (original source timestamps)",
+                "",
+                "```json",
+                "{",
+                f"  \"target_duration\": \"{cut_target_example}\",",
+                "  \"clips\": [",
+                "    {\"start\": 12.0, \"end\": 38.0, \"reason\": \"关键冲突开端\"}",
+                "  ]",
+                "}",
+                "```",
+            ])
+        else:
+            # PASS 2 of 2: the cut is rendered (edited_source.mp4); narrate in OUTPUT time.
+            lines.extend(_format_output_clip_list(work_dir))
+            lines.extend([
+                "## Cut mode — step 2 of 2: write `narration.json` in OUTPUT time",
+                "",
+                f"The cut is rendered as `edited_source.mp4` (~{output_label}). Write narration timed to THAT output",
+                "timeline (0 .. total), NOT the original source — your timestamps play exactly where you put them, with",
+                "no mapping and no dropping. Use the kept-clip OUTPUT ranges above to know what is on screen when, tell",
+                "one continuous arc across the cut, and aim for the density guide in the header.",
+                "",
+                "### narration.json shape (OUTPUT timestamps, 0..total)",
+                "",
+                "```json",
+                "[",
+                "  {\"start\": 2.0, \"end\": 7.0, \"narration\": \"解说文本。\", \"pause_after_ms\": 250, \"overlaps_speech\": true}",
+                "]",
+                "```",
+            ])
     else:
         lines.extend([
             "## Required JSON shape",

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -403,7 +403,7 @@ def _mimo_endpoint(kind):
         "api_key_source": CONFIG.get(src_key, "MIMO_API_KEY"),
     }
 
-def _call_mimo_endpoint(kind, payload, max_retries=5):
+def _call_mimo_endpoint(kind, payload, max_retries=10):
     settings = _mimo_endpoint(kind)
     return api_call(
         payload,
@@ -414,20 +414,25 @@ def _call_mimo_endpoint(kind, payload, max_retries=5):
         api_key_source=settings["api_key_source"],
     )
 
-def mimo_video_api_call(payload, max_retries=5):
+def mimo_video_api_call(payload, max_retries=10):
     """Call the MiMo video-understanding endpoint."""
     return _call_mimo_endpoint("video", payload, max_retries=max_retries)
 
-def mimo_tts_api_call(payload, max_retries=5):
+def mimo_tts_api_call(payload, max_retries=10):
     """Call the MiMo TTS endpoint."""
     return _call_mimo_endpoint("tts", payload, max_retries=max_retries)
 
-def mimo_asr_api_call(payload, max_retries=5):
+def mimo_asr_api_call(payload, max_retries=10):
     """Call the MiMo speech-recognition (ASR) endpoint."""
     return _call_mimo_endpoint("asr", payload, max_retries=max_retries)
 
-def api_call(payload, max_retries=5, *, api_provider=None, api_url=None, api_key=None, api_key_source=None):
-    """调用 OpenAI-compatible API，带重试"""
+def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key=None, api_key_source=None):
+    """调用 OpenAI-compatible API，带重试。
+
+    长视频理解会发出数百次 VLM/ASR 调用，集群的 429 限流是常态而非错误，所以重试更耐心
+    （更多次数 + 退避封顶 60s + 遵从 Retry-After），避免一次瞬时限流就中止整段理解。
+    集群的配额窗口常以分钟计，所以 429 在没有 Retry-After 时也至少等 10s，给窗口时间复位。
+    """
     endpoint = normalize_api_url(api_url if api_url is not None else CONFIG["api_url"])
     headers = _api_headers(api_provider=api_provider, api_url=endpoint, api_key=api_key)
     data = json.dumps(_prepare_api_payload(payload, api_provider=api_provider, api_url=endpoint)).encode("utf-8")
@@ -440,10 +445,10 @@ def api_call(payload, max_retries=5, *, api_provider=None, api_url=None, api_key
                 return result
         except urllib.error.HTTPError as e:
             body = e.read().decode("utf-8", errors="replace")[:500]
-            wait = 2 ** attempt
+            wait = min(2 ** attempt, 60)
             if e.code == 429:
                 retry_after = e.headers.get("Retry-After")
-                wait = _retry_after_seconds(retry_after, wait)
+                wait = _retry_after_seconds(retry_after, max(wait, 10))
                 log(f"API 速率限制 (尝试 {attempt+1}/{max_retries}), 等待 {wait}s")
             elif e.code == 401:
                 key_name = api_key_source or CONFIG.get("api_key_source", "MIMO_API_KEY")
@@ -470,7 +475,7 @@ def api_call(payload, max_retries=5, *, api_provider=None, api_url=None, api_key
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: HTTP {e.code} — {body}")
         except (urllib.error.URLError, Exception) as e:
-            wait = 2 ** attempt
+            wait = min(2 ** attempt, 60)
             log(f"API 调用失败 (尝试 {attempt+1}/{max_retries}): {e}")
             if attempt < max_retries - 1:
                 log(f"等待 {wait}s 后重试...")

--- a/skills/video-understanding/scripts/understand.py
+++ b/skills/video-understanding/scripts/understand.py
@@ -253,7 +253,8 @@ def main():
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
     ap.add_argument("--force", action="store_true", help="ignore cached artifacts and recompute")
-    ap.add_argument("--consolidate", action="store_true", help="build the global understanding index (Pass B)")
+    ap.add_argument("--consolidate", action=argparse.BooleanOptionalAction, default=True,
+                    help="build the global understanding story index (Pass B); default ON, --no-consolidate to skip")
     ap.add_argument("--consolidate-asr", action="store_true", help="also clean the ASR transcript (Pass A)")
     args = ap.parse_args()
 

--- a/skills/video-voiceover/SKILL.md
+++ b/skills/video-voiceover/SKILL.md
@@ -5,7 +5,8 @@ description: >
  Synthesize Chinese narration audio (TTS voiceover) from a timestamped narration.json.
  Use to turn a written narration script into per-segment speech audio, with MiMo TTS
  (mimo-v2.5-tts), dynamic speed fitting, and loudness handling. Part of the video-recap bundle:
- consumes narration.json (or an explicit narration_mapped.json), produces tts_segments + tts_meta.json.
+ consumes narration.json (output-timeline time), produces tts_segments + tts_meta.json.
+ In the legacy direct-cut path, narration_mapped.json may be passed explicitly instead.
  触发词: 配音, 语音合成, TTS, 解说配音, voiceover, text to speech, 旁白配音.
 ---
 
@@ -23,9 +24,11 @@ export MIMO_API_KEY=***         # MiMo TTS (or a TTS-specific MIMO_TTS_API_KEY)
 
 ## Input contract
 
-`work_dir/narration.json` (or an explicit `work_dir/narration_mapped.json` in cut mode) — segments with
-`start` / `end` / `narration` (+ optional `pause_after_ms`, `overlaps_speech`). Times are the
-**output-timeline** seconds the audio will be placed at.
+`work_dir/narration.json` — segments with `start` / `end` / `narration` (+ optional `pause_after_ms`,
+`overlaps_speech`). Times are the **output-timeline** seconds the audio will be placed at.
+In the orchestrated cut-mode flow, the agent writes `narration.json` directly against the output
+timeline, and the orchestrator passes it here. In the legacy direct-cut path,
+`narration_mapped.json` may be passed explicitly instead.
 
 ## Run
 
@@ -34,8 +37,8 @@ python3 scripts/voiceover.py --work-dir <work_dir> --narration <narration.json> 
 ```
 
 For direct one-off use, omitting `--narration` reads `work_dir/narration.json`.
-Pass `--narration work_dir/narration_mapped.json` explicitly for cut-mode output;
-the video-recap orchestrator always passes the intended file.
+Pass `--narration work_dir/narration_mapped.json` explicitly only for the legacy direct-cut path;
+the video-recap orchestrator always passes `narration.json`.
 
 ## Output contract
 

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -449,6 +449,7 @@ def test_build_audio_filter_complex_gap_fill_envelope(monkeypatch):
     monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
     monkeypatch.setitem(CONFIG, "zone_ducking_volume", 0.12)
     monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "duck_bridge_seconds", 0.5)  # keep the 3s gap unbridged so each beat keeps its own level
     fc = _build_audio_filter_complex([
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
         {"actual_place_start": 5.0, "actual_place_end": 7.0, "overlaps_speech": False},
@@ -464,8 +465,8 @@ def test_build_audio_filter_complex_gap_fill_envelope(monkeypatch):
 
 def test_build_audio_filter_complex_all_overlap_still_fills_gaps(monkeypatch):
     # Regression: all-overlap beats used to fall back to a constant duck, leaving the
-    # original quiet across the whole video (dead air between sentences). Now the
-    # original swells back to idle in the gaps and only ducks under each beat.
+    # original quiet across the whole video (dead air). A single beat ducks only under its
+    # own window; the lead-in/out around it still swells back to idle.
     monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
     monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
     monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
@@ -477,6 +478,75 @@ def test_build_audio_filter_complex_all_overlap_still_fills_gaps(monkeypatch):
     assert "min(t-0.00,2.00-t)/0.25" in fc            # ducks only under the narration window
     assert "eval=frame" in fc
     assert fc.endswith("[aout]")
+
+
+def test_build_audio_filter_complex_bridges_short_gaps(monkeypatch):
+    # The fix: beats separated by a gap smaller than duck_bridge_seconds stay ducked across
+    # the gap (one held span) so the source dialogue does not pop back up between sentences.
+    monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
+    monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "duck_bridge_seconds", 6.0)
+    fc = _build_audio_filter_complex([
+        {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
+        {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": True},  # gap 2.0 < 6.0
+    ])
+    assert "min(t-0.00,6.00-t)/0.25" in fc            # one held duck across both beats + the gap
+    assert "min(t-0.00,2.00-t)" not in fc             # NOT two separate dips
+    assert "min(t-4.00,6.00-t)" not in fc
+    assert fc.count("(-0.650)") == 1                  # a single coalesced duck term
+
+
+def test_build_audio_filter_complex_releases_long_gaps(monkeypatch):
+    # A genuine gap >= duck_bridge_seconds still releases the original to idle so the
+    # picture can breathe (e.g. a deliberate long pause between sections).
+    monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
+    monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "duck_bridge_seconds", 6.0)
+    fc = _build_audio_filter_complex([
+        {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
+        {"actual_place_start": 10.0, "actual_place_end": 12.0, "overlaps_speech": True},  # gap 8.0 >= 6.0
+    ])
+    assert "min(t-0.00,2.00-t)/0.25" in fc            # two separate dips with idle between
+    assert "min(t-10.00,12.00-t)/0.25" in fc
+    assert fc.count("(-0.650)") == 2
+
+
+def test_build_audio_filter_complex_bridged_mixed_levels_flatten_to_min(monkeypatch):
+    # A bridged span mixing a speech beat (0.2) and a quiet beat (0.12) flattens to the MIN
+    # level across the span — matching variable_ducking_keyframes so the 剪映 draft == the mp4.
+    monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(CONFIG, "idle_orig_volume", 0.85)
+    monkeypatch.setitem(CONFIG, "speech_ducking_volume", 0.2)
+    monkeypatch.setitem(CONFIG, "zone_ducking_volume", 0.12)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "duck_bridge_seconds", 6.0)
+    fc = _build_audio_filter_complex([
+        {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},   # 0.2
+        {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": False},  # 0.12, gap 2 < 6
+    ])
+    assert "min(t-0.00,6.00-t)/0.25" in fc            # one coalesced span across both beats
+    assert "(-0.730)" in fc                           # held at the MIN level (0.12)
+    assert "(-0.650)" not in fc                       # NOT the speech level (0.2)
+
+
+def test_build_audio_filter_complex_bgm_envelope_bridges_short_gaps(monkeypatch):
+    # The BGM bed bridges the same way: two beats within the bridge coalesce to one BGM dip.
+    monkeypatch.setitem(CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(CONFIG, "bgm_volume", 0.18)
+    monkeypatch.setitem(CONFIG, "bgm_ducking_volume", 0.10)
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "duck_bridge_seconds", 6.0)
+    fc = _build_audio_filter_complex([
+        {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
+        {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": True},  # gap 2 < 6
+    ], has_bgm=True)
+    bgm_part = fc.split("[bgm]")[0]                    # the bgm chain comes first
+    assert "min(t-0.00,6.00-t)/0.25" in bgm_part      # one coalesced BGM dip across both beats
+    assert "min(t-0.00,2.00-t)" not in bgm_part
 
 
 def test_build_audio_filter_complex_all_quiet_ducks_to_zone(monkeypatch):

--- a/tests/assemble/test_timeline.py
+++ b/tests/assemble/test_timeline.py
@@ -38,6 +38,45 @@ def test_ducking_keyframes_preserves_real_gaps():
     assert gains[3.0] == 0.2 and gains[7.0] == 0.2       # ducked under each beat
 
 
+def test_ducking_keyframes_bridge_param_holds_across_wider_gaps():
+    # an explicit bridge holds the duck across a gap that the default 2*fade would release:
+    # the two beats coalesce into one held span [2,8], so no keyframe inside swells to idle.
+    kfs = ducking_keyframes([(2.0, 3.0), (7.0, 8.0)], idle=0.85, duck=0.2,
+                            fade=0.25, span_start=0.0, span_end=10.0, bridge=6.0)
+    held = [k["gain"] for k in kfs if 2.0 <= k["t"] <= 8.0]
+    assert held and all(g == 0.2 for g in held), "duck held across the bridged gap (no idle inside)"
+    gains = {round(k["t"], 2): k["gain"] for k in kfs}
+    assert gains[2.0] == 0.2 and gains[8.0] == 0.2
+
+
+def test_variable_ducking_bridges_gaps_below_bridge():
+    # original-audio automation: a 3s gap with bridge=6 coalesces into one held span [2,9],
+    # so no keyframe inside swells back to idle.
+    kfs = variable_ducking_keyframes([(2.0, 4.0, 0.2), (7.0, 9.0, 0.2)], idle=0.85,
+                                     fade=0.25, span_start=0.0, span_end=12.0, bridge=6.0)
+    held = [k["gain"] for k in kfs if 2.0 <= k["t"] <= 9.0]
+    assert held and all(g == 0.2 for g in held), "duck held across the bridged gap (no idle inside)"
+    gains = {round(k["t"], 2): k["gain"] for k in kfs}
+    assert gains[2.0] == 0.2 and gains[9.0] == 0.2
+
+
+def test_variable_ducking_releases_gaps_at_or_above_bridge():
+    # the same 3s gap with bridge=2 releases the original back to idle.
+    kfs = variable_ducking_keyframes([(2.0, 4.0, 0.2), (7.0, 9.0, 0.2)], idle=0.85,
+                                     fade=0.25, span_start=0.0, span_end=12.0, bridge=2.0)
+    assert any(k["gain"] == 0.85 for k in kfs if 4.0 < k["t"] < 7.0), "long gap must swell to idle"
+
+
+def test_variable_ducking_mixed_levels_coalesce_to_min_like_render():
+    # Render/draft consistency: a bridged span mixing a speech beat (0.2) and a quiet beat
+    # (0.12) must flatten to the MIN level across the whole span, exactly as the ffmpeg render
+    # coalesces it — otherwise the 剪映 draft would play the original louder than the mp4.
+    kfs = variable_ducking_keyframes([(0.0, 2.0, 0.2), (4.0, 6.0, 0.12)], idle=0.85,
+                                     fade=0.25, span_start=0.0, span_end=8.0, bridge=6.0)
+    held = [k["gain"] for k in kfs if 0.0 <= k["t"] <= 6.0]
+    assert held and all(g == 0.12 for g in held), "mixed bridged span holds at the min (0.12)"
+
+
 def test_build_timeline_has_all_tracks():
     canvas = {"width": 1280, "height": 720, "fps": 25}
     video = [{"source_path": "/src.mp4", "source_start": 10.0, "source_end": 20.0,
@@ -115,6 +154,7 @@ def test_variable_ducking_keyframes_do_not_release_to_idle_between_close_windows
         span_end=8.0,
     )
 
-    between = [kf for kf in keyframes if 4.0 < kf["t"] < 5.0]
-    assert between
-    assert all(kf["gain"] != 0.85 for kf in between)
+    # the two close windows (gap 0.1 < 2*fade) coalesce into one held span [1,5] at the min
+    # level — the duck never swells back to idle between them.
+    held = [kf["gain"] for kf in keyframes if 1.0 <= kf["t"] <= 5.0]
+    assert held and all(g == 0.12 for g in held)

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -26,6 +26,87 @@ def test_lint_mapped_narration_flags_dropped_and_sparse():
     assert healthy["warnings"] == []
 
 
+def test_lint_mapped_narration_blocking_and_clamped_flags():
+    """Step 4: heavy drop/sparse output is BLOCKING; clamped-but-kept beats are surfaced
+    (advisory, not blocking)."""
+    sparse = [{"start": 5.0, "end": 8.0, "narration": "一。"}, {"start": 50.0, "end": 53.0, "narration": "二。"}]
+    assert lint_mapped_narration(sparse, original_count=8, output_duration=60.0)["blocking"] is True
+
+    dense = [{"start": float(i * 6), "end": float(i * 6 + 4), "narration": "一句。"} for i in range(10)]
+    assert lint_mapped_narration(dense, original_count=10, output_duration=60.0)["blocking"] is False
+
+    clamped = [{"start": 0.0, "end": 4.0, "narration": "一。", "clamped": True},
+               {"start": 5.0, "end": 9.0, "narration": "二。", "clamped": False}]
+    rep = lint_mapped_narration(clamped, original_count=2, output_duration=12.0)
+    assert rep["clamped_count"] == 1
+    assert any(w["code"] == "clamped_beats" for w in rep["warnings"])
+    assert rep["blocking"] is False  # clamp alone (no drop/sparse) does not block
+
+
+def test_map_narration_to_clips_tags_clamped_beats():
+    """Step 4: a beat trimmed to a clip edge is tagged clamped (its text may describe cut footage)."""
+    plan = {"clips": [{"clip_id": 0, "source_start": 10.0, "source_end": 20.0,
+                       "output_start": 0.0, "output_end": 10.0}]}
+    mapped = map_narration_to_clips([
+        {"start": 12.0, "end": 18.0, "narration": "完全在片段内。"},   # not clamped
+        {"start": 15.0, "end": 22.0, "narration": "尾巴越界被裁。"},   # mid 18.5 in clip, end 22>20 -> clamped to 20
+    ], plan)
+    by_text = {m["narration"]: m for m in mapped}
+    assert by_text["完全在片段内。"]["clamped"] is False
+    assert by_text["尾巴越界被裁。"]["clamped"] is True
+
+
+def test_cut_main_normalize_only_writes_validated_plan_without_render(monkeypatch, tmp_path):
+    """Step 4: --normalize-only writes clip_plan_validated.json and skips the render/map."""
+    import sys
+    import json as _json
+    import cut
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"v")
+    (tmp_path / "clip_plan.json").write_text('{"clips":[{"start":10.0,"end":20.0}]}', encoding="utf-8")
+    monkeypatch.setattr("cut.get_video_duration", lambda p: 30.0)
+    rendered = []
+    monkeypatch.setattr("cut.build_edited_source_video", lambda *a, **k: rendered.append(1))
+    monkeypatch.setattr(sys, "argv", ["cut.py", str(video), "--work-dir", str(tmp_path), "--normalize-only"])
+
+    cut.main()
+
+    validated = _json.loads((tmp_path / "clip_plan_validated.json").read_text(encoding="utf-8"))
+    assert validated["clips"]
+    assert rendered == []                                   # no render in normalize-only
+    assert not (tmp_path / "edited_source.mp4").exists()
+
+
+def test_cut_main_blocks_on_heavy_drop_unless_allow_sparse(monkeypatch, tmp_path):
+    """Step 4: a cut whose narration mostly falls outside the kept clips FAILS the preflight
+    (before TTS), unless --allow-sparse-cut is given."""
+    import sys
+    import json as _json
+    import pytest as _pytest
+    import cut
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"v")
+    (tmp_path / "clip_plan.json").write_text('{"clips":[{"start":10.0,"end":20.0}]}', encoding="utf-8")
+    (tmp_path / "narration.json").write_text(_json.dumps([
+        {"start": 12.0, "end": 15.0, "narration": "片段内。"},
+        {"start": 100.0, "end": 103.0, "narration": "片段外一。"},
+        {"start": 110.0, "end": 113.0, "narration": "片段外二。"},
+        {"start": 120.0, "end": 123.0, "narration": "片段外三。"},
+    ]), encoding="utf-8")
+    monkeypatch.setattr("cut.get_video_duration", lambda p: 200.0)
+    monkeypatch.setattr("cut.should_reuse_edited_source", lambda *a, **k: False)
+    monkeypatch.setattr("cut.build_edited_source_video",
+                        lambda *a, **k: (tmp_path / "edited_source.mp4").write_bytes(b"e"))
+    base = ["cut.py", str(video), "--work-dir", str(tmp_path)]
+
+    monkeypatch.setattr(sys, "argv", base)
+    with _pytest.raises(SystemExit):
+        cut.main()
+
+    monkeypatch.setattr(sys, "argv", base + ["--allow-sparse-cut"])
+    cut.main()  # override -> must not raise
+
+
 def test_parse_duration_seconds_accepts_common_forms():
     assert parse_duration_seconds("600") == 600
     assert parse_duration_seconds("10m") == 600

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -115,31 +115,29 @@ def test_recap_full_mode_passes_explicit_narration_json(monkeypatch, tmp_path):
     assert args[args.index("--narration") + 1] == str(work / "narration.json")
 
 
-def test_recap_cut_mode_passes_explicit_mapped_narration(monkeypatch, tmp_path):
+def test_recap_cut_mode_voiceover_uses_output_time_narration(monkeypatch, tmp_path):
+    """Two-pass cut: narration is authored in OUTPUT time, so voiceover gets narration.json
+    directly (no narration_mapped) and assemble muxes onto edited_source.mp4."""
     video = tmp_path / "video.mp4"
     video.write_bytes(b"video")
     work = tmp_path / "work"
     work.mkdir()
     (work / "narration.json").write_text(
-        json.dumps([{"start": 10, "end": 12, "narration": "source。"}]),
+        json.dumps([{"start": 2, "end": 5, "narration": "output。"}]),
         encoding="utf-8",
     )
     (work / "clip_plan.json").write_text(
         json.dumps([{"start": 10, "end": 12}]),
         encoding="utf-8",
     )
-
     recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
-
+    recap._write_phase_ledger(work, clip_plan_fingerprint=recap._file_md5(work / "clip_plan.json"),
+                              edited_source_rendered=True)
     calls = []
 
     def fake_run(skill, script, *cli_args):
         calls.append((skill, script, [str(arg) for arg in cli_args]))
         if script == "cut.py":
-            (work / "narration_mapped.json").write_text(
-                json.dumps([{"start": 0, "end": 2, "narration": "mapped。"}]),
-                encoding="utf-8",
-            )
             (work / "edited_source.mp4").write_bytes(b"edited")
         if script == "assemble.py":
             (work / "output.mp4").write_bytes(b"mp4")
@@ -153,9 +151,12 @@ def test_recap_cut_mode_passes_explicit_mapped_narration(monkeypatch, tmp_path):
 
     recap.main()
 
-    voiceover_call = next(call for call in calls if call[:2] == ("video-voiceover", "voiceover.py"))
-    args = voiceover_call[2]
-    assert args[args.index("--narration") + 1] == str(work / "narration_mapped.json")
+    vo = next(c for c in calls if c[:2] == ("video-voiceover", "voiceover.py"))[2]
+    assert vo[vo.index("--narration") + 1] == str(work / "narration.json")    # NOT narration_mapped
+    cut_render = next(c for c in calls if c[:2] == ("video-cut", "cut.py"))[2]
+    assert "--no-narration-map" in cut_render
+    asm = next(c for c in calls if c[:2] == ("video-assemble", "assemble.py"))[2]
+    assert asm[0] == str(work / "edited_source.mp4")
 
 
 
@@ -205,15 +206,13 @@ def test_recap_honors_edit_mode_and_target_duration_env(monkeypatch, tmp_path):
         encoding="utf-8",
     )
     recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut", target_duration="10m"))
+    recap._write_phase_ledger(work, clip_plan_fingerprint=recap._file_md5(work / "clip_plan.json"),
+                              edited_source_rendered=True)
     calls = []
 
     def fake_run(skill, script, *cli_args):
         calls.append((skill, script, [str(arg) for arg in cli_args]))
         if script == "cut.py":
-            (work / "narration_mapped.json").write_text(
-                json.dumps([{"start": 0, "end": 2, "narration": "mapped。"}]),
-                encoding="utf-8",
-            )
             (work / "edited_source.mp4").write_bytes(b"edited")
         if script == "assemble.py":
             (work / "output.mp4").write_bytes(b"mp4")
@@ -233,9 +232,10 @@ def test_recap_honors_edit_mode_and_target_duration_env(monkeypatch, tmp_path):
     cut_args = cut_call[2]
     assert "--target-duration" in cut_args
     assert cut_args[cut_args.index("--target-duration") + 1] == "10m"
+    assert "--no-narration-map" in cut_args      # cut-first render, no source-time mapping
     validate_call = next(call for call in calls if call[:2] == ("video-script", "validate.py"))
     validate_args = validate_call[2]
-    assert validate_args[validate_args.index("--mode") + 1] == "cut"
+    assert validate_args[validate_args.index("--mode") + 1] == "cut_output"
 
 
 def test_recap_completion_prints_manifest_final_output(monkeypatch, tmp_path, capsys):
@@ -439,15 +439,14 @@ def test_recap_pause_banner_quiet_when_brief_has_no_research_flag(monkeypatch, t
     assert "理解素材偏薄" not in capsys.readouterr().out
 
 
-def test_recap_cut_normalizes_plan_before_validate(monkeypatch, tmp_path):
-    """Step 4: validate must lint the NORMALIZED clip plan, so recap runs cut --normalize-only
-    BEFORE validate.py in cut mode (then the full cut render after)."""
+def test_recap_cut_two_pass_renders_then_pauses_for_output_narration(monkeypatch, tmp_path):
+    """Step 6: cut mode is two-pass. With clip_plan present but narration absent, recap renders
+    the cut (--no-narration-map, no source-time mapping) and PAUSES for OUTPUT-time narration —
+    it does not run voiceover/assemble yet, and the ledger records the rendered cut."""
     video = tmp_path / "video.mp4"
     video.write_bytes(b"video")
     work = tmp_path / "work"
     work.mkdir()
-    (work / "narration.json").write_text(
-        json.dumps([{"start": 10, "end": 12, "narration": "source。"}]), encoding="utf-8")
     (work / "clip_plan.json").write_text(json.dumps([{"start": 10, "end": 12}]), encoding="utf-8")
     recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
     calls = []
@@ -455,54 +454,51 @@ def test_recap_cut_normalizes_plan_before_validate(monkeypatch, tmp_path):
     def fake_run(skill, script, *cli_args):
         cli = [str(a) for a in cli_args]
         calls.append((skill, script, cli))
-        if script == "cut.py" and "--normalize-only" not in cli:
-            (work / "narration_mapped.json").write_text(
-                json.dumps([{"start": 0, "end": 2, "narration": "mapped。"}]), encoding="utf-8")
+        if script == "cut.py":
             (work / "edited_source.mp4").write_bytes(b"edited")
-        if script == "assemble.py":
-            (work / "output.mp4").write_bytes(b"mp4")
-            (work / "assembly_manifest.json").write_text(
-                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}), encoding="utf-8")
+            (work / "clip_plan_validated.json").write_text(json.dumps({"clips": []}), encoding="utf-8")
 
     monkeypatch.setattr("recap._run", fake_run)
     monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
 
-    recap.main()
+    recap.main()  # PASS 2: render the cut, then pause (narration.json absent)
 
-    cut_norm_idx = next(i for i, c in enumerate(calls)
-                        if c[:2] == ("video-cut", "cut.py") and "--normalize-only" in c[2])
-    validate_idx = next(i for i, c in enumerate(calls) if c[:2] == ("video-script", "validate.py"))
-    cut_full_idx = next(i for i, c in enumerate(calls)
-                        if c[:2] == ("video-cut", "cut.py") and "--normalize-only" not in c[2])
-    assert cut_norm_idx < validate_idx < cut_full_idx
+    cut_calls = [c for c in calls if c[:2] == ("video-cut", "cut.py")]
+    assert cut_calls and all("--no-narration-map" in c[2] for c in cut_calls)
+    assert all("--normalize-only" not in c[2] for c in cut_calls)        # mapping path is bypassed
+    assert not any(c[1] in ("voiceover.py", "assemble.py") for c in calls)  # paused, not produced
+    assert recap._read_phase_ledger(work).get("edited_source_rendered") is True
 
 
 def test_cut_narration_stale_guard_logic():
-    """Step 5: stale iff clip_plan changed but narration did NOT (re-cut without re-writing)."""
-    assert recap._cut_narration_is_stale(None, "cp1", "n1") is False
-    base = {"clip_plan_fingerprint": "cp1", "narration_fingerprint": "n1"}
-    assert recap._cut_narration_is_stale(base, "cp1", "n1") is False      # nothing changed
-    assert recap._cut_narration_is_stale(base, "cp2", "n1") is True       # clip_plan changed, narration same -> stale
-    assert recap._cut_narration_is_stale(base, "cp2", "n2") is False      # both changed (re-authored) -> fresh
+    """Two-pass cut: the narration is written for the rendered cut, so any clip_plan change
+    while that narration is still present makes it stale (it describes the old cut)."""
+    assert recap._cut_narration_is_stale(None, "cp1") is False
+    base = {"clip_plan_fingerprint": "cp1"}
+    assert recap._cut_narration_is_stale(base, "cp1") is False    # clip_plan unchanged
+    assert recap._cut_narration_is_stale(base, "cp2") is True     # clip_plan changed -> stale
 
 
 def test_recap_cut_rejects_stale_narration_after_clip_plan_change(monkeypatch, tmp_path):
-    """Step 5: a narration written for a previous clip_plan must not resume into the cut/TTS."""
+    """Step 6: a narration written for a previous clip_plan must not drive a re-cut into TTS;
+    the render may run, but validate/voiceover/assemble must not."""
     video = tmp_path / "video.mp4"
     video.write_bytes(b"video")
     work = tmp_path / "work"
     work.mkdir()
     (work / "narration.json").write_text(
-        json.dumps([{"start": 10, "end": 12, "narration": "解说。"}]), encoding="utf-8")
+        json.dumps([{"start": 1, "end": 3, "narration": "解说。"}]), encoding="utf-8")
     (work / "clip_plan.json").write_text(json.dumps([{"start": 10, "end": 12}]), encoding="utf-8")
     recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
-    # Ledger recorded for an OLD clip_plan; the narration has not changed since.
-    recap._write_phase_ledger(work, clip_plan_fingerprint="OLD_DIFFERENT_FP",
-                              narration_fingerprint=recap._file_md5(work / "narration.json"),
-                              narration_written=True)
+    recap._write_phase_ledger(work, clip_plan_fingerprint="OLD_DIFFERENT_FP", edited_source_rendered=True)
 
-    monkeypatch.setattr("recap._run",
-                        lambda *a: (_ for _ in ()).throw(AssertionError("must reject before any stage runs")))
+    def fake_run(skill, script, *cli_args):
+        if script == "cut.py":
+            (work / "edited_source.mp4").write_bytes(b"edited")   # render allowed
+        if script in ("validate.py", "voiceover.py", "assemble.py"):
+            raise AssertionError(f"{script} ran despite stale narration")
+
+    monkeypatch.setattr("recap._run", fake_run)
     monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
 
     with pytest.raises(SystemExit, match="clip_plan.json 已改变"):

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -356,3 +356,40 @@ def test_recap_phase_b_allows_environment_changes_when_artifacts_are_unchanged(m
     recap.main()
 
     assert any(call[:2] == ("video-assemble", "assemble.py") for call in calls)
+
+
+def test_recap_resumes_old_manifest_missing_consolidate_key(monkeypatch, tmp_path):
+    """Step 2 backward-compat: --consolidate now defaults ON, so its value lives in the run
+    manifest. A work_dir whose manifest predates the consolidate setting (key absent) — or
+    carries the old default false — must still resume, not hard-fail on a settings mismatch."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "old。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+    manifest = json.loads((work / recap.RUN_MANIFEST).read_text(encoding="utf-8"))
+    manifest["settings"].pop("consolidate", None)        # simulate a pre-consolidate-key manifest
+    manifest["settings"].pop("consolidate_asr", None)
+    (work / recap.RUN_MANIFEST).write_text(json.dumps(manifest), encoding="utf-8")
+
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()  # must NOT SystemExit on a consolidate settings mismatch
+
+    assert any(call[:2] == ("video-assemble", "assemble.py") for call in calls)

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -393,3 +393,47 @@ def test_recap_resumes_old_manifest_missing_consolidate_key(monkeypatch, tmp_pat
     recap.main()  # must NOT SystemExit on a consolidate settings mismatch
 
     assert any(call[:2] == ("video-assemble", "assemble.py") for call in calls)
+
+
+def test_recap_pause_banner_amplifies_research_when_brief_flags_thin(monkeypatch, tmp_path, capsys):
+    """Step 3: when the Phase-A brief fires the research directive (thin substrate, no research),
+    the recap pause banner amplifies it so the agent researches before writing."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+
+    def fake_run(skill, script, *cli_args):
+        if script == "understand.py":
+            (work / "agent_narration_brief.md").write_text(
+                "# Agent Narration Brief\n\n## ⚑ Research the story FIRST (do this before writing narration)\n",
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()  # Phase A (no narration.json) -> pause
+
+    out = capsys.readouterr().out
+    assert "理解素材偏薄" in out
+    assert "Research the story FIRST" in out
+
+
+def test_recap_pause_banner_quiet_when_brief_has_no_research_flag(monkeypatch, tmp_path, capsys):
+    """A rich-substrate brief (no research directive) must NOT add a research nag to the banner."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+
+    def fake_run(skill, script, *cli_args):
+        if script == "understand.py":
+            (work / "agent_narration_brief.md").write_text("# Agent Narration Brief\n", encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    assert "理解素材偏薄" not in capsys.readouterr().out

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -437,3 +437,41 @@ def test_recap_pause_banner_quiet_when_brief_has_no_research_flag(monkeypatch, t
     recap.main()
 
     assert "理解素材偏薄" not in capsys.readouterr().out
+
+
+def test_recap_cut_normalizes_plan_before_validate(monkeypatch, tmp_path):
+    """Step 4: validate must lint the NORMALIZED clip plan, so recap runs cut --normalize-only
+    BEFORE validate.py in cut mode (then the full cut render after)."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 10, "end": 12, "narration": "source。"}]), encoding="utf-8")
+    (work / "clip_plan.json").write_text(json.dumps([{"start": 10, "end": 12}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        cli = [str(a) for a in cli_args]
+        calls.append((skill, script, cli))
+        if script == "cut.py" and "--normalize-only" not in cli:
+            (work / "narration_mapped.json").write_text(
+                json.dumps([{"start": 0, "end": 2, "narration": "mapped。"}]), encoding="utf-8")
+            (work / "edited_source.mp4").write_bytes(b"edited")
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}), encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
+
+    recap.main()
+
+    cut_norm_idx = next(i for i, c in enumerate(calls)
+                        if c[:2] == ("video-cut", "cut.py") and "--normalize-only" in c[2])
+    validate_idx = next(i for i, c in enumerate(calls) if c[:2] == ("video-script", "validate.py"))
+    cut_full_idx = next(i for i, c in enumerate(calls)
+                        if c[:2] == ("video-cut", "cut.py") and "--normalize-only" not in c[2])
+    assert cut_norm_idx < validate_idx < cut_full_idx

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -475,3 +475,59 @@ def test_recap_cut_normalizes_plan_before_validate(monkeypatch, tmp_path):
     cut_full_idx = next(i for i, c in enumerate(calls)
                         if c[:2] == ("video-cut", "cut.py") and "--normalize-only" not in c[2])
     assert cut_norm_idx < validate_idx < cut_full_idx
+
+
+def test_cut_narration_stale_guard_logic():
+    """Step 5: stale iff clip_plan changed but narration did NOT (re-cut without re-writing)."""
+    assert recap._cut_narration_is_stale(None, "cp1", "n1") is False
+    base = {"clip_plan_fingerprint": "cp1", "narration_fingerprint": "n1"}
+    assert recap._cut_narration_is_stale(base, "cp1", "n1") is False      # nothing changed
+    assert recap._cut_narration_is_stale(base, "cp2", "n1") is True       # clip_plan changed, narration same -> stale
+    assert recap._cut_narration_is_stale(base, "cp2", "n2") is False      # both changed (re-authored) -> fresh
+
+
+def test_recap_cut_rejects_stale_narration_after_clip_plan_change(monkeypatch, tmp_path):
+    """Step 5: a narration written for a previous clip_plan must not resume into the cut/TTS."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 10, "end": 12, "narration": "解说。"}]), encoding="utf-8")
+    (work / "clip_plan.json").write_text(json.dumps([{"start": 10, "end": 12}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
+    # Ledger recorded for an OLD clip_plan; the narration has not changed since.
+    recap._write_phase_ledger(work, clip_plan_fingerprint="OLD_DIFFERENT_FP",
+                              narration_fingerprint=recap._file_md5(work / "narration.json"),
+                              narration_written=True)
+
+    monkeypatch.setattr("recap._run",
+                        lambda *a: (_ for _ in ()).throw(AssertionError("must reject before any stage runs")))
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
+
+    with pytest.raises(SystemExit, match="clip_plan.json 已改变"):
+        recap.main()
+
+
+def test_recap_full_mode_writes_no_phase_ledger(monkeypatch, tmp_path):
+    """Step 5: the phase ledger is cut-mode only; full mode stays unchanged."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    def fake_run(skill, script, *cli_args):
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "r.mp4")}), encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    assert not (work / "recap_phase.json").exists()

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -366,6 +366,22 @@ def test_build_agent_brief_storyless_rich_video_relaxes_and_prompts_research(mon
     assert "segments/min (minimum" not in text           # strict quota line suppressed
 
 
+def test_build_agent_brief_rich_density_is_a_guide_not_quota(monkeypatch, tmp_path):
+    """Step 1: even with RICH substrate, density is framed as a GUIDE, not a hard quota,
+    so the writer never pads with pixel-filler just to hit a beat count."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "full")
+    monkeypatch.setitem(CONFIG, "target_duration", "")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    scenes = [{"scene_id": i, "start": float(i * 6), "end": float(i * 6 + 6),
+               "description": "范闲在书房翻看卷宗神色凝重", "frame_facts": {str(i * 6): ["翻书"]}} for i in range(6)]
+    asr = [{"start": 1.0, "end": 5.0, "text": "对" * 250}]  # >= 200 chars -> a real story spine -> rich
+    assert assess_understanding_substrate(scenes, asr)["level"] == "rich"
+    text = build_agent_brief(scenes, asr, [], 36.0, tmp_path).read_text(encoding="utf-8")
+    assert "a GUIDE, not a quota" in text
+    assert "never pad with" in text
+    assert "Narration density target:" not in text  # the old hard-quota phrasing is gone
+
+
 def test_cut_validate_prefers_raw_plan_when_validated_is_stale(tmp_path):
     import sys
     import importlib.util

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -155,6 +155,20 @@ def test_build_agent_brief_research_directive_when_context_without_research(monk
     assert "Research the story FIRST" not in text2  # already researched -> directive gone
 
 
+def test_research_directive_does_not_fire_for_dialogue_rich_titled_run(monkeypatch, tmp_path):
+    """Step 3: a dialogue-rich (substrate=rich) titled run with no research file must NOT be
+    nagged — the directive fires only for thin/empty substrate, not merely because a title exists."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "full")
+    monkeypatch.setitem(CONFIG, "target_duration", "")
+    monkeypatch.setitem(CONFIG, "context_info", "这是《庆余年》第一集")  # a title, but no research file
+    scenes = [{"scene_id": i, "start": float(i * 6), "end": float(i * 6 + 6),
+               "description": "范闲与人对峙", "frame_facts": {str(i * 6): ["对峙"]}} for i in range(4)]
+    asr = [{"start": 1.0, "end": 5.0, "text": "对" * 250}]  # rich dialogue spine
+    assert assess_understanding_substrate(scenes, asr)["level"] == "rich"
+    text = build_agent_brief(scenes, asr, [], 24.0, tmp_path).read_text(encoding="utf-8")
+    assert "Research the story FIRST" not in text  # rich + titled -> no nag
+
+
 def test_lint_narration_cut_mode_warns_on_clip_boundary_crossing():
     """A beat that spills past its clip is silently trimmed by the mapper and ends up
     over cut-away footage -> warn so the agent tightens it inside the clip."""

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -121,8 +121,26 @@ def test_build_agent_brief_cut_mode_sizes_to_output(monkeypatch, tmp_path):
     assert "CUT OUTPUT" in text
     assert "10 short beats" in text       # 1min output * 10/min = 10 beats (sized to output)
     assert "100 short beats" not in text   # the old source-sized (buggy) count
-    assert "Keep each beat INSIDE one clip" in text
+    assert "step 1 of 2" in text           # A1: cut-first, write clip_plan only (no edited_source yet)
     assert '"target_duration": "1m"' in text
+
+
+def test_build_agent_brief_cut_pass2_is_output_timeline(monkeypatch, tmp_path):
+    """Step 6: once the cut is rendered (edited_source.mp4 exists), the cut brief switches to
+    the PASS-2 output-timeline variant: narrate in OUTPUT time, with the kept clips listed."""
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "1m")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({"clips": [
+        {"clip_id": 0, "source_start": 10.0, "source_end": 20.0, "output_start": 0.0, "output_end": 10.0, "reason": "开端"},
+    ]}), encoding="utf-8")
+    scenes = [{"scene_id": 0, "start": 0.0, "end": 60.0, "description": "画面"}]
+    text = build_agent_brief(scenes, [], [], 600.0, tmp_path).read_text(encoding="utf-8")
+    assert "step 2 of 2: write `narration.json` in OUTPUT time" in text
+    assert "Kept clips on the OUTPUT timeline" in text
+    assert "output 0.0–10.0s ← source 10.0–20.0s" in text
+    assert "step 1 of 2" not in text
 
 
 def test_build_agent_brief_thin_substrate_relaxes_density(monkeypatch, tmp_path):

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -173,4 +173,4 @@ def test_build_agent_brief_cut_mode_sizes_to_output(monkeypatch, tmp_path):
     assert "CUT OUTPUT" in text
     assert "10 short beats" in text
     assert "100 short beats" not in text
-    assert "Keep each beat INSIDE one clip" in text
+    assert "step 1 of 2" in text           # A1: cut-first, write clip_plan only (no edited_source yet)

--- a/tests/understanding/test_io_fixes.py
+++ b/tests/understanding/test_io_fixes.py
@@ -257,7 +257,9 @@ def _run_understand_for_cache_tests(monkeypatch, tmp_path, video, *, argv_extra=
     monkeypatch.setattr("understand.api_call", lambda payload: {"choices": [{"message": {"content": "ok"}}]})
     monkeypatch.setattr("understand.extract_frames", lambda video_path, work_dir: [frame])
     monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
-    argv = ["understand.py", str(video), "--work-dir", str(tmp_path), *(argv_extra or [])]
+    # These tests exercise VLM cache-key behavior, not the consolidate index (now default-on,
+    # whose api_call is the real lib.api_call, not the mocked understand.api_call). Skip it.
+    argv = ["understand.py", str(video), "--work-dir", str(tmp_path), "--no-consolidate", *(argv_extra or [])]
     monkeypatch.setattr(sys, "argv", argv)
     understand.main()
 


### PR DESCRIPTION
Quality-focused release. Makes cut mode sync by construction, the narration mix a continuous bed, the narration itself less "cold", and full-episode understanding robust to the MiMo cluster's rate limit. Docs synced and version bumped to **0.2.0**.

## Highlights

### Cut mode is cut-first / narrate-second (structural desync cure)
The orchestrator renders `edited_source.mp4` from `clip_plan.json` first, then the agent writes `narration.json` against the **output** timeline. No source→output remap (`map_narration_to_clips` is never called in the orchestrated path), so beats can't be silently dropped/clamped and narration can't drift from the picture. Full mode is unchanged (single pause). A `recap_phase.json` ledger drives deterministic resume.

### Continuous original-audio bed (fixes "原声在句间窜起来")
The original was restored to idle (0.85) in every inter-beat gap, so source dialogue popped back between sentences. Now beats whose gap < `duck_bridge_seconds` (default 12s, just above the 11s max narration gap) coalesce into one held duck span — a continuous low bed under the whole narrated stretch; only lead-in/out and genuine long gaps swell back. The render and the optional 剪映 draft coalesce identically (flat min level), so they match even on mixed speech/quiet spans.

### Narration is less "cold"
Density is framed as a **guide, not a quota** — the brief explicitly tells the agent never to pad with filler/pixel-description to hit a number. `--consolidate` story index is **on by default** (richer substrate), with a backward-compat manifest shim so old `work_dir`s still resume. The research directive only fires when the substrate is thin/empty.

### Long-video robustness
A full 45-min episode fans out into ~90 ASR + ~185 VLM calls; the MiMo endpoints now retry up to 10× with a 60s backoff cap (+10s floor when no `Retry-After`), and an optional `ASR_THROTTLE_SECONDS` spaces sequential ASR — a transient 429 no longer aborts the run. Resume also proves a cached artifact matches the current bytes/settings before reuse.

### Other
Interim cut-desync floor (normalized-plan lint + blocking preflight + `--allow-sparse-cut`); docs synced (README zh/en, config-playbook, video-cut/voiceover SKILLs, timeline-and-jianying); `CHANGELOG.md` added.

## Verification
- `python3 scripts/test.py`: **261 passed** across all 6 groups
- No-ffmpeg CI reproduction (`PATH= python3 scripts/test.py`): 261 (3 ffmpeg tests skipped)
- `ruff check skills tests scripts`: clean
- brief.py ⇄ narration.py parity holds
- End-to-end validated on a full 庆余年 EP01 → 5-min cut recap (render 303.0s, lint 0/0, frame-checked picture↔narration sync, single continuous bed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)