### PR TITLE
docs: de-AI the README top section + shrink the 剪映 screenshot

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,21 +2,19 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple)
-![Powered by MiMo](https://img.shields.io/badge/AI-Xiaomi%20MiMo-green)
-![Python](https://img.shields.io/badge/Python-3.10%2B-blue)
-![Cross-platform](https://img.shields.io/badge/macOS%20%7C%20Linux%20%7C%20Windows-supported-informational)
+![Powered by Xiaomi MiMo](https://img.shields.io/badge/AI-Xiaomi%20MiMo-green)
 
 [中文](README.md) · English
 
-**Turn any video into a Chinese-narration recap — from one sentence inside Claude Code.** All it needs locally is `ffmpeg` and one Xiaomi MiMo API key. No GPU, no model downloads.
+**Turn any video into a Chinese-narration recap, from one sentence inside Claude Code.** All it needs locally is `ffmpeg` and one Xiaomi MiMo API key — no GPU, no model downloads, on macOS / Linux / Windows.
 
 ## Demo
 
 https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff
 
-Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand — original clips, narration, BGM, and subtitles each on their own track, with the ducking as editable volume keyframes:
+Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand — original clips, narration, BGM, and subtitles each on their own track:
 
-![Exported 剪映 draft: original clips, narration, BGM, and subtitles, each independently editable](docs/jianying-export.png)
+<img alt="Exported 剪映 draft: original clips, narration, BGM, and subtitles each on their own track" src="docs/jianying-export.png" width="70%">
 
 ## What is it?
 
@@ -35,11 +33,11 @@ flowchart LR
 
 ## Why use it?
 
-- **One key, runs anywhere.** ASR, VLM, and TTS all go through [Xiaomi MiMo](https://platform.xiaomimimo.com); the only local dependency is `ffmpeg` — no GPU, no model files, no extra service, on macOS / Linux / Windows.
-- **Research before analysis.** Put the plot and characters into `background_research.json` first, and the VLM names people on screen instead of labelling everyone "黑衣男子".
-- **Narration in blocks, original in blocks (~7:3).** Narration is written as continuous blocks, each synthesized as one fluent utterance; between blocks the original audio plays back at FULL volume instead of being ducked the whole way through (pacing tunable via `duck_bridge_seconds`). Subtitles are split into short one-line chunks and the masking band is only one line tall, so it never compresses the picture.
-- **Cut and review.** `--edit-mode cut` is cut-first/narrate-second: it renders the cut from `clip_plan.json`, then you narrate against that real output timeline, so narration and picture stay in sync by construction. An LLM review pass flags hallucinations, weak hooks, and a missing throughline before TTS.
-- **Keep editing in 剪映.** Optionally export a multi-track 剪映 draft; the core render only needs `ffmpeg` and never depends on 剪映.
+- **One key, runs anywhere.** ASR, VLM, and TTS all go through [Xiaomi MiMo](https://platform.xiaomimimo.com); `ffmpeg` is the only local dependency.
+- **Research before you write.** Get the plot and characters into `background_research.json` first, so the VLM actually knows who's who.
+- **Narration in blocks, original in blocks.** Narration plays in connected blocks, each voiced in one pass; in the gaps between, the original audio plays at full volume — roughly 7:3.
+- **Cut first, no drift.** `--edit-mode cut` renders the cut first, then you narrate against that timeline, so picture and voice stay in sync; an LLM pass reviews the draft before TTS.
+- **Keep editing in 剪映.** Optionally export a multi-track 剪映 draft — original, narration, BGM, and subtitles each on a track; the core render needs only `ffmpeg`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,19 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple)
-![Powered by MiMo](https://img.shields.io/badge/AI-Xiaomi%20MiMo-green)
-![Python](https://img.shields.io/badge/Python-3.10%2B-blue)
-![Cross-platform](https://img.shields.io/badge/macOS%20%7C%20Linux%20%7C%20Windows-supported-informational)
+![Powered by Xiaomi MiMo](https://img.shields.io/badge/AI-Xiaomi%20MiMo-green)
 
 中文 · [English](README.en.md)
 
-**把任何视频做成中文解说 recap——在 Claude Code 里一句话搞定。** 本地只要 `ffmpeg` 和一个小米 MiMo 的 API Key，不要 GPU、不用下载模型。
+**一句话，把视频做成中文解说 recap。** 在 Claude Code 里说一声就开跑，本地只要 `ffmpeg` 加一个小米 MiMo 的 API Key——不用 GPU、不下模型，macOS / Linux / Windows 都能跑。
 
 ## 演示
 
 https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff
 
-成片之外，还能一键导出**剪映草稿**接着手动精修——原片片段、解说、BGM、字幕各成一轨：
+成片之外，还能一键导出**剪映草稿**手动精修——原片、解说、BGM、字幕各一轨：
 
-![导出的剪映草稿：原片片段、解说、BGM、字幕，各自独立可编辑](docs/jianying-export.png)
+<img alt="导出的剪映草稿：原片、解说、BGM、字幕各一轨" src="docs/jianying-export.png" width="70%">
 
 ## 这是什么
 
@@ -35,11 +33,11 @@ flowchart LR
 
 ## 为什么用它
 
-- **一个 key 跑全程。** ASR、VLM、TTS 全走[小米 MiMo](https://platform.xiaomimimo.com)，本地只装 `ffmpeg`。
-- **先调研再分析。** 先把剧情人物查清楚写进 `background_research.json`。
-- **解说成块，原声也成块（约 7:3）。** 解说写成一段段连续的解说块，整块一次配音、更连贯；块与块之间留出原声块——精彩原声整段放回满音量，不再被全程压低（节奏阈值 `duck_bridge_seconds` 可调）。字幕拆成短句逐句跟读，底部遮挡只占一行高度，不压画面。
-- **能剪、能审。** `--edit-mode cut` 先剪后配——先按 `clip_plan.json` 把长视频剪成成片，再对着剪好的成片时间轴写解说，解说与画面天然对齐、不会错位；出稿前一道 LLM 评审挑幻觉、钩子、主线的毛病。
-- **接着在剪映里改。** 可选导出多轨剪映草稿；核心渲染只靠 `ffmpeg`，不装剪映也照常出片。
+- **一个 key 跑全程。** ASR、VLM、TTS 全走[小米 MiMo](https://platform.xiaomimimo.com)，本地除了 `ffmpeg` 没别的依赖。
+- **先查资料再写稿。** 跑前把剧情、人物查清楚存进 `background_research.json`，VLM 才认得出谁是谁。
+- **解说成块，原声也成块。** 解说一段段连着讲、整块一次配音，段间留白把精彩原声整段放回满音量——大致七三开。
+- **先剪后配，画面不串。** `--edit-mode cut` 先把长视频剪成成片，再对着成片写解说，时间轴天然对齐；出稿前还有一道 LLM 评审挑幻觉、钩子和主线。
+- **能接着在剪映里改。** 可选导出多轨剪映草稿，原片、解说、BGM、字幕各占一轨；核心渲染只靠 `ffmpeg`，不装剪映照样出片。
 
 ## 安装
 


### PR DESCRIPTION
A formatting + voice pass on the README (both 中文 and English), per feedback that the layout was cluttered and the copy read a bit AI-generated.

- **Badges 5 → 3** — drop the `Python 3.10+` and `Cross-platform … supported` badges (badge soup); cross-platform now lives in the tagline where it actually informs.
- **Tagline** de-duplicated against the Installation section and made to read less like a product page.
- **"Why use it?" list** taken out of the rigid `**bold.** one sentence` ×5 mold — varied rhythm, two over-explained tails trimmed, and a `duck_bridge_seconds` knob-drop pulled out of the pitch.
- **剪映 screenshot** shrunk to `<img width="70%">` so it no longer dominates the page.

No content/links removed beyond the redundant phrasing; README.md and README.en.md kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)