### PR TITLE
Make cut-output recaps safer before spending render time

### DIFF
--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import re
 import wave
 from pathlib import Path
 
@@ -8,8 +9,10 @@ from lib import CONFIG
 from lib import log, run_cmd, get_video_duration
 from timeline import build_timeline, save_timeline
 
-SUBTITLE_RENDER_VERSION = 2
+SUBTITLE_RENDER_VERSION = 3
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
+_SUBTITLE_TERMINAL_PUNCTUATION = "。！？!?…."
+_SUBTITLE_CLOSING_QUOTES = "」』”’）)]】》〉\"'"
 
 
 def _stable_json_dumps(value):
@@ -192,7 +195,7 @@ def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
             "overlaps_speech": seg.get("overlaps_speech", True),
             "gain": 1.0,
         })
-    fade = CONFIG.get("duck_fade_seconds", 0.25)
+    fade = CONFIG.get("duck_fade_seconds", 0.3)
     bgm = None
     if has_bgm:
         bgm = {"source_path": CONFIG.get("bgm_path", ""),
@@ -203,11 +206,11 @@ def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
     # mode the draft gets editable volume keyframes (ffmpeg stays the canonical mix)
     ducking = None
     if CONFIG.get("ducking_mode", "fixed") != "none":
-        ducking = {"idle": CONFIG.get("idle_orig_volume", 0.85),
+        ducking = {"idle": CONFIG.get("idle_orig_volume", 1.0),
                    "speech": CONFIG.get("speech_ducking_volume", 0.2),
                    "quiet": CONFIG.get("zone_ducking_volume", 0.12),
                    "fade": fade,
-                   "bridge": CONFIG.get("duck_bridge_seconds", 12.0)}
+                   "bridge": CONFIG.get("duck_bridge_seconds", 1.5)}
     timeline = build_timeline(canvas, duration_s, video_clips,
                               narration_segments, bgm=bgm, ducking=ducking)
     out = Path(work_dir) / "timeline.json"
@@ -325,6 +328,50 @@ def _wrap_subtitle_text(text, max_chars=20, line_break="\n"):
     return line_break.join([line1, line2])
 
 
+def _subtitle_display_text(text):
+    """Return display-only subtitle text with trailing sentence punctuation removed.
+
+    Narration/TTS source text stays untouched; this is applied only to SRT/ASS cue text.
+    Closing quotes/brackets are preserved, so 「原声台词。」 renders as 「原声台词」.
+    """
+    text = str(text or "").strip()
+    if not text:
+        return ""
+    suffix = ""
+    while text and text[-1] in _SUBTITLE_CLOSING_QUOTES:
+        suffix = text[-1] + suffix
+        text = text[:-1].rstrip()
+    text = text.rstrip(_SUBTITLE_TERMINAL_PUNCTUATION).rstrip()
+    return (text + suffix).strip()
+
+
+def _subtitle_chunk_weight(text):
+    """Weight raw subtitle chunks for timing, independent of display punctuation cleanup."""
+    core = re.sub(r"\s+", "", str(text or ""))
+    return max(1, len(core))
+
+
+def _subtitle_entry_chunks(raw_chunks):
+    """Pair raw chunks used for timing with their final display text.
+
+    Timing remains based on the raw split topology. Terminal punctuation is stripped only
+    on the emitted text, while quote-only suffix chunks are folded into the previous cue
+    so a closing bracket never renders alone.
+    """
+    chunks = [str(c).strip() for c in (raw_chunks or []) if str(c).strip()]
+    out = []
+    for i, chunk in enumerate(chunks):
+        display = _subtitle_display_text(chunk)
+        if not display:
+            continue
+        if all(ch in _SUBTITLE_CLOSING_QUOTES for ch in display):
+            if out:
+                out[-1]["text"] += display
+            continue
+        out.append({"raw": chunk, "text": display})
+    return out
+
+
 def _split_subtitle_chunks(text, max_chars):
     """Split one narration block (often several sentences) into short display chunks.
 
@@ -332,7 +379,8 @@ def _split_subtitle_chunks(text, max_chars):
     whole paragraph as a single subtitle would force a tall multi-line band and lag the picture.
     So we cut the block at punctuation into clauses, then greedily pack adjacent clauses into
     chunks of at most `max_chars` — each chunk renders as ONE readable line synced to its slice of
-    the block's audio. Punctuation stays attached to its clause; we never orphan a lone mark."""
+    the block's audio. Punctuation stays attached here for lossless splitting; the display layer
+    strips terminal sentence marks per subtitle-cue style."""
     text = str(text).strip()
     if not text:
         return []
@@ -355,7 +403,8 @@ def _split_subtitle_chunks(text, max_chars):
                 sized.append(clause[i:i + max_chars])
     chunks, cur = [], ""
     for clause in sized:
-        if cur and len(cur) + len(clause) > max_chars:
+        sentence_closed = cur.rstrip().endswith(tuple(_SUBTITLE_TERMINAL_PUNCTUATION))
+        if cur and (sentence_closed or len(cur) + len(clause) > max_chars):
             chunks.append(cur)
             cur = clause
         else:
@@ -387,24 +436,25 @@ def _subtitle_entries(narration):
             continue
         if end - start < 0.1:
             continue
-        chunks = _split_subtitle_chunks(text, max_chars)
+        chunks = _subtitle_entry_chunks(_split_subtitle_chunks(text, max_chars))
         if not chunks:
             continue
         if len(chunks) == 1:
-            entries.append({"start": start, "end": end, "text": chunks[0]})
+            entries.append({"start": start, "end": end, "text": chunks[0]["text"]})
             continue
-        total_chars = sum(len(c) for c in chunks) or 1
+        total_chars = sum(_subtitle_chunk_weight(c["raw"]) for c in chunks) or 1
         span = end - start
         cursor = start
         for i, chunk in enumerate(chunks):
-            chunk_end = end if i == len(chunks) - 1 else cursor + span * (len(chunk) / total_chars)
+            weight = _subtitle_chunk_weight(chunk["raw"])
+            chunk_end = end if i == len(chunks) - 1 else cursor + span * (weight / total_chars)
             if i > 0 and chunk_end - cursor < 0.05:
                 # slice too short to show on its own — fold the text into the previous line of THIS
                 # block (i>0) and extend its end, so no chunk is ever silently dropped.
-                entries[-1]["text"] += chunk
+                entries[-1]["text"] += chunk["text"]
                 entries[-1]["end"] = chunk_end
             else:
-                entries.append({"start": cursor, "end": chunk_end, "text": chunk})
+                entries.append({"start": cursor, "end": chunk_end, "text": chunk["text"]})
             cursor = chunk_end
     return entries
 
@@ -416,22 +466,27 @@ _MAX_ORIGINAL_READ_CPS = 9.0     # densest an AUTO (uncalibrated) original line 
 
 
 def _distribute_chunks(chunks, start, end):
-    """Distribute [start,end] across one-line `chunks` in proportion to character count
-    (karaoke timing). Folds a too-short trailing slice into the previous line."""
+    """Distribute [start,end] across raw chunks while emitting display-clean text.
+
+    Terminal subtitle punctuation is visual-only: it is stripped from final cue text,
+    but the raw split chunks remain the timing topology.
+    """
+    chunks = _subtitle_entry_chunks(chunks)
     if not chunks or end - start < 0.1:
         return []
     if len(chunks) == 1:
-        return [{"start": start, "end": end, "text": chunks[0]}]
-    total_chars = sum(len(c) for c in chunks) or 1
+        return [{"start": start, "end": end, "text": chunks[0]["text"]}]
+    total_chars = sum(_subtitle_chunk_weight(c["raw"]) for c in chunks) or 1
     span = end - start
     out, cursor = [], start
     for i, chunk in enumerate(chunks):
-        chunk_end = end if i == len(chunks) - 1 else cursor + span * (len(chunk) / total_chars)
+        weight = _subtitle_chunk_weight(chunk["raw"])
+        chunk_end = end if i == len(chunks) - 1 else cursor + span * (weight / total_chars)
         if out and chunk_end - cursor < 0.05:
-            out[-1]["text"] += chunk
+            out[-1]["text"] += chunk["text"]
             out[-1]["end"] = chunk_end
         else:
-            out.append({"start": cursor, "end": chunk_end, "text": chunk})
+            out.append({"start": cursor, "end": chunk_end, "text": chunk["text"]})
         cursor = chunk_end
     return out
 
@@ -444,7 +499,10 @@ def _karaoke_chunks(text, start, end, max_chars):
 def _bracketed_original_chunks(text, start, end, max_chars):
     """Like _karaoke_chunks, but for ORIGINAL dialogue: wrap the whole line in 「」 so it reads
     as quoted original speech, visually distinct from the recap's own narration."""
-    chunks = _split_subtitle_chunks(str(text).strip().strip("「」"), max_chars)
+    raw = str(text).strip()
+    if raw.startswith("「") and raw.endswith("」"):
+        raw = raw[1:-1].strip()
+    chunks = _split_subtitle_chunks(raw, max_chars)
     if chunks:
         chunks = list(chunks)
         chunks[0] = "「" + chunks[0]
@@ -905,7 +963,7 @@ def _build_audio_filter_complex(
     """
     ducking_mode = CONFIG.get("ducking_mode", "fixed")
     narr_vol = CONFIG.get("ducking_narr_weight", 1.5)
-    fade = CONFIG.get("duck_fade_seconds", 0.25)
+    fade = CONFIG.get("duck_fade_seconds", 0.3)
     original_in = f"[{original_audio_label}]"
     bgm_in = f"[{bgm_audio_label or '2:a'}]"
 
@@ -914,7 +972,7 @@ def _build_audio_filter_complex(
     if has_bgm:
         base = CONFIG.get("bgm_volume", 0.18)
         bgm_expr = _bgm_envelope(tts_segments, base, CONFIG.get("bgm_ducking_volume", 0.10), fade,
-                                 bridge=CONFIG.get("duck_bridge_seconds", 12.0))
+                                 bridge=CONFIG.get("duck_bridge_seconds", 1.5))
         if bgm_expr:
             bgm_chain = f"{bgm_in}volume='{bgm_expr}':eval=frame,aresample=48000[bgm];"
         else:
@@ -939,10 +997,10 @@ def _build_audio_filter_complex(
         return f"{original_in}aresample=48000[orig];" + _amix_tail(narr_vol, bgm_chain)
 
     # fixed (default): gap-fill ducking envelope on the original track.
-    idle = CONFIG.get("idle_orig_volume", 0.85)
+    idle = CONFIG.get("idle_orig_volume", 1.0)
     speech_vol = CONFIG.get("speech_ducking_volume", 0.2)
     quiet_vol = CONFIG.get("zone_ducking_volume", 0.12)
-    bridge = CONFIG.get("duck_bridge_seconds", 12.0)
+    bridge = CONFIG.get("duck_bridge_seconds", 1.5)
     expr = _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=bridge)
     if expr:
         n_overlap = sum(1 for s in tts_segments if isinstance(s, dict) and s.get("overlaps_speech", True))

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -4,6 +4,7 @@ The bundle runs **zero-config** with sensible defaults. To change behavior, set 
 environment variables below (or pass the noted CLI flags) — they **override** the defaults.
 Nothing here is required; this is documentation only. No tool reads a config file, and the
 bundle ships no root `CLAUDE.md` (so it never collides with your project/global instructions).
+Defaults below are bundle-level defaults unless a note scopes them to a specific stage.
 
 | Concern | Env var / flag | Default | Notes |
 |---|---|---|---|
@@ -16,11 +17,11 @@ bundle ships no root `CLAUDE.md` (so it never collides with your project/global 
 | TTS model | `MIMO_TTS_MODEL` | `mimo-v2.5-tts` | the only TTS engine |
 | MiMo voice | `MIMO_TTS_VOICE` / `--mimo-tts-voice` | `冰糖` | |
 | Narration density | `TARGET_SEGMENTS_PER_MINUTE` | `9.6` | min `MIN_SEGMENTS_PER_MINUTE=6.24` |
-| Narration speed | `NARRATION_SPEED` | `1.2` | global atempo on the voiceover; default leans snappy for short-form, set `1.0` for long-form/documentary |
+| Narration speed | `NARRATION_SPEED` | `1.3` | global atempo on the voiceover; default leans snappy for short-form, set `1.0` for long-form/documentary |
 | Mask source subs | `MASK_SOURCE_SUBTITLES` / `SOURCE_SUBTITLE_MASK_RATIO` | on / `0.14` | covers burned-in source subtitles (bottom band) so only the recap's subtitles show; set `MASK_SOURCE_SUBTITLES=false` for sources without hardcoded subs |
-| Original ducking | `IDLE_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `0.85` / `0.2` | the original is held as a **continuous low bed** under narration: inter-beat gaps shorter than `duck_bridge_seconds` stay ducked (no swelling back up between sentences). Only the lead-in, lead-out, and genuine gaps >= `duck_bridge_seconds` return to the `IDLE` level. Ducks to `SPEECH` under each narration beat. `DUCKING_ORIG_VOLUME` (`0.3`) is only the fallback when beats carry no placement info |
-| Duck fade | `DUCK_FADE_SECONDS` | `0.25` | ramp time for each duck transition, so the original fades down/up without clicks |
-| Duck bridge | `DUCK_BRIDGE_SECONDS` | `12` | inter-beat gaps shorter than this stay ducked (continuous bed); gaps >= this return to the idle original. Default 12 s is just above `max_narration_gap_seconds` (11 s) — lower it to let section gaps resurface sooner |
+| Original ducking | `IDLE_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `1.0` / `0.2` | the original returns to full-volume `IDLE` in deliberate gaps/original blocks, and ducks to `SPEECH` under narration. Inter-beat gaps shorter than `DUCK_BRIDGE_SECONDS` stay ducked so a single narration block does not swell between sentences. `DUCKING_ORIG_VOLUME` (`0.3`) is only the fallback when beats carry no placement info |
+| Duck fade | `DUCK_FADE_SECONDS` | `0.3` | ramp time for each duck transition, so full-volume original blocks and ducked narration blocks switch without clicks |
+| Duck bridge | `DUCK_BRIDGE_SECONDS` | `1.5` | inter-beat gaps shorter than this stay ducked inside one narration block; gaps >= this are treated as intentional original-audio blocks and return to `IDLE_ORIG_VOLUME` |
 | Background music | `BGM_PATH` / `BGM_VOLUME` / `BGM_DUCKING_VOLUME` | off / `0.18` / `0.10` | optional looped music bed mixed as its own track; point `BGM_PATH` at any audio file. It ducks to `BGM_DUCKING_VOLUME` under narration |
 | Final loudness | `FINAL_LOUDNORM` / `TARGET_LUFS` | `true` / `-14` | end-of-pipeline normalize |
 | Style | `--style` | `纪录片` | |
@@ -30,6 +31,7 @@ bundle ships no root `CLAUDE.md` (so it never collides with your project/global 
 | VLM workers | `VLM_WORKERS` | `8` | lower to 1 if a proxy/WAF rate-limits |
 | Subtitle size | `SUBTITLE_FONT_SIZE` / `SUBTITLE_MARGIN_V` | `42` / `48` | look & placement |
 | 整理 / index | `--no-consolidate` / `--consolidate-asr` | on | build the understanding index (and optionally clean ASR); use `--no-consolidate` to skip |
+| Advisory narration review | `REVIEW_NARRATION` / `--review-narration` / `--no-review-narration` | on | runs `video-script/review.py` after validation and before TTS; advisory only and fail-open, while `validate.py` remains the hard gate. In cut mode the reviewer uses `clip_plan_validated.json` to remap VLM/ASR grounding onto the output timeline |
 | 剪映 export (optional) | `--export-jianying` / `EXPORT_JIANYING` | off | after rendering, also write a 剪映/JianYing draft from `timeline.json`. Decoupled — the core render never needs it |
 | 剪映 draft dir | `JIANYING_DRAFT_DIR` | work_dir | parent folder for the exported draft (point it at 剪映's drafts root to open in-app) |
 | 剪映 bundle media | `JIANYING_BUNDLE_MEDIA` / `--jianying-no-bundle-media` | **on** | copies media into the draft folder so it is self-contained. **Required on macOS** — 剪映 is sandboxed and cannot read external paths, so an unbundled draft opens with all media offline. Use `--jianying-no-bundle-media` only if 剪映 can reach the original paths |

--- a/skills/video-recap/scripts/doctor.py
+++ b/skills/video-recap/scripts/doctor.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 from lib import CONFIG
 
@@ -125,15 +126,17 @@ def build_report() -> dict[str, object]:
 
     failures: list[str] = []
     warnings: list[str] = []
-    tools = checks["system_tools"]  # type: ignore[index]
+    tools = cast(dict[str, Any], checks["system_tools"])
+    api_config = cast(dict[str, Any], checks["api_config"])
+    asr_check = cast(dict[str, Any], checks["asr"])
     for name in ("ffmpeg", "ffprobe"):
-        if not tools.get(name):  # type: ignore[union-attr]
+        if not tools.get(name):
             failures.append(f"Missing system tool: {name}")
-    if tools.get("ffmpeg") and not tools.get("ffmpeg_subtitles_filter"):  # type: ignore[union-attr]
+    if tools.get("ffmpeg") and not tools.get("ffmpeg_subtitles_filter"):
         warnings.append("ffmpeg lacks subtitles/libass filter; --burn-subtitles will fail")
-    if not checks["api_config"].get("api_key_set"):  # type: ignore[union-attr]
+    if not api_config.get("api_key_set"):
         failures.append("MIMO_API_KEY is not set; ASR / VLM / TTS all require a MiMo key")
-    if not checks["asr"].get("available"):  # type: ignore[union-attr]
+    if not asr_check.get("available"):
         warnings.append("ASR not configured (MIMO_API_KEY); pipeline can run with --skip-asr")
     return {
         "ok": not failures,
@@ -151,11 +154,11 @@ def _status_icon(ok: bool, *, warning: bool = False) -> str:
 
 
 def _print_human(report: dict[str, object]) -> None:
-    checks = report["checks"]  # type: ignore[index]
+    checks = cast(dict[str, Any], report["checks"])
     print("video-recap doctor")
     print(f"Repo root: {report['repo_root']}")
 
-    system = checks["system_tools"]  # type: ignore[index]
+    system = cast(dict[str, Any], checks["system_tools"])
     print("\n[system]")
     print(f"{_status_icon(bool(system.get('ffmpeg')))} ffmpeg: {system.get('ffmpeg_path') or 'not found'}")
     print(f"{_status_icon(bool(system.get('ffprobe')))} ffprobe: {system.get('ffprobe_path') or 'not found'}")
@@ -165,7 +168,7 @@ def _print_human(report: dict[str, object]) -> None:
         f"{'available' if system.get('ffmpeg_subtitles_filter') else 'missing'}"
     )
 
-    api = checks["api_config"]  # type: ignore[index]
+    api = cast(dict[str, Any], checks["api_config"])
     print("\n[api]")
     print(f"✓ API provider: {api.get('api_provider')}")
     print(f"✓ API URL: {api.get('api_url')} (source: {api.get('api_url_source')})")
@@ -176,7 +179,7 @@ def _print_human(report: dict[str, object]) -> None:
     print(f"✓ VLM model: {api.get('vlm_model')} (source: {api.get('vlm_model_source')})")
     print(f"✓ VLM_WORKERS: {api.get('vlm_workers')}")
 
-    asr = checks["asr"]  # type: ignore[index]
+    asr = cast(dict[str, Any], checks["asr"])
     print("\n[asr]")
     print(
         f"{_status_icon(bool(asr.get('available')), warning=True)} "
@@ -189,7 +192,7 @@ def _print_human(report: dict[str, object]) -> None:
     if not asr.get("available"):
         print(f"  note: {asr.get('note')}")
 
-    tts = checks["tts"]  # type: ignore[index]
+    tts = cast(dict[str, Any], checks["tts"])
     print("\n[tts]")
     print(
         f"{_status_icon(bool(tts.get('available')))} MiMo TTS: "
@@ -199,13 +202,15 @@ def _print_human(report: dict[str, object]) -> None:
     print(f"✓ TTS voice: {tts.get('mimo_tts_voice')} (source: {tts.get('mimo_tts_voice_source')})")
     print(f"✓ TTS API URL: {tts.get('mimo_tts_api_url')} (source: {tts.get('mimo_tts_api_url_source')})")
 
-    if report.get("warnings"):
+    warnings = cast(list[str], report.get("warnings") or [])
+    failures = cast(list[str], report.get("failures") or [])
+    if warnings:
         print("\nWarnings:")
-        for warning in report["warnings"]:  # type: ignore[index]
+        for warning in warnings:
             print(f"- {warning}")
-    if report.get("failures"):
+    if failures:
         print("\nStatus: FAILED")
-        for failure in report["failures"]:  # type: ignore[index]
+        for failure in failures:
             print(f"- {failure}")
     else:
         print("\nStatus: OK")

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -200,8 +200,8 @@ CONFIG = {
     "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
     "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
     "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
     "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -14,6 +14,7 @@ work_dir artifacts.
 import argparse
 import hashlib
 import json
+import math
 import os
 import shlex
 import subprocess
@@ -38,6 +39,58 @@ def _run(skill, script, *cli_args):
     res = subprocess.run(cmd)
     if res.returncode != 0:
         raise SystemExit(f"{skill}/{script} 失败 (exit {res.returncode})")
+
+
+def _env_bool(name, default=False):
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _read_video_duration_or_raise(path):
+    """Return media duration via ffprobe, or hard-fail before downstream TTS/render."""
+    path = Path(path)
+    cmd = [
+        "ffprobe", "-v", "quiet", "-show_entries", "format=duration",
+        "-of", "csv=p=0", str(path),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        detail = (res.stderr or res.stdout or "ffprobe failed").strip()
+        raise SystemExit(f"无法读取成片时长: {path} ({detail})")
+    try:
+        duration = float(res.stdout.strip())
+    except (TypeError, ValueError):
+        raise SystemExit(f"无法读取成片时长: {path} (ffprobe 输出无效: {res.stdout!r})")
+    if not math.isfinite(duration) or duration <= 0:
+        raise SystemExit(f"无法读取成片时长: {path} (duration={duration:.3f})")
+    return duration
+
+
+def _review_narration_enabled(args):
+    if getattr(args, "review_narration", None) is not None:
+        return bool(args.review_narration)
+    return _env_bool("REVIEW_NARRATION", True)
+
+
+def _run_advisory_review(work_dir, args, *, timeline="source"):
+    """Run quality review before TTS, but never block production on reviewer availability.
+
+    Returns True only when review.py completed, so the completion message can avoid
+    pointing at stale review artifacts after an opt-out or fail-open run.
+    """
+    if not _review_narration_enabled(args):
+        return False
+    try:
+        rargs = ["--work-dir", work_dir]
+        if timeline != "source":
+            rargs += ["--timeline", timeline]
+        _run("video-script", "review.py", *rargs)
+    except SystemExit as exc:
+        print(f"[video-recap] ⚠️ 建议性评审失败，继续执行 TTS: {exc}", flush=True)
+        return False
+    return True
 
 
 def _file_fingerprint(path, chunk_size=1024 * 1024):
@@ -127,10 +180,14 @@ def _preflight_burn_subtitles(args):
             "  自检：python3 skills/video-recap/scripts/doctor.py")
 
 
-def _print_narration_review_pointer(work_dir):
-    """Surface the advisory narration review to the user at delivery — it is otherwise
-    buried in the video-script stage and never echoed by the orchestrator. Pointer only:
-    never blocks (validate.py is the hard gate). Silent when no review was run."""
+def _print_narration_review_pointer(work_dir, *, review_ran=True):
+    """Surface the advisory narration review produced by this run, if any.
+
+    Review is optional/fail-open. Avoid surfacing a stale narration_review.md from an
+    older run when review was disabled or failed before producing fresh artifacts.
+    """
+    if not review_ran:
+        return
     review_md = Path(work_dir) / "narration_review.md"
     if not review_md.exists():
         return
@@ -250,6 +307,8 @@ def _continuation_command(video, work_dir, args):
         parts.append("--jianying-bundle-media")
     if getattr(args, "jianying_no_bundle_media", False):
         parts.append("--jianying-no-bundle-media")
+    if getattr(args, "review_narration", None) is not None:
+        parts.append("--review-narration" if args.review_narration else "--no-review-narration")
     return " ".join(shlex.quote(part) for part in parts)
 
 
@@ -274,6 +333,8 @@ def main():
                     help="allow video-voiceover to continue when some narration segments fail TTS")
     ap.add_argument("--burn-subtitles", action=argparse.BooleanOptionalAction, default=None,
                     help="burn narration subtitles into the video (default on; --no-burn-subtitles to disable)")
+    ap.add_argument("--review-narration", action=argparse.BooleanOptionalAction, default=None,
+                    help="run advisory narration quality review before TTS (default on; fail-open)")
     ap.add_argument("--output-dir", default=None)
     ap.add_argument("--export-jianying", action="store_true",
                     help="also export an OPTIONAL 剪映/JianYing draft (decoupled; never required)")
@@ -383,9 +444,12 @@ def main():
                 "请删除 narration.json，重跑后按新成片重新写解说。")
         _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp,
                             narration_fingerprint=_file_md5(narration_json), narration_written=True)
-        _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", "cut_output")
+        output_duration = _read_video_duration_or_raise(edited_source)
+        _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", "cut_output",
+             "--output-duration", f"{output_duration:.3f}")
         narration_for_tts = narration_json
         assemble_video_path = edited_source
+    review_ran = _run_advisory_review(work_dir, args, timeline="cut_output" if cut else "source")
     vargs = ["--work-dir", str(work_dir), "--narration", str(narration_for_tts)]
     if args.mimo_tts_voice:
         vargs += ["--mimo-voice", args.mimo_tts_voice]
@@ -414,7 +478,7 @@ def main():
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
     final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + video.stem + ".mp4"))
     print(f"[video-recap] ✅ 完成: {final_output}")
-    _print_narration_review_pointer(work_dir)
+    _print_narration_review_pointer(work_dir, review_ran=review_ran)
 
 
 if __name__ == "__main__":

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -210,8 +210,8 @@ CONFIG = {
     "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
     "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
     "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
     "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -457,7 +457,7 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                     start=start, end=end, budget_chars=budget, actual_chars=char_count,
                     estimated_tts_seconds=round(estimated_tts_seconds, 2), slot_seconds=round(slot_seconds, 2),
                 ))
-            if text[-1] not in "。！？!?…":
+            if text[-1] not in "。！？!?….":
                 warnings.append(_lint_issue(
                     "warning", idx, "incomplete_sentence",
                     "Narration should end with a complete sentence punctuation",

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -11,7 +11,9 @@ Output: narration_review.json (structured) + narration_review.md (readable). Adv
 verdict REVISE means "fix and re-review"; it never blocks (validate.py is the hard gate).
 """
 import argparse
+import hashlib
 import json
+import math
 import re
 from pathlib import Path
 
@@ -35,6 +37,11 @@ RUBRIC = """你是中文视频解说稿的严格评审。依据以下规则审�
 {"verdict":"REVISE|OK","summary":"一两句总体判断","findings":[{"segment":<草稿段号(从0起)或null表示整体>,"severity":"error|warning|suggestion","category":"<上面类别之一>","issue":"问题","fix":"具体改法"}]}"""
 
 
+
+def _value_fingerprint(value):
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.md5(payload.encode("utf-8")).hexdigest()
+
 def _load(work_dir, name):
     path = Path(work_dir) / name
     if not path.exists():
@@ -43,6 +50,138 @@ def _load(work_dir, name):
         return json.loads(path.read_text(encoding="utf-8"))
     except (ValueError, OSError):
         return None
+
+
+
+
+def _load_cut_clip_spans(work_dir):
+    """Load explicit source→output spans from the validated cut plan only.
+
+    `cut_output` review compares output-time narration to output-time evidence. A raw
+    clip_plan can be pre-padding/pre-snap and may omit output spans, so using it would
+    look grounded while disagreeing with edited_source.mp4. Missing/stale validated data
+    should fail this advisory stage and let the orchestrator fail-open visibly.
+    """
+    work_dir = Path(work_dir)
+    plan = _load(work_dir, "clip_plan_validated.json")
+    if not isinstance(plan, dict):
+        return None
+    raw_plan = _load(work_dir, "clip_plan.json")
+    if raw_plan is not None and plan.get("raw_plan_fingerprint") != _value_fingerprint(raw_plan):
+        return None
+    clips = plan.get("clips")
+    if not isinstance(clips, list):
+        return None
+    spans = []
+    for clip in clips:
+        if not isinstance(clip, dict):
+            continue
+        if not all(key in clip for key in ("source_start", "source_end", "output_start", "output_end")):
+            return None
+        try:
+            source_start = float(clip["source_start"])
+            source_end = float(clip["source_end"])
+            output_start = float(clip["output_start"])
+            output_end = float(clip["output_end"])
+        except (TypeError, ValueError):
+            return None
+        values = (source_start, source_end, output_start, output_end)
+        if not all(math.isfinite(value) for value in values):
+            return None
+        if source_end <= source_start or output_end <= output_start:
+            return None
+        spans.append({
+            "source_start": source_start,
+            "source_end": source_end,
+            "output_start": output_start,
+            "output_end": output_end,
+        })
+    return spans or None
+
+
+def _source_output_overlaps(start, end, spans):
+    overlaps = []
+    for span in spans or []:
+        source_start = max(start, span["source_start"])
+        source_end = min(end, span["source_end"])
+        if source_end <= source_start:
+            continue
+        output_start = span["output_start"] + (source_start - span["source_start"])
+        output_end = span["output_start"] + (source_end - span["source_start"])
+        overlaps.append({
+            "source_start": source_start,
+            "source_end": source_end,
+            "output_start": output_start,
+            "output_end": output_end,
+        })
+    return overlaps
+
+
+def _map_source_range_to_output(start, end, spans):
+    return [(o["output_start"], o["output_end"]) for o in _source_output_overlaps(start, end, spans)]
+
+
+def _remap_frame_facts(frame_facts, overlap):
+    if not isinstance(frame_facts, dict):
+        return frame_facts
+    out = {}
+    for raw_ts, vals in frame_facts.items():
+        try:
+            ts = float(raw_ts)
+        except (TypeError, ValueError):
+            continue
+        if not (overlap["source_start"] <= ts <= overlap["source_end"]):
+            continue
+        out_ts = overlap["output_start"] + (ts - overlap["source_start"])
+        out[f"{out_ts:.3f}"] = vals
+    return out
+
+
+def remap_grounding_to_output_timeline(vlm_analysis, asr_result, clip_spans):
+    """Return VLM/ASR grounding clipped/remapped from source time to cut output time."""
+    if not clip_spans:
+        return vlm_analysis or [], asr_result or []
+
+    remapped_scenes = []
+    for scene in vlm_analysis or []:
+        if not isinstance(scene, dict):
+            continue
+        try:
+            start = float(scene.get("start", 0))
+            end = float(scene.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        overlaps = _source_output_overlaps(start, end, clip_spans)
+        for part_idx, overlap in enumerate(overlaps):
+            item = dict(scene)
+            item["start"] = round(overlap["output_start"], 3)
+            item["end"] = round(overlap["output_end"], 3)
+            item["frame_facts"] = _remap_frame_facts(scene.get("frame_facts"), overlap)
+            if len(overlaps) > 1:
+                item["scene_id"] = f"{scene.get('scene_id', '?')}.{part_idx}"
+            remapped_scenes.append(item)
+
+    remapped_asr = []
+    for seg in asr_result or []:
+        if not isinstance(seg, dict):
+            continue
+        try:
+            start = float(seg.get("start", 0))
+            end = float(seg.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        text = str(seg.get("text", "")).strip()
+        if not text:
+            continue
+        for overlap in _source_output_overlaps(start, end, clip_spans):
+            item = dict(seg)
+            item["start"] = round(overlap["output_start"], 3)
+            item["end"] = round(overlap["output_end"], 3)
+            remapped_asr.append(item)
+
+    remapped_scenes.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
+    remapped_asr.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
+    return remapped_scenes, remapped_asr
 
 
 def _scene_grounding(vlm_analysis, limit=60):
@@ -173,13 +312,20 @@ def format_review_md(review):
     return "\n".join(out) + "\n"
 
 
-def review_narration(work_dir):
+def review_narration(work_dir, *, timeline="source"):
     work_dir = Path(work_dir)
     narration = _load(work_dir, "narration.json")
     if narration is None:
         raise SystemExit(f"缺少 {work_dir / 'narration.json'}；先写解说草稿再评审")
     vlm_analysis = _load(work_dir, "vlm_analysis.json") or []
     asr_result = _load(work_dir, "asr_result.json") or []
+    if timeline == "cut_output":
+        spans = _load_cut_clip_spans(work_dir)
+        if not spans:
+            raise SystemExit("cut_output review requires fresh clip_plan_validated.json with explicit source/output spans")
+        vlm_analysis, asr_result = remap_grounding_to_output_timeline(vlm_analysis, asr_result, spans)
+    elif timeline != "source":
+        raise SystemExit(f"unknown review timeline: {timeline}")
 
     messages = build_review_messages(narration, vlm_analysis, asr_result)
     resp = api_call({
@@ -206,8 +352,10 @@ def review_narration(work_dir):
 def main():
     ap = argparse.ArgumentParser(description="Review an agent-written narration.json for quality (LLM-as-judge).")
     ap.add_argument("--work-dir", required=True)
+    ap.add_argument("--timeline", choices=["source", "cut_output"], default="source",
+                    help="grounding timeline for narration.json; cut_output remaps source VLM/ASR via clip_plan_validated.json")
     args = ap.parse_args()
-    review = review_narration(args.work_dir)
+    review = review_narration(args.work_dir, timeline=args.timeline)
     print(json.dumps({
         "status": "reviewed",
         "verdict": review["verdict"],

--- a/skills/video-script/scripts/validate.py
+++ b/skills/video-script/scripts/validate.py
@@ -8,6 +8,7 @@ in full mode, rewrites narration.json with quiet-window alignment applied.
 import argparse
 import hashlib
 import json
+import math
 from pathlib import Path
 
 from lib import CONFIG, log
@@ -49,10 +50,57 @@ def _load_cut_clip_plan(work_dir):
     return raw
 
 
+
+
+def _validate_output_timeline_bounds(narration, output_duration, tolerance=0.05):
+    """Hard-gate cut_output narration against the rendered output timeline.
+
+    cut_output narration is authored in edited_source.mp4 time. If any segment falls outside
+    that media duration, fail before TTS/render instead of spending time on unusable audio.
+    """
+    try:
+        duration = float(output_duration)
+    except (TypeError, ValueError):
+        raise SystemExit(f"output_duration must be numeric, got {output_duration!r}")
+    if not math.isfinite(duration) or duration <= 0:
+        raise SystemExit(f"output_duration must be finite and positive, got output_duration={duration:.3f}")
+    if not isinstance(narration, list):
+        return
+
+    problems = []
+    for idx, seg in enumerate(narration):
+        if not isinstance(seg, dict):
+            continue
+        try:
+            start = float(seg.get("start"))
+            end = float(seg.get("end"))
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(start) or not math.isfinite(end):
+            problems.append(f"segment {idx} has non-finite time [{start!r},{end!r}]")
+            continue
+        if end <= -tolerance or start >= duration + tolerance:
+            problems.append(
+                f"segment {idx} [{start:.3f},{end:.3f}] fully outside output_duration={duration:.3f}"
+            )
+            continue
+        if start < -tolerance:
+            problems.append(
+                f"segment {idx} start={start:.3f} before output timeline (output_duration={duration:.3f})"
+            )
+        if end > duration + tolerance:
+            problems.append(
+                f"segment {idx} end={end:.3f} exceeds output_duration={duration:.3f}"
+            )
+    if problems:
+        raise SystemExit("cut_output narration exceeds rendered output timeline: " + "; ".join(problems))
+
 def main():
     ap = argparse.ArgumentParser(description="Validate + align agent-written narration.json.")
     ap.add_argument("--work-dir", required=True)
     ap.add_argument("--mode", default="full", choices=["full", "cut", "cut_output"])
+    ap.add_argument("--output-duration", type=float, default=None,
+                    help="cut_output: rendered edited_source.mp4 duration in seconds")
     args = ap.parse_args()
 
     work_dir = Path(args.work_dir)
@@ -68,6 +116,9 @@ def main():
         # no clip_plan to fall into and no source-time scene/quiet data to align to. Lint timing /
         # budget / overlap / density on the output timeline only; never realign or rewrite it.
         validate_narration_or_raise(narration, None, clip_plan=None, mode="full", work_dir=work_dir)
+        if args.output_duration is None:
+            raise SystemExit("--output-duration is required when --mode cut_output")
+        _validate_output_timeline_bounds(narration, args.output_duration)
     elif args.mode == "cut":
         clip_plan = _load_cut_clip_plan(work_dir)
         validate_narration_or_raise(narration, vlm_analysis, clip_plan=clip_plan, mode="cut", work_dir=work_dir)

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -457,7 +457,7 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                     start=start, end=end, budget_chars=budget, actual_chars=char_count,
                     estimated_tts_seconds=round(estimated_tts_seconds, 2), slot_seconds=round(slot_seconds, 2),
                 ))
-            if text[-1] not in "。！？!?…":
+            if text[-1] not in "。！？!?….":
                 warnings.append(_lint_issue(
                     "warning", idx, "incomplete_sentence",
                     "Narration should end with a complete sentence punctuation",

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -210,8 +210,8 @@ CONFIG = {
     "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
     "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
     "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
     "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -210,8 +210,8 @@ CONFIG = {
     "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
     "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
     "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 0.85, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.25, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
+    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
+    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
     "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
     "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
     "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)

--- a/tests/assemble/test_original_gap_subtitles.py
+++ b/tests/assemble/test_original_gap_subtitles.py
@@ -154,6 +154,32 @@ def test_original_lines_wrapped_in_brackets(monkeypatch, tmp_path):
     assert joined.startswith("「") and joined.endswith("」")
 
 
+def test_original_gap_entries_strip_terminal_punctuation_inside_brackets(monkeypatch, tmp_path):
+    _burn_on(monkeypatch)
+    (tmp_path / "asr_result.json").write_text(
+        json.dumps([{"start": 1.0, "end": 4.0, "text": "原声台词。"}]), encoding="utf-8")
+    segs = [{"actual_place_start": 5.0, "actual_place_end": 8.0, "narration": "解说"}]
+
+    entries = assemble._original_gap_subtitle_entries(segs, tmp_path, 10.0)
+
+    joined = "".join(e["text"] for e in entries)
+    assert joined == "「原声台词」"
+    assert "原声台词。" not in joined
+
+
+def test_original_gap_entries_keep_closing_quote_with_stripped_terminal_punctuation(monkeypatch, tmp_path):
+    _burn_on(monkeypatch)
+    (tmp_path / "asr_result.json").write_text(
+        json.dumps([{"start": 1.0, "end": 4.0, "text": "他说：「你好。」"}]), encoding="utf-8")
+    segs = [{"actual_place_start": 5.0, "actual_place_end": 8.0, "narration": "解说"}]
+
+    entries = assemble._original_gap_subtitle_entries(segs, tmp_path, 10.0)
+
+    texts = [e["text"] for e in entries]
+    assert "」" not in texts
+    assert "".join(texts) == "「他说：「你好」」"
+
+
 def test_agent_subtitles_preferred_over_asr(monkeypatch, tmp_path):
     _burn_on(monkeypatch)
     # ASR has a (wrong) line; the agent-calibrated file should win

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -273,6 +273,25 @@ def test_generate_srt_uses_actual_placement(tmp_path):
     assert "过短跳过" not in srt
 
 
+def test_generate_srt_strips_terminal_display_punctuation_without_mutating_source(tmp_path):
+    narration = [
+        {"start": 0.0, "end": 2.0, "actual_place_start": 0.5, "actual_place_end": 1.7, "narration": "他终于明白真相。"},
+        {"start": 2.0, "end": 4.0, "actual_place_start": 2.2, "actual_place_end": 3.5, "narration": "What now?"},
+        {"start": 4.0, "end": 6.0, "actual_place_start": 4.2, "actual_place_end": 5.5, "narration": "It ends."},
+    ]
+
+    _generate_srt(narration, tmp_path)
+
+    srt = (tmp_path / "subtitles.srt").read_text(encoding="utf-8")
+    assert "他终于明白真相\n" in srt
+    assert "他终于明白真相。" not in srt
+    assert "What now\n" in srt
+    assert "What now?" not in srt
+    assert "It ends\n" in srt
+    assert "It ends." not in srt
+    assert narration[0]["narration"].endswith("。")  # display-only; TTS source is untouched
+
+
 def test_generate_ass_escapes_text_and_writes_style(tmp_path):
     _generate_ass([
         {
@@ -290,6 +309,22 @@ def test_generate_ass_escapes_text_and_writes_style(tmp_path):
     assert "Dialogue: 0,0:00:01.25,0:00:03.50" in ass
     assert r"第一行\{重点\}\\路径\N第二行" in ass
     assert _escape_ass_text("{x}\\y") == r"\{x\}\\y"
+
+
+def test_generate_ass_strips_terminal_display_punctuation_before_escaping(tmp_path):
+    _generate_ass([
+        {
+            "start": 1.0,
+            "end": 4.0,
+            "actual_place_start": 1.25,
+            "actual_place_end": 3.5,
+            "narration": "他终于明白真相。",
+        }
+    ], tmp_path)
+
+    ass = (tmp_path / "subtitles.ass").read_text(encoding="utf-8")
+    assert "他终于明白真相" in ass
+    assert "他终于明白真相。" not in ass
 
 
 def test_build_timed_narration_clamps_delay_to_slot(monkeypatch, tmp_path):
@@ -749,6 +784,38 @@ def test_split_subtitle_chunks_breaks_block_into_short_one_line_pieces():
     assert _split_subtitle_chunks("   ", max_chars=20) == []
 
 
+def test_subtitle_entries_keep_timing_topology_when_stripping_display_punctuation():
+    entries = _subtitle_entries([
+        {
+            "start": 0.0,
+            "end": 10.0,
+            "actual_place_start": 0.0,
+            "actual_place_end": 10.0,
+            "narration": "短。长长长长。",
+        }
+    ])
+
+    assert [e["text"] for e in entries] == ["短", "长长长长"]
+    # Raw chunks are "短。" and "长长长长。" (2:5), so display cleanup must not
+    # retime the cue as stripped display text (1:4).
+    assert entries[0]["end"] == pytest.approx(10.0 * 2 / 7)
+
+
+def test_subtitle_entries_keep_closing_quote_with_stripped_terminal_punctuation():
+    entries = _subtitle_entries([
+        {
+            "start": 0.0,
+            "end": 2.0,
+            "actual_place_start": 0.0,
+            "actual_place_end": 2.0,
+            "narration": "他说：「你好。」",
+        }
+    ])
+
+    assert [e["text"] for e in entries] == ["他说：「你好」"]
+    assert all(e["text"] != "」" for e in entries)
+
+
 def test_subtitle_entries_distribute_block_window_across_chunks():
     # one placed block of 12s -> several timed one-line entries spanning [start, end] with no gaps
     entries = _subtitle_entries([
@@ -765,6 +832,7 @@ def test_subtitle_entries_distribute_block_window_across_chunks():
         assert b["start"] == pytest.approx(a["end"])         # contiguous, karaoke-style
         assert a["end"] > a["start"]
     assert all(len(e["text"]) <= 20 for e in entries)        # each line is short
+    assert all(not e["text"].endswith(("。", "！", "？", "!", "?", "…")) for e in entries)
 
 
 def test_subtitle_entries_never_drops_a_sub_threshold_chunk():
@@ -780,4 +848,4 @@ def test_subtitle_entries_never_drops_a_sub_threshold_chunk():
     joined = "".join(e["text"] for e in entries)
     assert "第三" in joined                                   # the tiny trailing chunk survives
     assert entries[-1]["end"] == pytest.approx(0.3)          # still closes at the audio end
-    assert joined == "第一句子比较长一点点。第二句子也比较长。第三。"
+    assert joined == "第一句子比较长一点点第二句子也比较长第三"

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -19,6 +19,7 @@ def _manifest_args(**overrides):
         "mimo_video_overview": False,
         "consolidate": False,
         "consolidate_asr": False,
+        "review_narration": None,
     }
     defaults.update(overrides)
     return Namespace(**defaults)
@@ -113,6 +114,8 @@ def test_recap_full_mode_passes_explicit_narration_json(monkeypatch, tmp_path):
     voiceover_call = next(call for call in calls if call[:2] == ("video-voiceover", "voiceover.py"))
     args = voiceover_call[2]
     assert args[args.index("--narration") + 1] == str(work / "narration.json")
+    order = [script for _, script, _ in calls]
+    assert order.index("validate.py") < order.index("review.py") < order.index("voiceover.py")
 
 
 def test_recap_cut_mode_voiceover_uses_output_time_narration(monkeypatch, tmp_path):
@@ -147,6 +150,7 @@ def test_recap_cut_mode_voiceover_uses_output_time_narration(monkeypatch, tmp_pa
             )
 
     monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr("recap._read_video_duration_or_raise", lambda path: 10.0)
     monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
 
     recap.main()
@@ -157,6 +161,13 @@ def test_recap_cut_mode_voiceover_uses_output_time_narration(monkeypatch, tmp_pa
     assert "--no-narration-map" in cut_render
     asm = next(c for c in calls if c[:2] == ("video-assemble", "assemble.py"))[2]
     assert asm[0] == str(work / "edited_source.mp4")
+    validate_args = next(c for c in calls if c[:2] == ("video-script", "validate.py"))[2]
+    assert "--output-duration" in validate_args
+    assert validate_args[validate_args.index("--output-duration") + 1] == "10.000"
+    review_args = next(c for c in calls if c[:2] == ("video-script", "review.py"))[2]
+    assert review_args[review_args.index("--timeline") + 1] == "cut_output"
+    order = [script for _, script, _ in calls]
+    assert order.index("validate.py") < order.index("review.py") < order.index("voiceover.py")
 
 
 
@@ -224,6 +235,7 @@ def test_recap_honors_edit_mode_and_target_duration_env(monkeypatch, tmp_path):
     monkeypatch.setenv("EDIT_MODE", "cut")
     monkeypatch.setenv("TARGET_DURATION", "10m")
     monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr("recap._read_video_duration_or_raise", lambda path: 600.0)
     monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
 
     recap.main()
@@ -236,6 +248,7 @@ def test_recap_honors_edit_mode_and_target_duration_env(monkeypatch, tmp_path):
     validate_call = next(call for call in calls if call[:2] == ("video-script", "validate.py"))
     validate_args = validate_call[2]
     assert validate_args[validate_args.index("--mode") + 1] == "cut_output"
+    assert validate_args[validate_args.index("--output-duration") + 1] == "600.000"
 
 
 def test_recap_completion_prints_manifest_final_output(monkeypatch, tmp_path, capsys):
@@ -280,6 +293,7 @@ def test_recap_continuation_preserves_phase_b_flags(tmp_path):
     args.jianying_bundle_media = True
     args.jianying_no_bundle_media = False
     args.allow_partial_tts = True
+    args.review_narration = False
 
     cmd = recap._continuation_command(video, work, args)
 
@@ -290,6 +304,7 @@ def test_recap_continuation_preserves_phase_b_flags(tmp_path):
     assert "--export-jianying" in cmd
     assert "--jianying-bundle-media" in cmd
     assert "--jianying-no-bundle-media" not in cmd
+    assert "--no-review-narration" in cmd
 
 
 def test_recap_forwards_allow_partial_tts_to_voiceover(monkeypatch, tmp_path):
@@ -356,6 +371,132 @@ def test_recap_phase_b_allows_environment_changes_when_artifacts_are_unchanged(m
     recap.main()
 
     assert any(call[:2] == ("video-assemble", "assemble.py") for call in calls)
+
+
+def test_recap_advisory_review_failure_is_fail_open(monkeypatch, tmp_path, capsys):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "review.py":
+            raise SystemExit("review API unavailable")
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    order = [script for _, script, _ in calls]
+    assert "review.py" in order and "voiceover.py" in order
+    assert order.index("review.py") < order.index("voiceover.py")
+    assert "建议性评审失败" in capsys.readouterr().out
+
+
+def test_recap_does_not_print_stale_review_pointer_after_fail_open(monkeypatch, tmp_path, capsys):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    (work / "narration_review.md").write_text("# stale review", encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    def fake_run(skill, script, *cli_args):
+        if script == "review.py":
+            raise SystemExit("review API unavailable")
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    out = capsys.readouterr().out
+    assert "建议性评审失败" in out
+    assert "解说评审" not in out
+    assert "stale" not in out
+
+
+def test_recap_advisory_review_can_be_disabled(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--no-review-narration",
+    ])
+
+    recap.main()
+
+    assert not any(call[:2] == ("video-script", "review.py") for call in calls)
+    assert any(call[:2] == ("video-voiceover", "voiceover.py") for call in calls)
+
+
+def test_recap_cut_duration_read_failure_stops_before_tts(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 1, "end": 3, "narration": "解说。"}]), encoding="utf-8")
+    (work / "clip_plan.json").write_text(json.dumps([{"start": 10, "end": 12}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
+    recap._write_phase_ledger(work, clip_plan_fingerprint=recap._file_md5(work / "clip_plan.json"),
+                              edited_source_rendered=True)
+
+    def fake_run(skill, script, *cli_args):
+        if script == "cut.py":
+            (work / "edited_source.mp4").write_bytes(b"edited")
+        if script in ("validate.py", "review.py", "voiceover.py", "assemble.py"):
+            raise AssertionError(f"{script} must not run when duration cannot be read")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr("recap._read_video_duration_or_raise",
+                        lambda path: (_ for _ in ()).throw(SystemExit("无法读取成片时长")))
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut"])
+
+    with pytest.raises(SystemExit, match="无法读取成片时长"):
+        recap.main()
 
 
 def test_recap_resumes_old_manifest_missing_consolidate_key(monkeypatch, tmp_path):

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -110,6 +110,14 @@ def test_lint_block_coverage_metrics_and_warnings(monkeypatch):
     assert cut_report["metrics"] == {}
 
 
+
+def test_lint_narration_accepts_ascii_period_as_complete_sentence():
+    report = lint_narration([
+        {"start": 0.0, "end": 3.0, "narration": "It ends."},
+    ], mode="full")
+
+    assert "incomplete_sentence" not in {issue["code"] for issue in report["warnings"]}
+
 def test_lint_flags_fragmented_beats(tmp_path, monkeypatch):
     # The forbidden pattern: many lone short sentences instead of blocks -> each synthesizes as a
     # separate choppy TTS utterance, so fragmented_beats must fire.
@@ -490,3 +498,69 @@ def test_cut_validate_uses_validated_plan_when_raw_fingerprint_matches(tmp_path)
     plan = validate._load_cut_clip_plan(tmp_path)
 
     assert plan["clips"][0]["source_start"] == 40.0
+
+
+def test_cut_output_duration_bounds_rejects_segments_outside_output_timeline():
+    import sys
+    import importlib.util
+
+    validate_path = Path(__file__).resolve().parents[2] / "skills" / "video-script" / "scripts" / "validate.py"
+    spec = importlib.util.spec_from_file_location("video_script_validate_bounds_under_test", validate_path)
+    validate = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = validate
+    spec.loader.exec_module(validate)
+
+    validate._validate_output_timeline_bounds([
+        {"start": 0.0, "end": 9.95, "narration": "有效。"},
+    ], output_duration=10.0)
+
+    bad = [
+        {"start": -0.1, "end": 1.0, "narration": "负时间。"},
+        {"start": 9.0, "end": 10.2, "narration": "超出时长。"},
+        {"start": 10.1, "end": 11.0, "narration": "完全在外。"},
+    ]
+    with pytest.raises(SystemExit) as exc:
+        validate._validate_output_timeline_bounds(bad, output_duration=10.0)
+
+    msg = str(exc.value)
+    assert "output_duration=10.000" in msg
+    assert "segment 0" in msg and "segment 1" in msg and "segment 2" in msg
+
+
+def test_cut_output_mode_requires_output_duration(tmp_path):
+    import sys
+    import importlib.util
+
+    validate_path = Path(__file__).resolve().parents[2] / "skills" / "video-script" / "scripts" / "validate.py"
+    spec = importlib.util.spec_from_file_location("video_script_validate_required_duration_under_test", validate_path)
+    validate = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = validate
+    spec.loader.exec_module(validate)
+
+    (tmp_path / "narration.json").write_text(
+        json.dumps([{"start": 0.0, "end": 1.0, "narration": "有效。"}]),
+        encoding="utf-8",
+    )
+    old_argv = sys.argv
+    try:
+        sys.argv = ["validate.py", "--work-dir", str(tmp_path), "--mode", "cut_output"]
+        with pytest.raises(SystemExit, match="--output-duration is required"):
+            validate.main()
+    finally:
+        sys.argv = old_argv
+
+
+def test_cut_output_duration_bounds_rejects_non_finite_duration():
+    import sys
+    import importlib.util
+
+    validate_path = Path(__file__).resolve().parents[2] / "skills" / "video-script" / "scripts" / "validate.py"
+    spec = importlib.util.spec_from_file_location("video_script_validate_finite_duration_under_test", validate_path)
+    validate = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = validate
+    spec.loader.exec_module(validate)
+
+    with pytest.raises(SystemExit, match="finite and positive"):
+        validate._validate_output_timeline_bounds([{"start": 0.0, "end": 1.0}], output_duration=float("nan"))
+    with pytest.raises(SystemExit, match="non-finite time"):
+        validate._validate_output_timeline_bounds([{"start": float("nan"), "end": 1.0}], output_duration=10.0)

--- a/tests/script/test_review.py
+++ b/tests/script/test_review.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-script' / 'scripts'))
 import json
+import pytest
 
 import review
 
@@ -56,3 +57,67 @@ def test_review_reads_dict_frame_facts():
             "frame_facts": {"2.0": ["男子握紧拳头"], "4.0": ["女子后退一步"]}}]
     content = review.build_review_messages(narration, vlm, [])[0]["content"]
     assert "男子握紧拳头" in content and "女子后退一步" in content
+
+
+def test_cut_output_review_remaps_grounding_to_output_timeline():
+    spans = [{"source_start": 10.0, "source_end": 20.0, "output_start": 0.0, "output_end": 10.0}]
+    vlm, asr = review.remap_grounding_to_output_timeline(
+        [{"scene_id": 1, "start": 12.0, "end": 16.0, "description": "保留片段", "frame_facts": {"14.0": ["关键动作"], "21.0": ["剪掉动作"]}}],
+        [
+            {"start": 13.0, "end": 15.0, "text": "这句在成片三到五秒"},
+            {"start": 25.0, "end": 26.0, "text": "被剪掉"},
+        ],
+        spans,
+    )
+
+    assert vlm[0]["start"] == 2.0
+    assert vlm[0]["end"] == 6.0
+    assert vlm[0]["frame_facts"] == {"4.000": ["关键动作"]}
+    assert asr == [{"start": 3.0, "end": 5.0, "text": "这句在成片三到五秒"}]
+
+
+def test_review_narration_cut_output_requires_fresh_validated_clip_spans(monkeypatch, tmp_path):
+    (tmp_path / "narration.json").write_text(json.dumps([{"start": 1, "end": 2, "narration": "测试。"}]), encoding="utf-8")
+    monkeypatch.setattr("review.api_call", lambda payload: {"choices": [{"message": {"content": "{}"}}]})
+
+    with pytest.raises(SystemExit, match="clip_plan_validated"):
+        review.review_narration(tmp_path, timeline="cut_output")
+
+    raw = [{"start": 10, "end": 20}]
+    (tmp_path / "clip_plan.json").write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(SystemExit, match="clip_plan_validated"):
+        review.review_narration(tmp_path, timeline="cut_output")
+
+    stale = {
+        "raw_plan_fingerprint": "stale",
+        "clips": [{"source_start": 10, "source_end": 20, "output_start": 0, "output_end": 10}],
+    }
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps(stale), encoding="utf-8")
+    with pytest.raises(SystemExit, match="clip_plan_validated"):
+        review.review_narration(tmp_path, timeline="cut_output")
+
+
+def test_review_narration_cut_output_uses_remapped_grounding(monkeypatch, tmp_path):
+    (tmp_path / "narration.json").write_text(json.dumps([{"start": 3, "end": 5, "narration": "测试。"}]), encoding="utf-8")
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps([
+        {"scene_id": 1, "start": 12, "end": 16, "description": "保留片段", "frame_facts": {}}
+    ]), encoding="utf-8")
+    (tmp_path / "asr_result.json").write_text(json.dumps([{ "start": 13, "end": 15, "text": "输出三到五秒对白"}]), encoding="utf-8")
+    raw_plan = [{"start": 10, "end": 20}]
+    (tmp_path / "clip_plan.json").write_text(json.dumps(raw_plan), encoding="utf-8")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "raw_plan_fingerprint": review._value_fingerprint(raw_plan),
+        "clips": [{"source_start": 10, "source_end": 20, "output_start": 0, "output_end": 10}],
+    }), encoding="utf-8")
+    payloads = []
+
+    def fake_api(payload):
+        payloads.append(payload)
+        return {"choices": [{"message": {"content": '{"verdict":"OK","summary":"ok","findings":[]}'}}]}
+
+    monkeypatch.setattr("review.api_call", fake_api)
+    review.review_narration(tmp_path, timeline="cut_output")
+
+    content = payloads[0]["messages"][0]["content"]
+    assert "[3-5s] 输出三到五秒对白" in content
+    assert "[场景1 2-6s] 保留片段" in content


### PR DESCRIPTION
## Summary
- harden cut-output timeline validation before render/TTS spend
- ground narration review to the rendered cut timeline using fresh validated plans
- strip subtitle terminal punctuation only at display time while preserving narration and timing semantics

## Verification
- python3 scripts/test.py
- python3 -m ruff check .
- python3 -m compileall -q skills tests scripts
- git diff --check
- per-skill mypy on validate.py, review.py, assemble.py, recap.py + doctor.py

Constraint: cut-mode narration is authored in edited output time, while VLM/ASR evidence starts in source time
Constraint: advisory review must remain fail-open and must not block production availability
Rejected: Raw clip_plan fallback for cut-output review | it can differ from snapped/padded validated cuts and produce misleading review evidence
Rejected: Stripping punctuation before timing math | display cleanup should not perturb subtitle cue timing
Confidence: high
Scope-risk: moderate
Directive: Do not reintroduce raw clip_plan fallback for cut_output review; require fresh clip_plan_validated.json source/output spans
Tested: python3 scripts/test.py
Tested: python3 -m ruff check .
Tested: python3 -m compileall -q skills tests scripts
Tested: git diff --check
Tested: per-skill mypy on validate.py, review.py, assemble.py, recap.py + doctor.py
Not-tested: Real MiMo API advisory-review latency/failure behavior beyond mocked fail-open tests