### PR TITLE
fail-fast: subtitle-burn preflight + surface narration review + burn-default doc fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+Fail faster and surface the content review, without adding new artifacts or stages.
+
+### Added
+
+- **Subtitle-burn preflight (fail fast).** Burning subtitles needs an ffmpeg built with the
+  libass `subtitles` filter. The orchestrator now checks this at the very start of a run — before
+  any understanding / VLM / ASR / TTS spend — and exits with a clear message (install a
+  libass-enabled ffmpeg, or pass `--no-burn-subtitles`) instead of dying at the final render after
+  the whole pipeline has run. `video-assemble` keeps the same guard for standalone runs.
+- **Narration review surfaced at delivery.** When an advisory `narration_review.md` exists, the
+  orchestrator prints its verdict + the path on completion, so the content risk report (weak hook /
+  no through-line / pacing) is visible at the end of a run instead of buried in the script stage.
+  Still advisory — `validate.py` remains the only hard gate.
+
+### Fixed
+
+- **Docs: subtitle burn-in is on by default.** The READMEs and SKILL.md described burn-in as
+  opt-in via `--burn-subtitles`, but it has been on by default (opt out with `--no-burn-subtitles`)
+  — corrected the wording across both READMEs and the assemble / orchestrator SKILL.md.
+
 ## [0.2.1] - 2026-06-17
 
 A delivery-quality release: narration now plays in blocks with the original audio breathing

--- a/README.en.md
+++ b/README.en.md
@@ -97,7 +97,7 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 ## Output
 
-- `recap_<video>.mp4`: the final recap; a stable output alias overwritten in place on every run, so iterating on the narration refreshes the same file. `subtitles.srt` (plus `subtitles.ass` with `--burn-subtitles`)
+- `recap_<video>.mp4`: the final recap; a stable output alias overwritten in place on every run, so iterating on the narration refreshes the same file. `subtitles.srt` (plus `subtitles.ass`; subtitle burn-in is on by default, `--no-burn-subtitles` to disable)
 - `work_dir/narration.json`: the narration script (`narration_lint.json` timing diagnostics, `narration_review.md` review notes)
 - `work_dir/agent_narration_brief.md`: timing and scene brief for the agent
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`: understanding artifacts

--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,8 @@ sudo apt install ffmpeg                     # Debian/Ubuntu
 choco install ffmpeg                        # Windows (or scoop / winget install ffmpeg)
 ```
 
+Subtitles are burned into the picture by default, which needs an ffmpeg built with **libass (the `subtitles` filter)** — the packages above include it in almost all cases. If yours lacks libass, the run fails fast at the start with a clear message (or pass `--no-burn-subtitles` to keep subtitles as a sidecar `.srt`). Run `python3 scripts/recap.py --doctor` to self-check.
+
 **③ Set your MiMo API key** (one key powers ASR / VLM / TTS — keep it in an env var, never in the repo):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ sudo apt install ffmpeg                     # Debian/Ubuntu
 choco install ffmpeg                        # Windows（或 scoop / winget install ffmpeg）
 ```
 
+字幕默认烧进画面，需要带 **libass（`subtitles` 滤镜）** 的 ffmpeg——上面这些包基本都自带。如果你的 ffmpeg 没编 libass，开跑前会立刻报错并提示（也可以加 `--no-burn-subtitles` 只出 `.srt` 外挂字幕）。用 `python3 scripts/recap.py --doctor` 自检。
+
 **③ 配 MiMo API Key**（一个 key 同时驱动 ASR / VLM / TTS，放环境变量、别写进仓库）：
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 ## 输出
 
-- `recap_<video>.mp4`：成片（固定输出名，每次运行原地覆盖，迭代解说时刷新同一文件）。`subtitles.srt`（加 `--burn-subtitles` 时还有 `subtitles.ass`）
+- `recap_<video>.mp4`：成片（固定输出名，每次运行原地覆盖，迭代解说时刷新同一文件）。`subtitles.srt`（默认烧录字幕，同时产出 `subtitles.ass`；`--no-burn-subtitles` 关闭）
 - `work_dir/narration.json`：解说脚本（`narration_lint.json` 时间诊断、`narration_review.md` 评审意见）
 - `work_dir/agent_narration_brief.md`：给 Agent 的时间和场景 brief
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`：理解产物

