### PR TITLE
Fix subtitle output consistency and cut-pass authoring evidence

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,7 +53,7 @@ sudo apt install ffmpeg                     # Debian/Ubuntu
 choco install ffmpeg                        # Windows (or scoop / winget install ffmpeg)
 ```
 
-Subtitles are burned into the picture by default, which needs an ffmpeg built with **libass (the `subtitles` filter)** — the packages above include it in almost all cases. If yours lacks libass, the run fails fast at the start with a clear message (or pass `--no-burn-subtitles` to keep subtitles as a sidecar `.srt`). Run `python3 scripts/recap.py --doctor` to self-check.
+Subtitles are burned into the picture by default, which needs an ffmpeg built with **libass (the `subtitles` filter)** — the packages above include it in almost all cases. If yours lacks libass, the run fails fast at the start with a clear message (or pass `--no-burn-subtitles` to keep the MP4 unmasked and subtitles as a sidecar `.srt`). Run `python3 scripts/recap.py --doctor` to self-check.
 
 **③ Set your MiMo API key** (one key powers ASR / VLM / TTS — keep it in an env var, never in the repo):
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sudo apt install ffmpeg                     # Debian/Ubuntu
 choco install ffmpeg                        # Windows（或 scoop / winget install ffmpeg）
 ```
 
-字幕默认烧进画面，需要带 **libass（`subtitles` 滤镜）** 的 ffmpeg——上面这些包基本都自带。如果你的 ffmpeg 没编 libass，开跑前会立刻报错并提示（也可以加 `--no-burn-subtitles` 只出 `.srt` 外挂字幕）。用 `python3 scripts/recap.py --doctor` 自检。
+字幕默认烧进画面，需要带 **libass（`subtitles` 滤镜）** 的 ffmpeg——上面这些包基本都自带。如果你的 ffmpeg 没编 libass，开跑前会立刻报错并提示（也可以加 `--no-burn-subtitles` 输出未遮黑条的 MP4 + `.srt` 外挂字幕）。用 `python3 scripts/recap.py --doctor` 自检。
 
 **③ 配 MiMo API Key**（一个 key 同时驱动 ASR / VLM / TTS，放环境变量、别写进仓库）：
 

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -177,6 +177,23 @@ def _build_video_clips(input_video, work_dir, duration_s):
              "timeline_end": float(duration_s)}]
 
 
+def _timeline_subtitle_segments(tts_segments, work_dir, duration_s):
+    """Display-ready subtitle cues for timeline/export text tracks.
+
+    The narration audio track keeps raw semantic text for editor reference; this
+    payload mirrors SRT/ASS display policy, including terminal-punctuation cleanup
+    and original-dialogue gap subtitles when configured.
+    """
+    return [
+        {
+            "text": entry["text"],
+            "timeline_start": float(entry["start"]),
+            "timeline_end": float(entry["end"]),
+        }
+        for entry in _combined_subtitle_entries(tts_segments, work_dir, duration_s)
+    ]
+
+
 def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
     """Build and persist the backend-neutral multi-track timeline.json."""
     canvas = _probe_canvas(input_video)
@@ -211,8 +228,10 @@ def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
                    "quiet": CONFIG.get("zone_ducking_volume", 0.12),
                    "fade": fade,
                    "bridge": CONFIG.get("duck_bridge_seconds", 1.5)}
+    subtitle_segments = _timeline_subtitle_segments(tts_segments, work_dir, duration_s)
     timeline = build_timeline(canvas, duration_s, video_clips,
-                              narration_segments, bgm=bgm, ducking=ducking)
+                              narration_segments, bgm=bgm, ducking=ducking,
+                              subtitle_segments=subtitle_segments)
     out = Path(work_dir) / "timeline.json"
     save_timeline(timeline, out)
     log(f"时间线模型: {out} ({len(timeline['tracks'])} 轨)")
@@ -261,13 +280,17 @@ def _subtitle_style_config():
 
 def assembly_settings_fingerprint():
     """Settings that affect the rendered video, used by pipeline resume cache."""
+    burn_subtitles = bool(CONFIG.get("burn_subtitles", False))
+    mask_source_subtitles = burn_subtitles and bool(CONFIG.get("mask_source_subtitles", False))
     fingerprint = {
         "version": SUBTITLE_RENDER_VERSION,
-        "burn_subtitles": bool(CONFIG.get("burn_subtitles", False)),
+        "burn_subtitles": burn_subtitles,
         "force_video_reencode": bool(CONFIG.get("force_video_reencode", False)),
         "video_filters": {
-            "mask_source_subtitles": bool(CONFIG.get("mask_source_subtitles", False)),
-            "source_subtitle_mask_ratio": CONFIG.get("source_subtitle_mask_ratio", 0.14),
+            "mask_source_subtitles": mask_source_subtitles,
+            "source_subtitle_mask_ratio": (
+                CONFIG.get("source_subtitle_mask_ratio", 0.14) if mask_source_subtitles else None
+            ),
         },
         "narration_timing": {
             "delay_seconds": CONFIG.get("narration_delay_seconds", 1.5),
@@ -296,7 +319,7 @@ def assembly_settings_fingerprint():
             "bgm_ducking_volume": CONFIG.get("bgm_ducking_volume", 0.10),
         },
     }
-    if fingerprint["burn_subtitles"]:
+    if burn_subtitles:
         fingerprint["subtitle_renderer"] = "ass"
         fingerprint["subtitle_style"] = _subtitle_style_config()
     return fingerprint
@@ -832,7 +855,7 @@ def _source_subtitle_mask_filter():
     shows the original subs AND our narration subs stacked. Covers the bottom band with
     an opaque box; our subtitles render on top of it.
     """
-    if not CONFIG.get("mask_source_subtitles", False):
+    if not (CONFIG.get("burn_subtitles", False) and CONFIG.get("mask_source_subtitles", False)):
         return None
     ratio = max(0.0, min(0.5, float(CONFIG.get("source_subtitle_mask_ratio", 0.14) or 0.0)))
     # When we burn our OWN subtitle the band must sit behind it, but our subtitles are split into

--- a/skills/video-assemble/scripts/timeline.py
+++ b/skills/video-assemble/scripts/timeline.py
@@ -126,7 +126,7 @@ def variable_ducking_keyframes(windows, idle, fade, span_start, span_end, bridge
 
 
 def build_timeline(canvas, duration_s, video_clips, narration_segments,
-                   bgm=None, ducking=None):
+                   bgm=None, ducking=None, subtitle_segments=None):
     """Assemble a Timeline dict from resolved placement data.
 
     canvas: {"width", "height", "fps"}
@@ -136,6 +136,9 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
                  full mode: a single clip spanning the whole video).
     narration_segments: placed beats [{"source_path", "timeline_start",
                  "timeline_end", "text", "overlaps_speech", "gain"?}].