--- a/skills/video-assemble/SKILL.md
+++ b/skills/video-assemble/SKILL.md
@@ -13,8 +13,8 @@ description: >
 
 1. Mixes the narration audio segments onto the source video at their placed times.
 2. **Ducks** the original audio under narration (fixed / sidechain / zone modes).
-3. Renders **subtitles** from the narration placement → `subtitles.srt` (+ `subtitles.ass`,
-   burned in with `--burn-subtitles`).
+3. Renders **subtitles** from the narration placement → `subtitles.srt` (+ `subtitles.ass`
+   when burning, which is **on by default**; `--no-burn-subtitles` to disable).
 4. Optional final **loudness normalization** to a target LUFS.
 
 ## Input contract
@@ -27,7 +27,7 @@ description: >
 
 ```bash
 python3 scripts/assemble.py <video> --work-dir <work_dir> \
-  [--recap-stem <name>] [--output-dir <dir>] [--burn-subtitles]
+  [--recap-stem <name>] [--output-dir <dir>] [--no-burn-subtitles]
   [--source-video <orig.mp4>] [--export-jianying [--jianying-out <dir>]]
 ```
 
@@ -35,7 +35,7 @@ python3 scripts/assemble.py <video> --work-dir <work_dir> \
 
 - `recap_<stem>.mp4` — the final recap video (written to `--output-dir` or `work_dir`'s parent). It is the stable output alias, overwritten in place on every run so iterating on the narration refreshes the same file.
 - `work_dir/output.mp4` — the in-place render.
-- `subtitles.srt` — narration subtitles; `subtitles.ass` when `--burn-subtitles` is used.
+- `subtitles.srt` — narration subtitles; `subtitles.ass` when burning subtitles (on by default).
 - `timeline.json` — backend-neutral multi-track model (video / original-audio / narration / BGM / subtitle tracks with ducking automation). Always written.
 - `assembly_manifest.json` — a slim render record: the input/source paths, the cut-mode source fingerprint (proving a stale ambient `SOURCE_VIDEO` did not leak into a full-mode export), the render settings, and the final output path.
 - 剪映 draft folder (`recap_<stem>/draft_content.json` + `draft_info.json` + `draft_meta_info.json`) — only with `--export-jianying`.
@@ -46,9 +46,11 @@ python3 scripts/assemble.py <video> --work-dir <work_dir> \
 - Subtitle look: `SUBTITLE_FONT_SIZE`, `SUBTITLE_MARGIN_V`, `SUBTITLE_MAX_CHARS`, etc.
 - Ducking / loudness: the original swells to `IDLE_ORIG_VOLUME` in the gaps and ducks to `SPEECH_DUCKING_VOLUME` under narration (`DUCK_FADE_SECONDS` smooths the transition); also `DUCKING_MODE`, `ZONE_DUCKING_VOLUME`, `FINAL_LOUDNORM`, `TARGET_LUFS`.
 - BGM (optional): set `BGM_PATH` to any audio file; it loops to length and ducks under narration (`BGM_VOLUME` / `BGM_DUCKING_VOLUME`).
-- Burning subtitles requires an ffmpeg with `subtitles`/libass support.
+- Burning subtitles requires an ffmpeg with `subtitles`/libass support; assemble (and the
+  recap orchestrator) preflight this and fail fast with a clear message if it is missing.
 
 ## What this skill does NOT do
 - Does NOT generate narration or synthesize TTS.
 - Does NOT re-transcribe or alter timing decisions — it consumes placement from tts_meta.json.
-- Burning subtitles is opt-in (`--burn-subtitles`); it does not re-encode unless asked.
+- Burning subtitles is **on by default** (`--no-burn-subtitles` to turn it off); when on, it
+  re-encodes the video to draw the subtitle band.

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1075,6 +1075,43 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
     log(f"解说音轨: {video_duration:.1f}s, {len(tts_segments)} 段")
 
 
+def _ffmpeg_filters():
+    """ffmpeg's compiled-in filter names. Independent copy of
+    skills/video-recap/scripts/doctor.py:_ffmpeg_filters (skills share no code) — keep the
+    parse in sync with that copy."""
+    import shutil
+    import subprocess
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return set()
+    try:
+        result = subprocess.run(["ffmpeg", "-hide_banner", "-filters"],
+                                text=True, capture_output=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    filters = set()
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] and parts[0][0] in ".TSCAPN|":
+            filters.add(parts[1])
+    return filters
+
+
+def _preflight_burn_subtitles():
+    """Fail before the (re-encoding) render when burn-in is on but ffmpeg lacks the libass
+    `subtitles` filter. _subtitle_burn_filter burns even the .ass through `subtitles=`, so
+    that is the required capability. Defense-in-depth: the orchestrator (recap.py) preflights
+    this earlier, but assemble.py can be run standalone."""
+    if not CONFIG.get("burn_subtitles", False):
+        return
+    if "subtitles" not in _ffmpeg_filters():
+        raise SystemExit(
+            "字幕烧录已开启，但当前 ffmpeg 不支持 subtitles/libass 滤镜，渲染会在最后一步失败。\n"
+            "  解决：安装带 libass 的 ffmpeg，或加 --no-burn-subtitles 关闭烧录（仍输出 .srt 外挂字幕）。")
+
+
 def main():
     import argparse
     import json
@@ -1117,6 +1154,7 @@ def main():
         CONFIG["jianying_bundle_media"] = True
     if args.jianying_no_bundle_media:
         CONFIG["jianying_bundle_media"] = False
+    _preflight_burn_subtitles()  # fail before the render if burn-in is on but ffmpeg lacks libass
     tts_meta = Path(args.tts_meta) if args.tts_meta else work_dir / "tts_meta.json"
     tts_segments = json.loads(tts_meta.read_text(encoding="utf-8"))["segments"]
     output_path = work_dir / "output.mp4"

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1103,8 +1103,13 @@ def _preflight_burn_subtitles():
     """Fail before the (re-encoding) render when burn-in is on but ffmpeg lacks the libass
     `subtitles` filter. _subtitle_burn_filter burns even the .ass through `subtitles=`, so
     that is the required capability. Defense-in-depth: the orchestrator (recap.py) preflights
-    this earlier, but assemble.py can be run standalone."""
+    this earlier, but assemble.py can be run standalone. Only fires when ffmpeg EXISTS but
+    can't burn — an absent ffmpeg fails the render regardless and would also break the mocked,
+    ffmpeg-less test environment."""
+    import shutil
     if not CONFIG.get("burn_subtitles", False):
+        return
+    if shutil.which("ffmpeg") is None:
         return
     if "subtitles" not in _ffmpeg_filters():
         raise SystemExit(

--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -60,7 +60,7 @@ Cut mode (`--edit-mode cut --target-duration 10m`) also requires `clip_plan.json
 Rerun the **same command** (narration.json now exists):
 
 ```bash
-python3 scripts/recap.py <video> --work-dir <work_dir>          # [--edit-mode cut] [--burn-subtitles]
+python3 scripts/recap.py <video> --work-dir <work_dir>          # [--edit-mode cut] [--no-burn-subtitles]
 ```
 
 This validates the narration, (cut: builds `edited_source.mp4`), synthesizes the voiceover, and
@@ -80,7 +80,7 @@ python3 scripts/recap.py --doctor
 ## Options (passed through to the stage skills)
 `--context`, `--scene-threshold`, `--style`, `--edit-mode {full,cut}`, `--target-duration`,
 `--skip-asr`, `--mimo-video-overview`, `--consolidate`, `--consolidate-asr`, `--mimo-tts-voice`,
-`--burn-subtitles`, `--output-dir`.
+`--no-burn-subtitles` (burn is on by default), `--output-dir`.
 
 ## What this skill does NOT do
 - Does NOT write narration.json / clip_plan.json — the agent authors those (see the video-script skill).

--- a/skills/video-recap/scripts/doctor.py
+++ b/skills/video-recap/scripts/doctor.py
@@ -51,6 +51,15 @@ def _ffmpeg_filters() -> set[str]:
     return filters
 
 
+def ffmpeg_has_subtitles_filter() -> bool:
+    """True when this ffmpeg can burn subtitles — its filter list includes the libass
+    `subtitles` filter. The render burns even the .ass file through `subtitles=` (see
+    video-assemble assemble.py:_subtitle_burn_filter), so this — not the `ass` filter — is
+    the exact capability `--burn-subtitles` needs. Reused by the orchestrator preflight
+    (recap.py) to fail fast before any API spend."""
+    return "subtitles" in _ffmpeg_filters()
+
+
 def _asr_status() -> dict[str, object]:
     configured = bool(CONFIG.get("mimo_asr_api_key"))
     return {

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -20,6 +20,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from doctor import ffmpeg_has_subtitles_filter
+
 BUNDLE = Path(__file__).resolve().parents[2]  # the skills/ directory
 RUN_MANIFEST = "recap_run_manifest.json"
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
@@ -85,6 +87,50 @@ def _load_json(path):
         return json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
         return None
+
+
+def _burn_subtitles_intended(args):
+    """Effective burn-subtitles state at orchestrator level. Mirrors video-assemble's
+    CONFIG default `env_bool("BURN_SUBTITLES", True)` (burn is ON by default); an explicit
+    CLI flag (--burn-subtitles / --no-burn-subtitles) overrides the env."""
+    if getattr(args, "burn_subtitles", None) is not None:
+        return bool(args.burn_subtitles)
+    raw = os.environ.get("BURN_SUBTITLES")
+    if raw is None or raw == "":
+        return True
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _preflight_burn_subtitles(args):
+    """Fail fast BEFORE any understanding/VLM/ASR/TTS spend when subtitle burn-in is on but
+    this ffmpeg lacks the libass `subtitles` filter. Without it the run only dies at the
+    final assemble `-vf subtitles=` step — after the whole expensive pipeline has run."""
+    if not _burn_subtitles_intended(args):
+        return
+    if not ffmpeg_has_subtitles_filter():
+        raise SystemExit(
+            "字幕烧录已开启，但当前 ffmpeg 不支持 subtitles/libass 滤镜，整条流程会跑到最后渲染才失败。\n"
+            "  解决其一：(1) 安装带 libass 的 ffmpeg；(2) 加 --no-burn-subtitles 关闭烧录"
+            "（仍输出 .srt 外挂字幕）。\n"
+            "  自检：python3 skills/video-recap/scripts/doctor.py")
+
+
+def _print_narration_review_pointer(work_dir):
+    """Surface the advisory narration review to the user at delivery — it is otherwise
+    buried in the video-script stage and never echoed by the orchestrator. Pointer only:
+    never blocks (validate.py is the hard gate). Silent when no review was run."""
+    review_md = Path(work_dir) / "narration_review.md"
+    if not review_md.exists():
+        return
+    data = _load_json(Path(work_dir) / "narration_review.json")
+    if isinstance(data, dict):
+        findings = [f for f in (data.get("findings") or []) if isinstance(f, dict)]
+        n_err = sum(1 for f in findings if f.get("severity") == "error")
+        tag = str(data.get("verdict") or "见文件")
+        print(f"[video-recap] 📋 解说评审（建议性，不拦截）: {tag} · "
+              f"{len(findings)} 条意见（error {n_err}）→ {review_md}")
+    else:
+        print(f"[video-recap] 📋 解说评审意见 → {review_md}")
 
 
 def _settings_for_compare(settings):
@@ -232,6 +278,10 @@ def main():
     if not args.video:
         ap.error("video is required (unless --doctor)")
 
+    # Fail fast before any expensive understanding/VLM/ASR/TTS work if the run will burn
+    # subtitles but this ffmpeg can't (otherwise it only blows up at the final render).
+    _preflight_burn_subtitles(args)
+
     video = Path(args.video).resolve()
     work_dir = Path(args.work_dir).resolve() if args.work_dir else video.parent / f"work_dir_{video.stem}"
     work_dir.mkdir(parents=True, exist_ok=True)
@@ -336,6 +386,8 @@ def main():
         aargs += ["--output-dir", args.output_dir]
     if args.burn_subtitles is not None:
         aargs.append("--burn-subtitles" if args.burn_subtitles else "--no-burn-subtitles")
+    # env-only burn intent (BURN_SUBTITLES) is propagated implicitly: assemble re-derives it
+    # via the same env_bool default the preflight used, so the two agree by shared env.
     if cut:
         # let the timeline / 剪映 export reference the original clips, not edited_source.mp4
         aargs += ["--source-video", str(video)]
@@ -350,6 +402,7 @@ def main():
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
     final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + video.stem + ".mp4"))
     print(f"[video-recap] ✅ 完成: {final_output}")
+    _print_narration_review_pointer(work_dir)
 
 
 if __name__ == "__main__":

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -101,13 +101,25 @@ def _burn_subtitles_intended(args):
     return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+def _ffmpeg_present_but_cannot_burn():
+    """True only when ffmpeg EXISTS but lacks the libass `subtitles` filter — the specific
+    "subtitle-burn environment unsupported" case. Returns False when ffmpeg is absent
+    entirely: that is a more fundamental problem that surfaces at the first stage (understand
+    calls ffprobe/ffmpeg) and is reported by doctor, so this guard stays narrow — and does
+    not fire in mocked, ffmpeg-less test environments."""
+    import shutil
+    if shutil.which("ffmpeg") is None:
+        return False
+    return not ffmpeg_has_subtitles_filter()
+
+
 def _preflight_burn_subtitles(args):
     """Fail fast BEFORE any understanding/VLM/ASR/TTS spend when subtitle burn-in is on but
-    this ffmpeg lacks the libass `subtitles` filter. Without it the run only dies at the
-    final assemble `-vf subtitles=` step — after the whole expensive pipeline has run."""
+    this ffmpeg can't burn it. Without it the run only dies at the final assemble
+    `-vf subtitles=` step — after the whole expensive pipeline has run."""
     if not _burn_subtitles_intended(args):
         return
-    if not ffmpeg_has_subtitles_filter():
+    if _ffmpeg_present_but_cannot_burn():
         raise SystemExit(
             "字幕烧录已开启，但当前 ffmpeg 不支持 subtitles/libass 滤镜，整条流程会跑到最后渲染才失败。\n"
             "  解决其一：(1) 安装带 libass 的 ffmpeg；(2) 加 --no-burn-subtitles 关闭烧录"

--- a/tests/assemble/test_burn_preflight.py
+++ b/tests/assemble/test_burn_preflight.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
+"""Fail-fast preflight: when subtitle burn-in is on but ffmpeg lacks the libass
+`subtitles` filter, assemble must raise BEFORE the render — not die at the final -vf."""
+import shutil  # noqa: E402
+import subprocess  # noqa: E402
+
+import pytest  # noqa: E402
+
+import assemble  # noqa: E402
+
+
+def test_preflight_raises_when_filter_missing(monkeypatch):
+    monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
+    monkeypatch.setattr(assemble, "_ffmpeg_filters", lambda: {"scale", "atempo"})
+    with pytest.raises(SystemExit, match="subtitles/libass"):
+        assemble._preflight_burn_subtitles()
+
+
+def test_preflight_ok_when_filter_present(monkeypatch):
+    monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
+    monkeypatch.setattr(assemble, "_ffmpeg_filters", lambda: {"subtitles", "scale"})
+    assemble._preflight_burn_subtitles()  # must not raise
+
+
+def test_preflight_skipped_when_burn_off(monkeypatch):
+    monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", False)
+
+    def _boom():
+        raise AssertionError("must not probe ffmpeg when burn is off")
+
+    monkeypatch.setattr(assemble, "_ffmpeg_filters", _boom)
+    assemble._preflight_burn_subtitles()  # must not raise, must not probe
+
+
+def test_ffmpeg_filters_parse_matches_doctor(monkeypatch):
+    """The parser must mirror doctor.py: take column-2 names from filter rows whose first
+    token starts with a flag char. A mis-parse returning an empty set would block every
+    capable ffmpeg, so this pins the parse contract."""
+    sample = (
+        "Filters:\n"
+        "  T.. atempo            A->A       Adjust audio tempo.\n"
+        " ..C subtitles          V->V       Render text subtitles.\n"
+        "garbage line with no flag token\n"
+    )
+
+    class _Result:
+        returncode = 0
+        stdout = sample
+
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Result())
+    filters = assemble._ffmpeg_filters()
+    assert "subtitles" in filters and "atempo" in filters
+
+
+def test_ffmpeg_filters_empty_when_ffmpeg_absent(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    assert assemble._ffmpeg_filters() == set()
+
+
+def test_ffmpeg_filters_empty_on_nonzero_returncode(monkeypatch):
+    class _Result:
+        returncode = 1
+        stdout = "should be ignored"
+
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Result())
+    assert assemble._ffmpeg_filters() == set()

--- a/tests/assemble/test_burn_preflight.py
+++ b/tests/assemble/test_burn_preflight.py
@@ -11,8 +11,9 @@ import pytest  # noqa: E402
 import assemble  # noqa: E402
 
 
-def test_preflight_raises_when_filter_missing(monkeypatch):
+def test_preflight_raises_when_present_but_filter_missing(monkeypatch):
     monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/ffmpeg")
     monkeypatch.setattr(assemble, "_ffmpeg_filters", lambda: {"scale", "atempo"})
     with pytest.raises(SystemExit, match="subtitles/libass"):
         assemble._preflight_burn_subtitles()
@@ -20,8 +21,22 @@ def test_preflight_raises_when_filter_missing(monkeypatch):
 
 def test_preflight_ok_when_filter_present(monkeypatch):
     monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/ffmpeg")
     monkeypatch.setattr(assemble, "_ffmpeg_filters", lambda: {"subtitles", "scale"})
     assemble._preflight_burn_subtitles()  # must not raise
+
+
+def test_preflight_noop_when_ffmpeg_absent(monkeypatch):
+    # ffmpeg absent entirely → guard stays out of it (render fails later regardless), so the
+    # mocked, ffmpeg-less test/CI environment is never blocked.
+    monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
+    monkeypatch.setattr(shutil, "which", lambda _n: None)
+
+    def _boom():
+        raise AssertionError("must not probe filters when ffmpeg is absent")
+
+    monkeypatch.setattr(assemble, "_ffmpeg_filters", _boom)
+    assemble._preflight_burn_subtitles()  # must not raise, must not probe
 
 
 def test_preflight_skipped_when_burn_off(monkeypatch):

--- a/tests/orchestrator/test_burn_preflight.py
+++ b/tests/orchestrator/test_burn_preflight.py
@@ -46,16 +46,16 @@ def test_burn_intended_env_token_forms(monkeypatch, raw, expected):
     assert recap._burn_subtitles_intended(_args()) is expected
 
 
-def test_preflight_raises_when_unsupported(monkeypatch):
+def test_preflight_raises_when_present_but_cannot_burn(monkeypatch):
     monkeypatch.delenv("BURN_SUBTITLES", raising=False)
-    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", lambda: False)
+    monkeypatch.setattr(recap, "_ffmpeg_present_but_cannot_burn", lambda: True)
     with pytest.raises(SystemExit, match="subtitles/libass"):
         recap._preflight_burn_subtitles(_args())
 
 
-def test_preflight_ok_when_supported(monkeypatch):
+def test_preflight_ok_when_can_burn(monkeypatch):
     monkeypatch.delenv("BURN_SUBTITLES", raising=False)
-    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", lambda: True)
+    monkeypatch.setattr(recap, "_ffmpeg_present_but_cannot_burn", lambda: False)
     recap._preflight_burn_subtitles(_args())  # must not raise
 
 
@@ -63,8 +63,29 @@ def test_preflight_does_not_probe_when_burn_off(monkeypatch):
     def _boom():
         raise AssertionError("must not probe ffmpeg when burn is off")
 
-    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", _boom)
+    monkeypatch.setattr(recap, "_ffmpeg_present_but_cannot_burn", _boom)
     recap._preflight_burn_subtitles(_args(burn_subtitles=False))  # must not raise
+
+
+def test_cannot_burn_false_when_ffmpeg_absent(monkeypatch):
+    # ffmpeg absent entirely → this guard stays out of it (fails later / reported by doctor)
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda _n: None)
+    assert recap._ffmpeg_present_but_cannot_burn() is False
+
+
+def test_cannot_burn_true_when_present_without_filter(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", lambda: False)
+    assert recap._ffmpeg_present_but_cannot_burn() is True
+
+
+def test_cannot_burn_false_when_present_with_filter(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", lambda: True)
+    assert recap._ffmpeg_present_but_cannot_burn() is False
 
 
 def test_review_pointer_prints_verdict(tmp_path, capsys):

--- a/tests/orchestrator/test_burn_preflight.py
+++ b/tests/orchestrator/test_burn_preflight.py
@@ -1,0 +1,101 @@
+import sys
+from argparse import Namespace
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-recap' / 'scripts'))
+"""Orchestrator fail-fast: recap.py must reject a burn-on run on an ffmpeg without the
+libass `subtitles` filter BEFORE any understand/VLM/ASR/TTS spend, and must surface the
+advisory narration review to the user at delivery."""
+import json  # noqa: E402
+
+import pytest  # noqa: E402
+
+import recap  # noqa: E402
+
+
+def _args(burn_subtitles=None):
+    return Namespace(burn_subtitles=burn_subtitles)
+
+
+def test_burn_intended_default_on(monkeypatch):
+    monkeypatch.delenv("BURN_SUBTITLES", raising=False)
+    assert recap._burn_subtitles_intended(_args()) is True
+
+
+def test_burn_intended_cli_overrides_to_off():
+    assert recap._burn_subtitles_intended(_args(burn_subtitles=False)) is False
+
+
+def test_burn_intended_env_off(monkeypatch):
+    monkeypatch.delenv("BURN_SUBTITLES", raising=False)
+    monkeypatch.setenv("BURN_SUBTITLES", "0")
+    assert recap._burn_subtitles_intended(_args()) is False
+
+
+def test_burn_intended_cli_beats_env(monkeypatch):
+    # explicit --burn-subtitles wins even when the env says off
+    monkeypatch.setenv("BURN_SUBTITLES", "0")
+    assert recap._burn_subtitles_intended(_args(burn_subtitles=True)) is True
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("on", True), ("yes", True), ("TRUE", True), ("1", True), (" 1 ", True),
+    ("0", False), ("no", False), ("off", False), ("false", False), ("garbage", False),
+])
+def test_burn_intended_env_token_forms(monkeypatch, raw, expected):
+    monkeypatch.setenv("BURN_SUBTITLES", raw)
+    assert recap._burn_subtitles_intended(_args()) is expected
+
+
+def test_preflight_raises_when_unsupported(monkeypatch):
+    monkeypatch.delenv("BURN_SUBTITLES", raising=False)
+    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", lambda: False)
+    with pytest.raises(SystemExit, match="subtitles/libass"):
+        recap._preflight_burn_subtitles(_args())
+
+
+def test_preflight_ok_when_supported(monkeypatch):
+    monkeypatch.delenv("BURN_SUBTITLES", raising=False)
+    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", lambda: True)
+    recap._preflight_burn_subtitles(_args())  # must not raise
+
+
+def test_preflight_does_not_probe_when_burn_off(monkeypatch):
+    def _boom():
+        raise AssertionError("must not probe ffmpeg when burn is off")
+
+    monkeypatch.setattr(recap, "ffmpeg_has_subtitles_filter", _boom)
+    recap._preflight_burn_subtitles(_args(burn_subtitles=False))  # must not raise
+
+
+def test_review_pointer_prints_verdict(tmp_path, capsys):
+    (tmp_path / "narration_review.md").write_text("# review", encoding="utf-8")
+    (tmp_path / "narration_review.json").write_text(
+        json.dumps({"verdict": "REVISE",
+                    "findings": [{"severity": "error"}, {"severity": "warning"}]}),
+        encoding="utf-8")
+    recap._print_narration_review_pointer(tmp_path)
+    out = capsys.readouterr().out
+    assert "REVISE" in out
+    assert "narration_review.md" in out
+    assert "error 1" in out
+
+
+def test_review_pointer_silent_when_absent(tmp_path, capsys):
+    recap._print_narration_review_pointer(tmp_path)
+    assert capsys.readouterr().out == ""
+
+
+def test_review_pointer_md_present_json_absent(tmp_path, capsys):
+    # md exists but no json → fall through to the plain-path branch, never crash
+    (tmp_path / "narration_review.md").write_text("# review", encoding="utf-8")
+    recap._print_narration_review_pointer(tmp_path)
+    out = capsys.readouterr().out
+    assert "narration_review.md" in out
+
+
+def test_review_pointer_json_malformed(tmp_path, capsys):
+    (tmp_path / "narration_review.md").write_text("# review", encoding="utf-8")
+    (tmp_path / "narration_review.json").write_text("{ not json", encoding="utf-8")
+    recap._print_narration_review_pointer(tmp_path)
+    out = capsys.readouterr().out
+    assert "narration_review.md" in out  # degrades to the plain pointer, no traceback


### PR DESCRIPTION
Acts on user feedback to **fail before wasting time/money** and make the content review **visible**, without adding new artifacts or pipeline stages (keeps the de-bloat ethos).

## What & why

**1. Subtitle-burn preflight (fail fast).** Burning subtitles needs an ffmpeg built with the libass `subtitles` filter. That check previously lived only in the opt-in `doctor.py`, and subtitle burn-in is **on by default** — so a user on a libass-less ffmpeg ran the entire pipeline (understand → VLM → ASR → narration → TTS) and only failed at the final `-vf subtitles=` render. The orchestrator now preflights this **at the very start of a run, before any API spend**, and exits with an actionable message (install a libass ffmpeg, or pass `--no-burn-subtitles`). `video-assemble` keeps the same guard for standalone runs (its own copy — skills share no code).

- The probe targets the `subtitles` filter (not `ass`) because `_subtitle_burn_filter` burns even the `.ass` through `subtitles=`. The parser mirrors `doctor.py` byte-for-byte (validated against real `ffmpeg -filters`: no false-block on a capable ffmpeg).
- `_burn_subtitles_intended` mirrors assemble's default exactly: on by default, `BURN_SUBTITLES` env honored, CLI flag overrides env.

**2. Surface the narration review at delivery.** When an advisory `narration_review.md` exists, the orchestrator now prints its verdict + path on completion, so the content-risk read (weak hook / no through-line / pacing) is visible at the end of a run instead of buried in the script stage. Still advisory — `validate.py` remains the only hard gate.

**3. Doc fix.** Both READMEs and the assemble/recap SKILL.md described burn-in as opt-in via `--burn-subtitles`; it has been **on by default** (opt out with `--no-burn-subtitles`). Corrected the wording (the "docs contradict code" item from the feedback).

## Scope deliberately excluded
- No hard duration-gate after cut (cut length is often intentional; the desync risk is already structurally gone).
- No new `recap_story_plan.json` / `content_qc.md` artifacts — craft is already taught in `brief.py`, the review already exists, and a new file would duplicate them.

## Tests
- New: `tests/assemble/test_burn_preflight.py`, `tests/orchestrator/test_burn_preflight.py` (parser-vs-doctor parity, raise/ok/skip-probe, env/CLI intent forms, review-pointer present/absent/malformed).
- Full suite green (302 across 6 groups via `python3 scripts/test.py`), ruff clean. Independently code-reviewed (APPROVE, no blocking/important findings). Functionally smoke-tested with a stubbed libass-less ffmpeg: fails at the preflight before `video-understanding` runs; `--no-burn-subtitles` skips the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)