+    subtitle_segments: optional display-ready text cues [{"text", "timeline_start",
+                 "timeline_end"}]. When present, this is authoritative for the
+                 subtitle/text track; narration segment text remains raw editor metadata.
     bgm: optional {"source_path", "volume", "ducking_volume"}.
     ducking: {"idle", "speech", "quiet", "fade", "bridge"?} for the original-audio
              automation; None disables original ducking (flat original). `bridge` holds
@@ -214,12 +217,23 @@ def build_timeline(canvas, duration_s, video_clips, narration_segments,
         })
 
     # --- subtitle (text) track
-    text_segs = [{
-        "text": s.get("text", ""),
-        "timeline_start": round(float(s["timeline_start"]), 4),
-        "timeline_end": round(float(s["timeline_end"]), 4),
-    } for s in narration_segments
-        if s.get("text") and s.get("timeline_end", 0) > s.get("timeline_start", 0)]
+    text_source = subtitle_segments if subtitle_segments is not None else narration_segments
+    text_segs = []
+    for s in text_source or []:
+        if not isinstance(s, dict) or not s.get("text"):
+            continue
+        try:
+            ts = float(s["timeline_start"])
+            te = float(s["timeline_end"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if te <= ts:
+            continue
+        text_segs.append({
+            "text": s.get("text", ""),
+            "timeline_start": round(ts, 4),
+            "timeline_end": round(te, 4),
+        })
     if text_segs:
         tracks.append({"kind": "text", "name": "subtitle", "segments": text_segs})
 

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -18,7 +18,7 @@ Defaults below are bundle-level defaults unless a note scopes them to a specific
 | MiMo voice | `MIMO_TTS_VOICE` / `--mimo-tts-voice` | `冰糖` | |
 | Narration density | `TARGET_SEGMENTS_PER_MINUTE` | `9.6` | min `MIN_SEGMENTS_PER_MINUTE=6.24` |
 | Narration speed | `NARRATION_SPEED` | `1.3` | global atempo on the voiceover; default leans snappy for short-form, set `1.0` for long-form/documentary |
-| Mask source subs | `MASK_SOURCE_SUBTITLES` / `SOURCE_SUBTITLE_MASK_RATIO` | on / `0.14` | covers burned-in source subtitles (bottom band) so only the recap's subtitles show; set `MASK_SOURCE_SUBTITLES=false` for sources without hardcoded subs |
+| Mask source subs | `MASK_SOURCE_SUBTITLES` / `SOURCE_SUBTITLE_MASK_RATIO` | on / `0.14` | effective only when burned recap subtitles are enabled; covers hardcoded source subtitles (bottom band) so only the recap's subtitles show. With `--no-burn-subtitles`, the mask is ignored and the MP4 stays unmasked while `.srt` is written |
 | Original ducking | `IDLE_ORIG_VOLUME` / `SPEECH_DUCKING_VOLUME` | `1.0` / `0.2` | the original returns to full-volume `IDLE` in deliberate gaps/original blocks, and ducks to `SPEECH` under narration. Inter-beat gaps shorter than `DUCK_BRIDGE_SECONDS` stay ducked so a single narration block does not swell between sentences. `DUCKING_ORIG_VOLUME` (`0.3`) is only the fallback when beats carry no placement info |
 | Duck fade | `DUCK_FADE_SECONDS` | `0.3` | ramp time for each duck transition, so full-volume original blocks and ducked narration blocks switch without clicks |
 | Duck bridge | `DUCK_BRIDGE_SECONDS` | `1.5` | inter-beat gaps shorter than this stay ducked inside one narration block; gaps >= this are treated as intentional original-audio blocks and return to `IDLE_ORIG_VOLUME` |
@@ -31,7 +31,7 @@ Defaults below are bundle-level defaults unless a note scopes them to a specific
 | VLM workers | `VLM_WORKERS` | `8` | lower to 1 if a proxy/WAF rate-limits |
 | Subtitle size | `SUBTITLE_FONT_SIZE` / `SUBTITLE_MARGIN_V` | `42` / `48` | look & placement |
 | 整理 / index | `--no-consolidate` / `--consolidate-asr` | on | build the understanding index (and optionally clean ASR); use `--no-consolidate` to skip |
-| Advisory narration review | `REVIEW_NARRATION` / `--review-narration` / `--no-review-narration` | on | runs `video-script/review.py` after validation and before TTS; advisory only and fail-open, while `validate.py` remains the hard gate. In cut mode the reviewer uses `clip_plan_validated.json` to remap VLM/ASR grounding onto the output timeline |
+| Advisory / strict narration review | `REVIEW_NARRATION` / `--review-narration` / `--no-review-narration`; strict: `REQUIRE_NARRATION_REVIEW` / `--require-narration-review` | advisory on, strict off | runs `video-script/review.py` after validation and before TTS. Default advisory mode is fail-open; strict mode blocks TTS on review failure, parse error, or error-severity findings. In cut mode the reviewer uses `clip_plan_validated.json` to remap VLM/ASR grounding onto the output timeline |
 | 剪映 export (optional) | `--export-jianying` / `EXPORT_JIANYING` | off | after rendering, also write a 剪映/JianYing draft from `timeline.json`. Decoupled — the core render never needs it |
 | 剪映 draft dir | `JIANYING_DRAFT_DIR` | work_dir | parent folder for the exported draft (point it at 剪映's drafts root to open in-app) |
 | 剪映 bundle media | `JIANYING_BUNDLE_MEDIA` / `--jianying-no-bundle-media` | **on** | copies media into the draft folder so it is self-contained. **Required on macOS** — 剪映 is sandboxed and cannot read external paths, so an unbundled draft opens with all media offline. Use `--jianying-no-bundle-media` only if 剪映 can reach the original paths |
@@ -39,6 +39,6 @@ Defaults below are bundle-level defaults unless a note scopes them to a specific
 
 `video-assemble` always writes `timeline.json` — a backend-neutral multi-track model
 (video / original-audio / narration / BGM / subtitle, with ducking automation). The
-canonical renderer is ffmpeg; the 剪映 exporter is an optional consumer of the same file.
+canonical renderer is ffmpeg; the 剪映 exporter is an optional consumer of the same file. Subtitle text in `timeline.json` is display-ready and follows the same terminal-punctuation policy as SRT/ASS.
 
 See each stage skill's SKILL.md for the full per-stage option list.

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -74,23 +74,75 @@ def _review_narration_enabled(args):
     return _env_bool("REVIEW_NARRATION", True)
 
 
-def _run_advisory_review(work_dir, args, *, timeline="source"):
-    """Run quality review before TTS, but never block production on reviewer availability.
+def _require_narration_review(args):
+    if getattr(args, "require_narration_review", False):
+        return True
+    return _env_bool("REQUIRE_NARRATION_REVIEW", False)
 
-    Returns True only when review.py completed, so the completion message can avoid
-    pointing at stale review artifacts after an opt-out or fail-open run.
+
+def _review_result_status(work_dir):
+    data = _load_json(Path(work_dir) / "narration_review.json")
+    if not isinstance(data, dict):
+        return {"ok": False, "reason": "missing or invalid narration_review.json"}
+    findings = [f for f in (data.get("findings") or []) if isinstance(f, dict)]
+    n_err = sum(1 for f in findings if f.get("severity") == "error")
+    if data.get("parse_error"):
+        return {"ok": False, "reason": "parse_error", "review": data, "errors": n_err}
+    if n_err:
+        return {"ok": False, "reason": f"error {n_err}", "review": data, "errors": n_err}
+    if str(data.get("verdict", "")).upper() == "REVISE" and n_err:
+        return {"ok": False, "reason": f"error {n_err}", "review": data, "errors": n_err}
+    return {"ok": True, "reason": "ok", "review": data, "errors": n_err}
+
+
+def _clear_narration_review_artifacts(work_dir):
+    """Remove prior review artifacts before a fresh pre-TTS review run.
+
+    The review is allowed to fail open in advisory mode, but completion output and
+    strict gating must never accidentally trust a stale narration_review.* from an
+    earlier run.
     """
-    if not _review_narration_enabled(args):
+    for name in ("narration_review.json", "narration_review.md"):
+        try:
+            (Path(work_dir) / name).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _run_narration_review(work_dir, args, *, timeline="source"):
+    """Run quality review before TTS.
+
+    Default mode remains advisory/fail-open. Strict mode
+    (`--require-narration-review` or REQUIRE_NARRATION_REVIEW) hard-fails before
+    TTS when review is unavailable, unparsable, or reports error findings.
+    Returns True only when review.py completed, so completion messages do not
+    point at stale review artifacts after opt-out/fail-open runs.
+    """
+    strict = _require_narration_review(args)
+    if not _review_narration_enabled(args) and not strict:
         return False
     try:
+        _clear_narration_review_artifacts(work_dir)
         rargs = ["--work-dir", work_dir]
         if timeline != "source":
             rargs += ["--timeline", timeline]
         _run("video-script", "review.py", *rargs)
     except SystemExit as exc:
+        if strict:
+            raise SystemExit(f"严格解说评审失败，已阻止 TTS: {exc}")
         print(f"[video-recap] ⚠️ 建议性评审失败，继续执行 TTS: {exc}", flush=True)
         return False
+
+    status = _review_result_status(work_dir)
+    if strict and not status["ok"]:
+        raise SystemExit(f"严格解说评审未通过，已阻止 TTS: {status['reason']}")
+    if strict:
+        print("[video-recap] ✅ 严格解说评审通过，继续 TTS", flush=True)
     return True
+
+
+def _run_advisory_review(work_dir, args, *, timeline="source"):
+    return _run_narration_review(work_dir, args, timeline=timeline)
 
 
 def _file_fingerprint(path, chunk_size=1024 * 1024):
@@ -309,6 +361,8 @@ def _continuation_command(video, work_dir, args):
         parts.append("--jianying-no-bundle-media")
     if getattr(args, "review_narration", None) is not None:
         parts.append("--review-narration" if args.review_narration else "--no-review-narration")
+    if getattr(args, "require_narration_review", False):
+        parts.append("--require-narration-review")
     return " ".join(shlex.quote(part) for part in parts)
 
 
@@ -335,6 +389,8 @@ def main():
                     help="burn narration subtitles into the video (default on; --no-burn-subtitles to disable)")
     ap.add_argument("--review-narration", action=argparse.BooleanOptionalAction, default=None,
                     help="run advisory narration quality review before TTS (default on; fail-open)")
+    ap.add_argument("--require-narration-review", action="store_true",
+                    help="make narration review a strict pre-TTS gate (also REQUIRE_NARRATION_REVIEW=1)")
     ap.add_argument("--output-dir", default=None)
     ap.add_argument("--export-jianying", action="store_true",
                     help="also export an OPTIONAL 剪映/JianYing draft (decoupled; never required)")
@@ -449,7 +505,7 @@ def main():
              "--output-duration", f"{output_duration:.3f}")
         narration_for_tts = narration_json
         assemble_video_path = edited_source
-    review_ran = _run_advisory_review(work_dir, args, timeline="cut_output" if cut else "source")
+    review_ran = _run_narration_review(work_dir, args, timeline="cut_output" if cut else "source")
     vargs = ["--work-dir", str(work_dir), "--narration", str(narration_for_tts)]
     if args.mimo_tts_voice:
         vargs += ["--mimo-voice", args.mimo_tts_voice]

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 import re
 from pathlib import Path
 
@@ -1379,6 +1380,161 @@ def _format_research_directive(work_dir, substrate):
     ]
 
 
+def _load_cut_output_spans_for_brief(work_dir, *, required=False):
+    """Load fresh source→output spans for cut pass 2 brief evidence.
+
+    Pass 2 narration is authored against edited_source.mp4's OUTPUT timeline, so
+    ASR chunks and timeline_fusion must use the same OUTPUT clock. Before pass 2
+    (no edited_source.mp4 yet), callers may fall back to source-time evidence; once
+    pass 2 exists, missing/stale validated spans are a hard contract failure.
+    """
+    def fail(reason):
+        if required:
+            raise SystemExit(
+                "cut pass2 brief requires fresh clip_plan_validated.json with explicit "
+                f"finite source/output spans ({reason})"
+            )
+        return None
+
+    work_dir = Path(work_dir)
+    if not (work_dir / "edited_source.mp4").exists():
+        return None
+    validated_path = work_dir / "clip_plan_validated.json"
+    if not validated_path.exists():
+        return fail("missing clip_plan_validated.json")
+    try:
+        plan = json.loads(validated_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return fail("invalid clip_plan_validated.json")
+    if not isinstance(plan, dict):
+        return fail("clip_plan_validated.json is not an object")
+    raw_path = work_dir / "clip_plan.json"
+    if raw_path.exists():
+        try:
+            raw_plan = json.loads(raw_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return fail("invalid clip_plan.json")
+        if plan.get("raw_plan_fingerprint") != stable_hash(raw_plan):
+            return fail("stale clip_plan_validated.json")
+    clips = plan.get("clips")
+    if not isinstance(clips, list):
+        return fail("clips is not a list")
+    spans = []
+    for clip in clips:
+        if not isinstance(clip, dict):
+            continue
+        if not all(key in clip for key in ("source_start", "source_end", "output_start", "output_end")):
+            return fail("clip missing source/output span fields")
+        try:
+            ss = float(clip["source_start"])
+            se = float(clip["source_end"])
+            os_ = float(clip["output_start"])
+            oe = float(clip["output_end"])
+        except (TypeError, ValueError):
+            return fail("non-numeric clip span")
+        if not all(math.isfinite(x) for x in (ss, se, os_, oe)):
+            return fail("non-finite clip span")
+        if se <= ss or oe <= os_:
+            return fail("non-positive clip span")
+        spans.append({"source_start": ss, "source_end": se, "output_start": os_, "output_end": oe})
+    return spans or fail("no valid clips")
+
+
+def _source_output_overlaps_for_brief(start, end, spans):
+    overlaps = []
+    for span in spans or []:
+        source_start = max(float(start), span["source_start"])
+        source_end = min(float(end), span["source_end"])
+        if source_end <= source_start:
+            continue
+        output_start = span["output_start"] + (source_start - span["source_start"])
+        output_end = span["output_start"] + (source_end - span["source_start"])
+        overlaps.append({
+            "source_start": source_start,
+            "source_end": source_end,
+            "output_start": output_start,
+            "output_end": output_end,
+        })
+    return overlaps
+
+
+def _remap_frame_facts_for_brief(frame_facts, overlap):
+    if not isinstance(frame_facts, dict):
+        return frame_facts
+    out = {}
+    for raw_ts, vals in frame_facts.items():
+        try:
+            ts = float(raw_ts)
+        except (TypeError, ValueError):
+            continue
+        if not (overlap["source_start"] <= ts <= overlap["source_end"]):
+            continue
+        out_ts = overlap["output_start"] + (ts - overlap["source_start"])
+        out[f"{out_ts:.3f}"] = vals
+    return out
+
+
+def _remap_scenes_to_output_for_brief(scenes, spans):
+    if not spans:
+        return scenes or []
+    out = []
+    for scene in scenes or []:
+        if not isinstance(scene, dict):
+            continue
+        try:
+            start = float(scene.get("start", 0))
+            end = float(scene.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        overlaps = _source_output_overlaps_for_brief(start, end, spans)
+        for part_idx, overlap in enumerate(overlaps):
+            item = dict(scene)
+            item["start"] = round(overlap["output_start"], 3)
+            item["end"] = round(overlap["output_end"], 3)
+            item["frame_facts"] = _remap_frame_facts_for_brief(scene.get("frame_facts"), overlap)
+            if len(overlaps) > 1:
+                item["scene_id"] = f"{scene.get('scene_id', '?')}.{part_idx}"
+            out.append(item)
+    out.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
+    return out
+
+
+def _remap_segments_to_output_for_brief(segments, spans):
+    if not spans:
+        return segments or []
+    out = []
+    for seg in segments or []:
+        if not isinstance(seg, dict):
+            continue
+        try:
+            start = float(seg.get("start", 0))
+            end = float(seg.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        for overlap in _source_output_overlaps_for_brief(start, end, spans):
+            item = dict(seg)
+            item["start"] = round(overlap["output_start"], 3)
+            item["end"] = round(overlap["output_end"], 3)
+            if "duration" in item:
+                item["duration"] = round(item["end"] - item["start"], 3)
+            out.append(item)
+    out.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
+    return out
+
+
+def _remap_brief_evidence_to_output_timeline(work_dir, scenes_analysis, asr_result, silence_periods, *, required=False):
+    spans = _load_cut_output_spans_for_brief(work_dir, required=required)
+    if not spans:
+        return scenes_analysis, asr_result, silence_periods
+    return (
+        _remap_scenes_to_output_for_brief(scenes_analysis, spans),
+        _remap_segments_to_output_for_brief(asr_result, spans),
+        _remap_segments_to_output_for_brief(silence_periods, spans),
+    )
+
+
 def _format_output_clip_list(work_dir):
     """List the kept clips on the OUTPUT timeline (cut-first/narrate-second pass 2), so the
     agent narrates against the real rendered cut instead of the source timeline."""
@@ -1489,8 +1645,15 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     lines.extend(_format_consolidation(_load_consolidation(work_dir, scenes_analysis)))
 
     asr_for_chunks = _load_clean_asr(work_dir, asr_result) or asr_result
-    asr_chunks = _chunk_asr_for_writing(asr_for_chunks, scenes_analysis)
-    timeline_fusion = _build_timeline_fusion(scenes_analysis, asr_result, silence_periods)
+    chunk_scenes, chunk_asr = scenes_analysis, asr_for_chunks
+    fusion_scenes, fusion_asr, fusion_silence = scenes_analysis, asr_result, silence_periods
+    if edit_mode == "cut" and (Path(work_dir) / "edited_source.mp4").exists():
+        chunk_scenes, chunk_asr, _ = _remap_brief_evidence_to_output_timeline(
+            work_dir, scenes_analysis, asr_for_chunks, [], required=True)
+        fusion_scenes, fusion_asr, fusion_silence = _remap_brief_evidence_to_output_timeline(
+            work_dir, scenes_analysis, asr_result, silence_periods, required=True)
+    asr_chunks = _chunk_asr_for_writing(chunk_asr, chunk_scenes)
+    timeline_fusion = _build_timeline_fusion(fusion_scenes, fusion_asr, fusion_silence)
     _write_json_artifact(work_dir, "asr_writing_chunks.json", asr_chunks)
     _write_json_artifact(work_dir, "timeline_fusion.json", timeline_fusion)
     lines.extend(_format_asr_chunks_for_brief(asr_chunks))

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 import re
 from pathlib import Path
 
@@ -1379,6 +1380,161 @@ def _format_research_directive(work_dir, substrate):
     ]
 
 
+def _load_cut_output_spans_for_brief(work_dir, *, required=False):
+    """Load fresh source→output spans for cut pass 2 brief evidence.
+
+    Pass 2 narration is authored against edited_source.mp4's OUTPUT timeline, so
+    ASR chunks and timeline_fusion must use the same OUTPUT clock. Before pass 2
+    (no edited_source.mp4 yet), callers may fall back to source-time evidence; once
+    pass 2 exists, missing/stale validated spans are a hard contract failure.
+    """
+    def fail(reason):
+        if required:
+            raise SystemExit(
+                "cut pass2 brief requires fresh clip_plan_validated.json with explicit "
+                f"finite source/output spans ({reason})"
+            )
+        return None
+
+    work_dir = Path(work_dir)
+    if not (work_dir / "edited_source.mp4").exists():
+        return None
+    validated_path = work_dir / "clip_plan_validated.json"
+    if not validated_path.exists():
+        return fail("missing clip_plan_validated.json")
+    try:
+        plan = json.loads(validated_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return fail("invalid clip_plan_validated.json")
+    if not isinstance(plan, dict):
+        return fail("clip_plan_validated.json is not an object")
+    raw_path = work_dir / "clip_plan.json"
+    if raw_path.exists():
+        try:
+            raw_plan = json.loads(raw_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return fail("invalid clip_plan.json")
+        if plan.get("raw_plan_fingerprint") != stable_hash(raw_plan):
+            return fail("stale clip_plan_validated.json")
+    clips = plan.get("clips")
+    if not isinstance(clips, list):
+        return fail("clips is not a list")
+    spans = []
+    for clip in clips:
+        if not isinstance(clip, dict):
+            continue
+        if not all(key in clip for key in ("source_start", "source_end", "output_start", "output_end")):
+            return fail("clip missing source/output span fields")
+        try:
+            ss = float(clip["source_start"])
+            se = float(clip["source_end"])
+            os_ = float(clip["output_start"])
+            oe = float(clip["output_end"])
+        except (TypeError, ValueError):
+            return fail("non-numeric clip span")
+        if not all(math.isfinite(x) for x in (ss, se, os_, oe)):
+            return fail("non-finite clip span")
+        if se <= ss or oe <= os_:
+            return fail("non-positive clip span")
+        spans.append({"source_start": ss, "source_end": se, "output_start": os_, "output_end": oe})
+    return spans or fail("no valid clips")
+
+
+def _source_output_overlaps_for_brief(start, end, spans):
+    overlaps = []
+    for span in spans or []:
+        source_start = max(float(start), span["source_start"])
+        source_end = min(float(end), span["source_end"])
+        if source_end <= source_start:
+            continue
+        output_start = span["output_start"] + (source_start - span["source_start"])
+        output_end = span["output_start"] + (source_end - span["source_start"])
+        overlaps.append({
+            "source_start": source_start,
+            "source_end": source_end,
+            "output_start": output_start,
+            "output_end": output_end,
+        })
+    return overlaps
+
+
+def _remap_frame_facts_for_brief(frame_facts, overlap):
+    if not isinstance(frame_facts, dict):
+        return frame_facts
+    out = {}
+    for raw_ts, vals in frame_facts.items():
+        try:
+            ts = float(raw_ts)
+        except (TypeError, ValueError):
+            continue
+        if not (overlap["source_start"] <= ts <= overlap["source_end"]):
+            continue
+        out_ts = overlap["output_start"] + (ts - overlap["source_start"])
+        out[f"{out_ts:.3f}"] = vals
+    return out
+
+
+def _remap_scenes_to_output_for_brief(scenes, spans):
+    if not spans:
+        return scenes or []
+    out = []
+    for scene in scenes or []:
+        if not isinstance(scene, dict):
+            continue
+        try:
+            start = float(scene.get("start", 0))
+            end = float(scene.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        overlaps = _source_output_overlaps_for_brief(start, end, spans)
+        for part_idx, overlap in enumerate(overlaps):
+            item = dict(scene)
+            item["start"] = round(overlap["output_start"], 3)
+            item["end"] = round(overlap["output_end"], 3)
+            item["frame_facts"] = _remap_frame_facts_for_brief(scene.get("frame_facts"), overlap)
+            if len(overlaps) > 1:
+                item["scene_id"] = f"{scene.get('scene_id', '?')}.{part_idx}"
+            out.append(item)
+    out.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
+    return out
+
+
+def _remap_segments_to_output_for_brief(segments, spans):
+    if not spans:
+        return segments or []
+    out = []
+    for seg in segments or []:
+        if not isinstance(seg, dict):
+            continue
+        try:
+            start = float(seg.get("start", 0))
+            end = float(seg.get("end", start))
+        except (TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        for overlap in _source_output_overlaps_for_brief(start, end, spans):
+            item = dict(seg)
+            item["start"] = round(overlap["output_start"], 3)
+            item["end"] = round(overlap["output_end"], 3)
+            if "duration" in item:
+                item["duration"] = round(item["end"] - item["start"], 3)
+            out.append(item)
+    out.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
+    return out
+
+
+def _remap_brief_evidence_to_output_timeline(work_dir, scenes_analysis, asr_result, silence_periods, *, required=False):
+    spans = _load_cut_output_spans_for_brief(work_dir, required=required)
+    if not spans:
+        return scenes_analysis, asr_result, silence_periods
+    return (
+        _remap_scenes_to_output_for_brief(scenes_analysis, spans),
+        _remap_segments_to_output_for_brief(asr_result, spans),
+        _remap_segments_to_output_for_brief(silence_periods, spans),
+    )
+
+
 def _format_output_clip_list(work_dir):
     """List the kept clips on the OUTPUT timeline (cut-first/narrate-second pass 2), so the
     agent narrates against the real rendered cut instead of the source timeline."""
@@ -1489,8 +1645,15 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     lines.extend(_format_consolidation(_load_consolidation(work_dir, scenes_analysis)))
 
     asr_for_chunks = _load_clean_asr(work_dir, asr_result) or asr_result
-    asr_chunks = _chunk_asr_for_writing(asr_for_chunks, scenes_analysis)
-    timeline_fusion = _build_timeline_fusion(scenes_analysis, asr_result, silence_periods)
+    chunk_scenes, chunk_asr = scenes_analysis, asr_for_chunks
+    fusion_scenes, fusion_asr, fusion_silence = scenes_analysis, asr_result, silence_periods
+    if edit_mode == "cut" and (Path(work_dir) / "edited_source.mp4").exists():
+        chunk_scenes, chunk_asr, _ = _remap_brief_evidence_to_output_timeline(
+            work_dir, scenes_analysis, asr_for_chunks, [], required=True)
+        fusion_scenes, fusion_asr, fusion_silence = _remap_brief_evidence_to_output_timeline(
+            work_dir, scenes_analysis, asr_result, silence_periods, required=True)
+    asr_chunks = _chunk_asr_for_writing(chunk_asr, chunk_scenes)
+    timeline_fusion = _build_timeline_fusion(fusion_scenes, fusion_asr, fusion_silence)
     _write_json_artifact(work_dir, "asr_writing_chunks.json", asr_chunks)
     _write_json_artifact(work_dir, "timeline_fusion.json", timeline_fusion)
     lines.extend(_format_asr_chunks_for_brief(asr_chunks))

--- a/tests/assemble/test_export_jianying.py
+++ b/tests/assemble/test_export_jianying.py
@@ -6,6 +6,45 @@ from export_jianying import build_draft, export_timeline_to_jianying, _us  # noq
 from timeline import build_timeline  # noqa: E402
 
 
+def _draft_texts(content):
+    return [json.loads(item["content"])["text"] for item in content["materials"]["texts"]]
+
+
+def test_exporter_uses_timeline_display_subtitles_not_raw_narration_text():
+    tl = build_timeline(
+        {"width": 100, "height": 100, "fps": 30},
+        5.0,
+        [{"source_path": "/s.mp4", "source_start": 0.0, "source_end": 5.0,
+          "timeline_start": 0.0, "timeline_end": 5.0}],
+        [{"source_path": "/n.wav", "timeline_start": 0.0, "timeline_end": 2.0,
+          "text": "第一句。", "overlaps_speech": True}],
+        subtitle_segments=[{"text": "第一句", "timeline_start": 0.0, "timeline_end": 2.0}],
+    )
+
+    content, _meta, _notes = build_draft(tl, new_id=_counter_ids(), probe=_fake_probe)
+
+    assert _draft_texts(content) == ["第一句"]
+
+
+def test_exporter_keeps_original_gap_display_subtitles_from_timeline():
+    tl = build_timeline(
+        {"width": 100, "height": 100, "fps": 30},
+        6.0,
+        [{"source_path": "/s.mp4", "source_start": 0.0, "source_end": 6.0,
+          "timeline_start": 0.0, "timeline_end": 6.0}],
+        [{"source_path": "/n.wav", "timeline_start": 3.0, "timeline_end": 5.0,
+          "text": "旁白原文。", "overlaps_speech": True}],
+        subtitle_segments=[
+            {"text": "「他说：「你好」」", "timeline_start": 0.5, "timeline_end": 2.0},
+            {"text": "旁白原文", "timeline_start": 3.0, "timeline_end": 5.0},
+        ],
+    )
+
+    content, _meta, _notes = build_draft(tl, new_id=_counter_ids(), probe=_fake_probe)
+
+    assert _draft_texts(content) == ["「他说：「你好」」", "旁白原文"]
+
+
 def _counter_ids():
     n = [0]
 

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -177,18 +177,23 @@ def test_resolve_final_output_overwrites_stable_alias(tmp_path):
     assert resolved == tmp_path / "recap_clip.mp4"
 
 
-def test_source_subtitle_mask_filter_toggles_with_config(monkeypatch):
-    monkeypatch.setitem(CONFIG, "burn_subtitles", False)  # isolate the raw ratio from the 2-line band
+def test_source_subtitle_mask_filter_toggles_with_effective_burn_policy(monkeypatch):
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
     assert _source_subtitle_mask_filter() is None
 
+    # no-burn means sidecar-subtitle mode: ambient/default source masking must not
+    # create a black band without burned recap subtitles.
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
     monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.15)
-    f = _source_subtitle_mask_filter()
-    assert f is not None and f.startswith("drawbox=") and "0.150" in f and "t=fill" in f
-
-    monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.0)  # ratio 0 -> no mask
     assert _source_subtitle_mask_filter() is None
+
+    monkeypatch.setitem(CONFIG, "burn_subtitles", True)
+    f = _source_subtitle_mask_filter()
+    assert f is not None and f.startswith("drawbox=") and "t=fill" in f
+
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.0)  # ratio 0 still allowed if style band requires it
+    assert _source_subtitle_mask_filter() is not None
 
 
 def test_mask_band_stays_one_line_small_when_burning(monkeypatch):
@@ -206,10 +211,9 @@ def test_mask_band_stays_one_line_small_when_burning(monkeypatch):
     one_line = (30 + 42 * 1.25 + 10) / 720
     assert ratio_on == pytest.approx(max(0.14, one_line), abs=0.005), ratio_on
     assert ratio_on < 0.16, ratio_on            # stays small — never the old ~0.23 two-line band
-    # not burning -> stays at the raw 0.14
+    # not burning -> no mask-only black band
     monkeypatch.setitem(CONFIG, "burn_subtitles", False)
-    ratio_off = float(re.search(r"ih-ih\*([0-9.]+)", _source_subtitle_mask_filter()).group(1))
-    assert abs(ratio_off - 0.14) < 0.001, ratio_off
+    assert _source_subtitle_mask_filter() is None
 
 
 def test_apply_narration_speed_atempos_each_segment(monkeypatch, tmp_path):
@@ -466,9 +470,9 @@ def test_assemble_video_without_burn_keeps_video_copy(monkeypatch, tmp_path):
     assert ffmpeg_cmd[ffmpeg_cmd.index("-c:v") + 1] == "copy"
 
 
-def test_assemble_video_masks_source_subs_by_default(monkeypatch, tmp_path):
-    # mask_source_subtitles defaults to True now: even with burn off, the bottom
-    # band is drawn, which forces a video re-encode (no -c:v copy).
+def test_assemble_video_no_burn_ignores_source_mask_default(monkeypatch, tmp_path):
+    # no-burn sidecar mode must not draw a mask-only black band, even if the
+    # ambient/default mask_source_subtitles setting is true.
     video = tmp_path / "input.mp4"
     video.write_bytes(b"video")
     output = tmp_path / "output.mp4"
@@ -489,15 +493,16 @@ def test_assemble_video_masks_source_subs_by_default(monkeypatch, tmp_path):
     assemble_video(video, [{
         "start": 0.0,
         "end": 3.0,
-        "narration": "默认遮挡原字幕。",
+        "narration": "外挂字幕不遮黑条。",
         "audio_path": str(tmp_path / "narr.wav"),
         "audio_duration": 1.0,
     }], tmp_path, output)
 
     ffmpeg_cmd = commands[-1]
-    assert "-vf" in ffmpeg_cmd
-    assert any("drawbox=" in str(arg) for arg in ffmpeg_cmd)
-    assert ffmpeg_cmd[ffmpeg_cmd.index("-c:v") + 1] == "libx264"
+    assert (tmp_path / "subtitles.srt").exists()
+    assert "-vf" not in ffmpeg_cmd
+    assert not any("drawbox=" in str(arg) for arg in ffmpeg_cmd)
+    assert ffmpeg_cmd[ffmpeg_cmd.index("-c:v") + 1] == "copy"
 
 
 def test_build_audio_filter_complex_gap_fill_envelope(monkeypatch):
@@ -706,10 +711,13 @@ def test_assembly_settings_fingerprint_tracks_render_affecting_settings(monkeypa
     base = assembly_settings_fingerprint()
 
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
-    assert assembly_settings_fingerprint() != base
-    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    assert assembly_settings_fingerprint() == base
     monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.20)
+    assert assembly_settings_fingerprint() == base
+    monkeypatch.setitem(CONFIG, "burn_subtitles", True)
     assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
     monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.14)
     monkeypatch.setitem(CONFIG, "narration_speed", 1.2)
     assert assembly_settings_fingerprint() != base

--- a/tests/assemble/test_timeline.py
+++ b/tests/assemble/test_timeline.py
@@ -4,6 +4,49 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-a
 import json  # noqa: E402
 from timeline import build_timeline, ducking_keyframes, load_timeline, save_timeline, variable_ducking_keyframes  # noqa: E402
 
+def _track(timeline, kind, name=None):
+    for track in timeline["tracks"]:
+        if track.get("kind") == kind and (name is None or track.get("name") == name):
+            return track
+    raise AssertionError(f"missing track {kind}/{name}")
+
+
+def test_build_timeline_uses_explicit_subtitle_segments_for_text_track():
+    tl = build_timeline(
+        {"width": 100, "height": 100, "fps": 30},
+        5.0,
+        [{"source_path": "/s.mp4", "source_start": 0.0, "source_end": 5.0,
+          "timeline_start": 0.0, "timeline_end": 5.0}],
+        [{"source_path": "/n.wav", "timeline_start": 0.0, "timeline_end": 2.0,
+          "text": "他说完了。", "overlaps_speech": True}],
+        subtitle_segments=[{"text": "他说完了", "timeline_start": 0.1, "timeline_end": 1.9}],
+    )
+
+    audio = _track(tl, "audio", "narration")["segments"]
+    text = _track(tl, "text", "subtitle")["segments"]
+    assert audio[0]["text"] == "他说完了。"
+    assert text == [{"text": "他说完了", "timeline_start": 0.1, "timeline_end": 1.9}]
+
+
+def test_build_timeline_subtitle_segments_skip_invalid_entries():
+    tl = build_timeline(
+        {"width": 100, "height": 100, "fps": 30},
+        5.0,
+        [{"source_path": "/s.mp4", "source_start": 0.0, "source_end": 5.0,
+          "timeline_start": 0.0, "timeline_end": 5.0}],
+        [],
+        subtitle_segments=[
+            {"text": "有效", "timeline_start": 1.0, "timeline_end": 2.0},
+            {"text": "", "timeline_start": 2.0, "timeline_end": 3.0},
+            {"text": "倒置", "timeline_start": 3.0, "timeline_end": 2.0},
+        ],
+    )
+
+    assert _track(tl, "text", "subtitle")["segments"] == [
+        {"text": "有效", "timeline_start": 1.0, "timeline_end": 2.0}
+    ]
+
+
 
 def test_ducking_keyframes_holds_idle_and_dips_under_window():
     kfs = ducking_keyframes([(2.0, 4.0)], idle=0.85, duck=0.2, fade=0.25,

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -668,3 +668,117 @@ def test_recap_full_mode_writes_no_phase_ledger(monkeypatch, tmp_path):
     recap.main()
 
     assert not (work / "recap_phase.json").exists()
+
+
+def test_strict_narration_review_blocks_voiceover_on_review_failure(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(json.dumps([{"start": 0, "end": 1, "narration": "full。"}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    def fake_run(skill, script, *cli_args):
+        if script == "review.py":
+            raise SystemExit("review unavailable")
+        if script == "voiceover.py":
+            raise AssertionError("voiceover must not run in strict review mode")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--require-narration-review",
+    ])
+
+    with pytest.raises(SystemExit, match="严格解说评审失败"):
+        recap.main()
+
+
+def test_strict_narration_review_blocks_voiceover_on_error_finding(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(json.dumps([{"start": 0, "end": 1, "narration": "full。"}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    def fake_run(skill, script, *cli_args):
+        if script == "review.py":
+            (work / "narration_review.json").write_text(json.dumps({
+                "verdict": "REVISE",
+                "findings": [{"severity": "error", "issue": "幻觉"}],
+            }), encoding="utf-8")
+            return
+        if script == "voiceover.py":
+            raise AssertionError("voiceover must not run with strict review errors")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--require-narration-review",
+    ])
+
+    with pytest.raises(SystemExit, match="error 1"):
+        recap.main()
+
+
+def test_strict_narration_review_requires_fresh_review_artifact(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(json.dumps([{"start": 0, "end": 1, "narration": "full。"}]), encoding="utf-8")
+    (work / "narration_review.json").write_text(json.dumps({
+        "verdict": "PASS",
+        "findings": [],
+    }), encoding="utf-8")
+    (work / "narration_review.md").write_text("# stale pass", encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    def fake_run(skill, script, *cli_args):
+        if script == "review.py":
+            return
+        if script == "voiceover.py":
+            raise AssertionError("voiceover must not run without a fresh review artifact")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--require-narration-review",
+    ])
+
+    with pytest.raises(SystemExit, match="missing or invalid narration_review.json"):
+        recap.main()
+    assert not (work / "narration_review.md").exists()
+
+
+def test_advisory_narration_review_still_continues_on_failure(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(json.dumps([{"start": 0, "end": 1, "narration": "full。"}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append(script)
+        if script == "review.py":
+            raise SystemExit("review unavailable")
+        if script == "assemble.py":
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "r.mp4")}), encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    assert "voiceover.py" in calls
+    assert "assemble.py" in calls
+
+
+def test_continuation_command_preserves_require_narration_review():
+    args = _manifest_args()
+    args.require_narration_review = True
+
+    command = recap._continuation_command("/tmp/in.mp4", "/tmp/work", args)
+
+    assert "--require-narration-review" in command

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -564,3 +564,92 @@ def test_cut_output_duration_bounds_rejects_non_finite_duration():
         validate._validate_output_timeline_bounds([{"start": 0.0, "end": 1.0}], output_duration=float("nan"))
     with pytest.raises(SystemExit, match="non-finite time"):
         validate._validate_output_timeline_bounds([{"start": float("nan"), "end": 1.0}], output_duration=10.0)
+
+
+def test_cut_pass2_agent_brief_writes_output_time_evidence(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "10s")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    raw_plan = {"clips": [{"start": 100.0, "end": 110.0}]}
+    (tmp_path / "clip_plan.json").write_text(json.dumps(raw_plan, ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "raw_plan_fingerprint": narration.stable_hash(raw_plan),
+        "clips": [{
+            "source_start": 100.0,
+            "source_end": 110.0,
+            "output_start": 0.0,
+            "output_end": 10.0,
+        }],
+    }, ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+    asr_payload = [{"start": 101.0, "end": 105.0, "text": "输出一到五秒对白。"}]
+    (tmp_path / "asr_result.json").write_text(json.dumps(asr_payload, ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "asr_clean.json").write_text(json.dumps({
+        "segments": [{"start": 101.0, "end": 105.0, "text": "清洗后一到五秒对白。"}],
+        "source_md5": __import__("hashlib").md5((tmp_path / "asr_result.json").read_bytes()).hexdigest(),
+        "model": narration._consolidation_model(),
+        "prompt_md5": narration._clean_asr_prompt_fingerprint(),
+    }, ensure_ascii=False), encoding="utf-8")
+
+    brief = build_agent_brief(
+        [{"scene_id": 7, "start": 100.0, "end": 110.0, "description": "保留片段",
+          "frame_facts": {"102.0": ["抬头"]}}],
+        asr_payload,
+        [{"start": 106.0, "end": 108.0, "duration": 2.0, "has_speech": False}],
+        120.0,
+        tmp_path,
+    )
+
+    chunks = json.loads((tmp_path / "asr_writing_chunks.json").read_text(encoding="utf-8"))
+    fusion = json.loads((tmp_path / "timeline_fusion.json").read_text(encoding="utf-8"))
+    text = brief.read_text(encoding="utf-8")
+
+    assert chunks[0]["start"] == pytest.approx(1.0)
+    assert chunks[0]["end"] == pytest.approx(5.0)
+    assert chunks[0]["text"] == "清洗后一到五秒对白。"
+    assert fusion[0]["time_range"] == [0.0, 10.0]
+    assert fusion[0]["dialogue_segments"][0]["start"] == pytest.approx(1.0)
+    assert fusion[0]["dialogue_segments"][0]["end"] == pytest.approx(5.0)
+    assert fusion[0]["narration_slots"][0]["start"] == pytest.approx(6.0)
+    assert "ASR chunk 1: 1.0-5.0s" in text
+    assert "ASR chunk 1: 101.0-105.0s" not in text
+
+
+def test_cut_pass2_agent_brief_requires_fresh_output_spans(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "10s")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+
+    with pytest.raises(SystemExit, match="cut pass2 brief requires fresh clip_plan_validated.json"):
+        build_agent_brief(
+            [{"scene_id": 7, "start": 100.0, "end": 110.0, "description": "保留片段"}],
+            [{"start": 101.0, "end": 105.0, "text": "源时间对白。"}],
+            [],
+            120.0,
+            tmp_path,
+        )
+
+
+def test_cut_pass2_agent_brief_rejects_non_finite_output_spans(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "10s")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "clips": [{
+            "source_start": 100.0,
+            "source_end": float("nan"),
+            "output_start": 0.0,
+            "output_end": 10.0,
+        }],
+    }), encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="non-finite clip span"):
+        build_agent_brief(
+            [{"scene_id": 7, "start": 100.0, "end": 110.0, "description": "保留片段"}],
+            [{"start": 101.0, "end": 105.0, "text": "源时间对白。"}],
+            [],
+            120.0,
+            tmp_path,
+        )

--- a/tests/understanding/test_pure_review.py
+++ b/tests/understanding/test_pure_review.py
@@ -51,3 +51,76 @@ def test_agent_brief_writes_asr_chunks_and_timeline_fusion(monkeypatch, tmp_path
     assert (tmp_path / "timeline_fusion.json").exists()
     fusion = json.loads((tmp_path / "timeline_fusion.json").read_text(encoding="utf-8"))
     assert fusion[0]["dialogue_segments"][0]["text"] == "第一句对白。第二句反击。"
+
+
+def test_understanding_brief_cut_pass2_writes_output_time_evidence(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "10s")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "clips": [{
+            "source_start": 100.0,
+            "source_end": 110.0,
+            "output_start": 0.0,
+            "output_end": 10.0,
+        }],
+    }, ensure_ascii=False), encoding="utf-8")
+
+    brief = build_agent_brief(
+        [{"scene_id": 7, "start": 100.0, "end": 110.0, "description": "保留片段"}],
+        [{"start": 101.0, "end": 105.0, "text": "输出一到五秒对白。"}],
+        [{"start": 106.0, "end": 108.0, "duration": 2.0, "has_speech": False}],
+        120.0,
+        tmp_path,
+    )
+
+    chunks = json.loads((tmp_path / "asr_writing_chunks.json").read_text(encoding="utf-8"))
+    fusion = json.loads((tmp_path / "timeline_fusion.json").read_text(encoding="utf-8"))
+    text = brief.read_text(encoding="utf-8")
+    assert chunks[0]["start"] == pytest.approx(1.0)
+    assert chunks[0]["end"] == pytest.approx(5.0)
+    assert fusion[0]["time_range"] == [0.0, 10.0]
+    assert fusion[0]["narration_slots"][0]["start"] == pytest.approx(6.0)
+    assert "ASR chunk 1: 1.0-5.0s" in text
+    assert "ASR chunk 1: 101.0-105.0s" not in text
+
+
+def test_understanding_brief_cut_pass2_requires_fresh_output_spans(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "10s")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+
+    with pytest.raises(SystemExit, match="cut pass2 brief requires fresh clip_plan_validated.json"):
+        build_agent_brief(
+            [{"scene_id": 7, "start": 100.0, "end": 110.0, "description": "保留片段"}],
+            [{"start": 101.0, "end": 105.0, "text": "源时间对白。"}],
+            [],
+            120.0,
+            tmp_path,
+        )
+
+
+def test_understanding_brief_cut_pass2_rejects_non_finite_output_spans(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "10s")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    (tmp_path / "edited_source.mp4").write_bytes(b"edited")
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "clips": [{
+            "source_start": 100.0,
+            "source_end": float("nan"),
+            "output_start": 0.0,
+            "output_end": 10.0,
+        }],
+    }), encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="non-finite clip span"):
+        build_agent_brief(
+            [{"scene_id": 7, "start": 100.0, "end": 110.0, "description": "保留片段"}],
+            [{"start": 101.0, "end": 105.0, "text": "源时间对白。"}],
+            [],
+            120.0,
+            tmp_path,
+        )


### PR DESCRIPTION
## Summary
- Fix `--no-burn-subtitles` so default sidecar-subtitle mode keeps the MP4 unmasked instead of drawing a mask-only black band.
- Make `timeline.json` / JianYing subtitle text consume display-ready subtitle cues matching SRT/ASS punctuation policy while preserving raw narration text on the narration audio track.
- Remap cut pass2 brief evidence (`asr_writing_chunks.json`, `timeline_fusion.json`) to OUTPUT time, fail fast when fresh output spans are unavailable, and reject non-finite spans.
- Add opt-in strict narration review (`--require-narration-review` / `REQUIRE_NARRATION_REVIEW=1`) while keeping default advisory fail-open behavior.
- Document mask/review/timeline subtitle behavior.

## Skill independence / no shared-lib guarantee
- No shared-lib extraction.
- No production cross-skill runtime imports introduced.
- `skills/video-script/scripts/narration.py` and `skills/video-understanding/scripts/brief.py` remain byte-identical local copies by design.
- The duplicated cut-output remap logic is intentionally local to preserve independent skill packaging.

## Validation
- `python scripts/test.py`
  - understanding: 91 passed
  - cut: 25 passed
  - voiceover: 27 passed
  - assemble: 111 passed
  - script: 50 passed
  - orchestrator: 59 passed
- `python -m ruff check .`
- `python -m compileall -q skills tests scripts conftest.py`
- `cmp -s skills/video-script/scripts/narration.py skills/video-understanding/scripts/brief.py` (`parity:0`)

## Review
- Independent code-reviewer follow-up: APPROVE, 0 issues.
- Independent architecture follow-up: CLEAR.

## Remaining risk / non-goal
- Did not test actual JianYing GUI import; validated generated draft/timeline JSON only.
- Did not perform broad shared-lib cleanup because skill independence is a hard constraint.
