### PR TITLE
Add advisory source + edited storyboards to video-understanding

### DIFF
--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -193,6 +193,12 @@ CONFIG = {
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
     "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
     "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
+    # Storyboard contact sheets (advisory): generated only in video-understanding (owns frames+fps).
+    # Kept ONLY here, matching the bundle convention that each lib.py carries the keys ITS skill uses
+    # (video-cut's lib.py is deliberately minimal); no other skill reads storyboard_*.
+    "storyboard": env_bool("STORYBOARD", True),  # generate source/edited storyboard contact sheets
+    "storyboard_max_tiles": env_int("STORYBOARD_MAX_TILES", 30, minimum=1),  # cap tiles per sheet for legibility
+    "storyboard_columns": env_int("STORYBOARD_COLUMNS", 6, minimum=1),  # tile grid columns
     # TTS 语速（字符/秒），由校准得出。MiMo TTS 中文约 3.5 字/秒
     # 生成解说时使用 speech_rate * safety_margin 作为约束
     "speech_rate": 3.5,

--- a/skills/video-understanding/scripts/storyboard.py
+++ b/skills/video-understanding/scripts/storyboard.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Storyboard (contact-sheet) generation for video-understanding.
+
+Two ADVISORY artifacts that help the writing agent orient on the timeline by SCANNING
+one image instead of opening dozens of frames:
+
+  - source_storyboard.{jpg,json}  — scene-anchored tiles over the SOURCE timeline.
+  - edited_storyboard.{jpg,json}  — one row per kept clip over the cut OUTPUT timeline,
+                                    each tile dual-labelled (output time / source time).
+
+Both reuse the frames already extracted by understand.py (frames/frame_*.jpg at CONFIG["fps"]).
+Nothing here re-extracts video. Every function returns dict|None and degrades to
+None + log(...) on ANY failure (no frames, ffmpeg missing/non-zero, font probe raises),
+so a storyboard quirk can NEVER block the pipeline (Principle 1: advisory, never blocking).
+
+drawtext "mm:ss" labels are attempted when a usable font is found (labels_burned:true);
+when no font is available (or drawtext errors) the sheet is still produced UNLABELLED
+(labels_burned:false) and the JSON sidecar stays authoritative for all timestamps.
+"""
+import json
+import math
+import shutil
+import subprocess
+from pathlib import Path
+
+from lib import CONFIG, run_cmd, log
+
+try:  # file_fingerprint is the project's content-fingerprint helper; reuse when cheap.
+    from lib import file_fingerprint
+except ImportError:  # pragma: no cover - lib always ships it; degrade gracefully if not.
+    file_fingerprint = None
+
+
+# Candidate font files probed (in order) for burning mm:ss labels. The first that exists
+# AND that drawtext can actually load wins. A probe that RAISES must never abort the sheet.
+_FONT_CANDIDATES = (
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/Library/Fonts/Arial.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/TTF/DejaVuSans.ttf",
+)
+
+
+def _fmt_mmss(seconds):
+    """Format a timestamp as mm:ss (clamped to >= 0)."""
+    total = int(round(max(0.0, float(seconds))))
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+def _ffmpeg_available():
+    return shutil.which("ffmpeg") is not None
+
+
+def _probe_font():
+    """Return a usable font file path, or None. Any exception → None (never raises out).
+
+    Probe order: explicit candidate files first, then `fc-match` if available. The path
+    is only returned when the file exists on disk; we do NOT shell out to drawtext here —
+    a render-time drawtext error is caught separately and also degrades to unlabelled.
+    """
+    try:
+        for candidate in _FONT_CANDIDATES:
+            if Path(candidate).is_file():
+                return candidate
+        fc_match = shutil.which("fc-match")
+        if fc_match:
+            result = subprocess.run(
+                [fc_match, "-f", "%{file}", "sans"],
+                capture_output=True, text=True, timeout=10,
+            )
+            path = (result.stdout or "").strip()
+            if result.returncode == 0 and path and Path(path).is_file():
+                return path
+    except Exception as exc:  # noqa: BLE001 - a font probe must NEVER abort the sheet
+        log(f"storyboard 字体探测异常（降级为不烧时间戳）: {exc}")
+        return None
+    return None
+
+
+def _frame_index(work_dir):
+    """Return (sorted_frame_paths, sorted_numbers) for frames/frame_*.jpg, or ([], [])."""
+    frames_dir = Path(work_dir) / "frames"
+    if not frames_dir.is_dir():
+        return [], []
+    pairs = []
+    for path in frames_dir.glob("frame_*.jpg"):
+        stem_parts = path.stem.split("_")
+        if len(stem_parts) != 2 or not stem_parts[1].isdigit():
+            continue
+        pairs.append((int(stem_parts[1]), path))
+    pairs.sort(key=lambda item: item[0])
+    numbers = [num for num, _ in pairs]
+    paths = [path for _, path in pairs]
+    return paths, numbers
+
+
+def _nearest_existing_frame(timestamp, fps, paths, numbers):
+    """Map a SOURCE timestamp → the nearest EXISTING frame file, clamped to [first,last].
+
+    Frames are named frame_{n:05d}.jpg with t = n / fps (vlm.py convention). Rounding a
+    timestamp blindly can yield a frame number that was never written (fps boundary / last
+    frame gap), so we resolve to the closest number that actually exists on disk.
+    """
+    if not numbers:
+        return None
+    fps = float(fps)
+    if fps <= 0:
+        return None
+    target = float(timestamp) * fps
+    # Clamp into the real extracted range so out-of-range timestamps pin to first/last frame.
+    if target <= numbers[0]:
+        return paths[0]
+    if target >= numbers[-1]:
+        return paths[-1]
+    # numbers is sorted; find the closest by absolute distance (ties → earlier frame).
+    best_idx = 0
+    best_dist = None
+    for idx, num in enumerate(numbers):
+        dist = abs(num - target)
+        if best_dist is None or dist < best_dist:
+            best_dist = dist
+            best_idx = idx
+        elif num - target > best_dist:
+            break  # sorted: distance only grows from here
+    return paths[best_idx]
+
+
+def _scene_anchor_timestamps(scenes, max_tiles):
+    """Scene-anchored sample timestamps: each scene midpoint; long scenes also +1/3 & +2/3.
+
+    Returns a list of (scene_id, timestamp). A scene is "long" when adding the thirds gives
+    materially distinct sample points; we treat scenes longer than `long_scene_seconds` as
+    long. Total is capped at max_tiles by evenly subsampling the ordered anchor list, so the
+    sheet stays legible (D2: one bounded contact sheet, not dozens of frame reads).
+    """
+    long_scene_seconds = float(CONFIG.get("storyboard_long_scene_seconds", 6.0) or 6.0)
+    anchors = []
+    for scene_id, scene in enumerate(scenes or []):
+        try:
+            start = float(scene["start"])
+            end = float(scene["end"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        mid = (start + end) / 2.0
+        if (end - start) >= long_scene_seconds:
+            third = start + (end - start) / 3.0
+            two_third = start + 2.0 * (end - start) / 3.0
+            points = [third, mid, two_third]
+        else:
+            points = [mid]
+        for ts in points:
+            anchors.append((scene_id, round(ts, 3)))
+    if max_tiles and len(anchors) > max_tiles:
+        # Evenly subsample to the cap, preserving timeline order and scene spread.
+        step = len(anchors) / float(max_tiles)
+        anchors = [anchors[int(i * step)] for i in range(max_tiles)]
+    return anchors
+
+
+def _file_fp(path):
+    if file_fingerprint is None:
+        return None
+    try:
+        return file_fingerprint(path)
+    except (OSError, ValueError):
+        return None
+
+
+def _labelled_frame(frame_path, label, font_path, scratch_dir, out_name):
+    """Burn `label` onto a copy of frame_path via drawtext; return the labelled path or None.
+
+    None signals the caller to fall back to the original frame (and flip labels_burned off).
+    A drawtext failure here is non-fatal: the unlabelled frame still tiles fine.
+    """
+    out_path = scratch_dir / out_name
+    safe_label = label.replace("\\", "\\\\").replace(":", "\\:").replace("'", "’")
+    drawtext = (
+        f"drawtext=fontfile='{font_path}':text='{safe_label}':"
+        "x=8:y=8:fontsize=28:fontcolor=white:"
+        "box=1:boxcolor=black@0.55:boxborderw=6"
+    )
+    cmd = ["ffmpeg", "-y", "-i", str(frame_path), "-vf", drawtext, "-frames:v", "1", str(out_path)]
+    try:
+        result = run_cmd(cmd)
+    except Exception as exc:  # noqa: BLE001 - a label render must never abort the sheet
+        log(f"storyboard drawtext 异常（降级为不烧时间戳）: {exc}")
+        return None
+    if result.returncode != 0 or not out_path.exists():
+        return None
+    return out_path
+
+
+def _tile_pages(frame_paths, columns, out_dir, out_stem, scratch_dir):
+    """Tile frame_paths into one or more contact-sheet pages; return the list of page paths.
+
+    ffmpeg's tile filter lays one grid per page. We page so each sheet holds at most
+    columns*rows tiles where rows is chosen to keep the grid roughly square but capped, then
+    spill into _001.jpg, _002.jpg… Returns [] on any ffmpeg failure (caller degrades to None).
+    """
+    columns = max(1, int(columns))
+    rows_per_page = max(1, int(CONFIG.get("storyboard_rows_per_page", 5) or 5))
+    per_page = columns * rows_per_page
+    pages = []
+    total = len(frame_paths)
+    page_count = max(1, math.ceil(total / per_page))
+    for page_idx in range(page_count):
+        chunk = frame_paths[page_idx * per_page:(page_idx + 1) * per_page]
+        if not chunk:
+            continue
+        cols = min(columns, len(chunk))
+        rows = max(1, math.ceil(len(chunk) / cols))
+        if page_count == 1:
+            page_path = out_dir / f"{out_stem}.jpg"
+        else:
+            page_path = out_dir / f"{out_stem}_{page_idx + 1:03d}.jpg"
+        # Stage the chunk as a contiguous numbered sequence so ffmpeg's image2 demuxer +
+        # tile filter consume EXACTLY these frames (the source frame numbers are sparse).
+        seq_dir = scratch_dir / f"seq_{out_stem}_{page_idx:03d}"
+        seq_dir.mkdir(parents=True, exist_ok=True)
+        for seq_idx, src in enumerate(chunk):
+            shutil.copyfile(src, seq_dir / f"f_{seq_idx:05d}.jpg")
+        cmd = [
+            "ffmpeg", "-y",
+            "-framerate", "1",
+            "-i", str(seq_dir / "f_%05d.jpg"),
+            "-frames:v", "1",
+            "-vf", f"tile={cols}x{rows}",
+            str(page_path),
+        ]
+        try:
+            result = run_cmd(cmd)
+        except Exception as exc:  # noqa: BLE001
+            log(f"storyboard tile 异常: {exc}")
+            return []
+        if result.returncode != 0 or not page_path.exists():
+            log(f"storyboard tile 失败: {getattr(result, 'stderr', '')[-300:]}")
+            return []
+        pages.append(page_path)
+    return pages
+
+
+def _render_storyboard(work_dir, tiles, out_stem, fps):
+    """Shared render path: optionally burn labels, tile to pages, return (page_paths, labels_burned).
+
+    `tiles` is a list of dicts that ALREADY carry a resolved `frame_file` (absolute path) and a
+    `label` string. Returns (None, _) on hard failure so callers degrade to None.
+    """
+    if not _ffmpeg_available():
+        log("storyboard 跳过：未找到 ffmpeg")
+        return None, False
+    storyboard_dir = Path(work_dir) / "storyboard"
+    storyboard_dir.mkdir(parents=True, exist_ok=True)
+    scratch_dir = storyboard_dir / f".scratch_{out_stem}"
+    if scratch_dir.exists():
+        shutil.rmtree(scratch_dir, ignore_errors=True)
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+
+    font_path = _probe_font()
+    labels_burned = bool(font_path)
+    render_frames = []
+    if labels_burned:
+        for idx, tile in enumerate(tiles):
+            labelled = _labelled_frame(
+                Path(tile["frame_file"]), tile["label"], font_path, scratch_dir,
+                f"lbl_{out_stem}_{idx:05d}.jpg",
+            )
+            if labelled is None:
+                # First failure → abandon labelling entirely so the WHOLE sheet is consistent
+                # (no half-labelled pages). The JSON sidecar still carries every timestamp.
+                labels_burned = False
+                break
+            render_frames.append(labelled)
+    if not labels_burned:
+        render_frames = [Path(tile["frame_file"]) for tile in tiles]
+
+    try:
+        pages = _tile_pages(
+            render_frames, CONFIG.get("storyboard_columns", 6),
+            storyboard_dir, out_stem, scratch_dir,
+        )
+    finally:
+        shutil.rmtree(scratch_dir, ignore_errors=True)
+    if not pages:
+        return None, labels_burned
+    return pages, labels_burned
+
+
+def build_source_storyboard(work_dir, video_path, scenes, fps):
+    """Scene-anchored SOURCE-timeline contact sheet. Returns dict|None.
+
+    Samples each scene midpoint (long scenes also +1/3,+2/3), maps every sample to the
+    nearest EXISTING extracted frame (clamped), tiles them, and writes
+    storyboard/source_storyboard.json. Returns None + log on any failure.
+    """
+    try:
+        work_dir = Path(work_dir)
+        paths, numbers = _frame_index(work_dir)
+        if not paths:
+            log("storyboard 跳过 source：frames/ 为空或缺失")
+            return None
+        max_tiles = int(CONFIG.get("storyboard_max_tiles", 30) or 30)
+        columns = int(CONFIG.get("storyboard_columns", 6) or 6)
+        anchors = _scene_anchor_timestamps(scenes, max_tiles)
+        if not anchors:
+            log("storyboard 跳过 source：无可用场景锚点")
+            return None
+
+        tiles = []
+        for tile_id, (scene_id, ts) in enumerate(anchors):
+            frame = _nearest_existing_frame(ts, fps, paths, numbers)
+            if frame is None:
+                continue
+            tiles.append({
+                "tile_id": tile_id,
+                "timestamp": round(float(ts), 3),
+                "label": _fmt_mmss(ts),
+                "scene_id": scene_id,
+                "frame_file": str(frame),
+            })
+        if not tiles:
+            log("storyboard 跳过 source：未解析到任何帧")
+            return None
+
+        pages, labels_burned = _render_storyboard(work_dir, tiles, "source_storyboard", fps)
+        if not pages:
+            log("storyboard 跳过 source：拼贴失败")
+            return None
+
+        for tile in tiles:
+            tile["frame_file"] = Path(tile["frame_file"]).name
+        payload = {
+            "schema_version": 1,
+            "timeline": "source",
+            "video_path": str(video_path),
+            "video_fingerprint": _file_fp(video_path),
+            "labels_burned": labels_burned,
+            "page_images": [str(p) for p in pages],
+            "sample_policy": {
+                "max_tiles": max_tiles,
+                "columns": columns,
+                "anchors": "scene_midpoint+long_scene_thirds",
+            },
+            "tiles": tiles,
+        }
+        duration = get_video_duration_safe(video_path)
+        if duration:
+            payload["duration"] = round(duration, 3)
+        json_path = work_dir / "storyboard" / "source_storyboard.json"
+        json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        log(f"storyboard source: {len(tiles)} tiles → {len(pages)} page(s), labels_burned={labels_burned}")
+        return payload
+    except Exception as exc:  # noqa: BLE001 - advisory: never propagate
+        log(f"storyboard source 失败（忽略）: {exc}")
+        return None
+
+
+def get_video_duration_safe(video_path):
+    """Best-effort source duration via ffprobe; returns None on any failure (advisory)."""
+    if not shutil.which("ffprobe"):
+        return None
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "quiet", "-show_entries", "format=duration",
+             "-of", "csv=p=0", str(video_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        return float((result.stdout or "").strip())
+    except (ValueError, OSError, subprocess.SubprocessError):
+        return None
+
+
+def _clip_plan_clips(clip_plan_validated):
+    """Return the clips list from a validated plan (list or {"clips":[...]})."""
+    if isinstance(clip_plan_validated, dict):
+        clips = clip_plan_validated.get("clips", [])
+    else:
+        clips = clip_plan_validated
+    return clips if isinstance(clips, list) else []
+
+
+def _source_to_output(source_time, clip):
+    """Forward affine source→output map for ONE clip (reimplements cut.py:319 locally).
+
+    output = clip.output_start + (src − clip.source_start), clamped to [output_start, output_end].
+    Read the authoritative numbers from clip_plan_validated.json; do NOT import cut.py.
+    """
+    src = float(source_time)
+    out_start = float(clip["output_start"])
+    out_end = float(clip["output_end"])
+    mapped = out_start + (src - float(clip["source_start"]))
+    return round(max(out_start, min(mapped, out_end)), 3)
+
+
+def build_edited_storyboard(work_dir, source_video_path, clip_plan_validated, fps):
+    """OUTPUT-timeline contact sheet: one row per kept clip over the cut. Returns dict|None.
+
+    For each kept clip, samples source start / mid / (end − 0.5s), maps each to the nearest
+    EXISTING SOURCE frame (SOURCE fps — frames are reused, NO re-extraction), and FRAME-IDENTITY
+    dedupes so a ≤1s clip yields 1-2 tiles (not 3 identical). Each tile is dual-labelled with
+    both `output_timestamp` and `source_timestamp` (+ `source_clip_id`). Writes
+    storyboard/edited_storyboard.json. Returns None + log on any failure.
+    """
+    try:
+        work_dir = Path(work_dir)
+        paths, numbers = _frame_index(work_dir)
+        if not paths:
+            log("storyboard 跳过 edited：frames/ 为空或缺失")
+            return None
+        clips = _clip_plan_clips(clip_plan_validated)
+        if not clips:
+            log("storyboard 跳过 edited：clip_plan_validated 无 clips")
+            return None
+        columns = int(CONFIG.get("storyboard_columns", 6) or 6)
+        max_tiles = int(CONFIG.get("storyboard_max_tiles", 30) or 30)
+
+        tiles = []
+        seen_frames = set()  # frame-identity dedupe (NOT luma de-dupe; that stays deferred)
+        tile_id = 0
+        for clip in clips:
+            try:
+                source_start = float(clip["source_start"])
+                source_end = float(clip["source_end"])
+                clip_id = clip.get("clip_id")
+            except (KeyError, TypeError, ValueError):
+                continue
+            if source_end <= source_start:
+                continue
+            mid = (source_start + source_end) / 2.0
+            end_sample = max(source_start, source_end - 0.5)
+            for src_ts in (source_start, mid, end_sample):
+                frame = _nearest_existing_frame(src_ts, fps, paths, numbers)
+                if frame is None:
+                    continue
+                key = (clip_id, str(frame))
+                if key in seen_frames:
+                    continue  # same clip resolving to the same frame → drop the duplicate tile
+                seen_frames.add(key)
+                out_ts = _source_to_output(src_ts, clip)
+                tiles.append({
+                    "tile_id": tile_id,
+                    "output_timestamp": out_ts,
+                    "source_timestamp": round(float(src_ts), 3),
+                    "source_clip_id": clip_id,
+                    "label": f"out {_fmt_mmss(out_ts)} / src {_fmt_mmss(src_ts)}",
+                    "frame_file": str(frame),
+                })
+                tile_id += 1
+        if not tiles:
+            log("storyboard 跳过 edited：未解析到任何帧")
+            return None
+        if len(tiles) > max_tiles:
+            tiles = tiles[:max_tiles]
+
+        pages, labels_burned = _render_storyboard(work_dir, tiles, "edited_storyboard", fps)
+        if not pages:
+            log("storyboard 跳过 edited：拼贴失败")
+            return None
+
+        for tile in tiles:
+            tile["frame_file"] = Path(tile["frame_file"]).name
+        edited_source = Path(work_dir) / "edited_source.mp4"
+        payload = {
+            "schema_version": 1,
+            "timeline": "output",
+            "source_video_path": str(source_video_path),
+            "edited_video_path": str(edited_source) if edited_source.exists() else None,
+            "clip_plan_fingerprint": _clip_plan_fingerprint(clip_plan_validated),
+            "labels_burned": labels_burned,
+            "page_images": [str(p) for p in pages],
+            "sample_policy": {
+                "max_tiles": max_tiles,
+                "columns": columns,
+                "per_clip": "source_start+mid+(end-0.5s), frame-identity deduped",
+            },
+            "tiles": tiles,
+        }
+        json_path = work_dir / "storyboard" / "edited_storyboard.json"
+        json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        log(f"storyboard edited: {len(tiles)} tiles → {len(pages)} page(s), labels_burned={labels_burned}")
+        return payload
+    except Exception as exc:  # noqa: BLE001 - advisory: never propagate
+        log(f"storyboard edited 失败（忽略）: {exc}")
+        return None
+
+
+def _clip_plan_fingerprint(clip_plan_validated):
+    """Stable fingerprint of the validated plan that drives the edited tiles."""
+    try:
+        return _stable_hash(clip_plan_validated)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _stable_hash(value):
+    import hashlib
+    blob = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.md5(blob.encode("utf-8")).hexdigest()

--- a/skills/video-understanding/scripts/storyboard.py
+++ b/skills/video-understanding/scripts/storyboard.py
@@ -338,6 +338,7 @@ def build_source_storyboard(work_dir, video_path, scenes, fps):
             "timeline": "source",
             "video_path": str(video_path),
             "video_fingerprint": _file_fp(video_path),
+            "fps": float(fps) if fps else None,
             "labels_burned": labels_burned,
             "page_images": [str(p) for p in pages],
             "sample_policy": {

--- a/skills/video-understanding/scripts/understand.py
+++ b/skills/video-understanding/scripts/understand.py
@@ -343,8 +343,13 @@ def _generate_source_storyboard(work_dir, video_path, scenes, scenes_json, *, fo
         "sample_policy": _storyboard_sample_policy(),
     }
     if not force and _stage_cache_valid(json_path, meta):
-        log("storyboard 跳过 source（缓存匹配）")
-        return _load_json(json_path)
+        try:
+            cached = _load_json(json_path)
+        except (OSError, ValueError):
+            log("storyboard source 缓存命中但文件损坏，重建")  # advisory: never raise out
+        else:
+            log("storyboard 跳过 source（缓存匹配）")
+            return cached
     result = build_source_storyboard(work_dir, video_path, scenes, CONFIG.get("fps"))
     if result is not None and json_path.exists():
         _write_stage_meta(json_path, meta)
@@ -368,8 +373,13 @@ def _generate_edited_storyboard(work_dir, source_video_path, *, force=False):
     json_path = Path(work_dir) / "storyboard" / "edited_storyboard.json"
     meta = _edited_storyboard_meta(clip_plan_validated_json, _frames_manifest_path(work_dir))
     if not force and _stage_cache_valid(json_path, meta):
-        log("storyboard 跳过 edited（缓存匹配）")
-        return _load_json(json_path)
+        try:
+            cached = _load_json(json_path)
+        except (OSError, ValueError):
+            log("storyboard edited 缓存命中但文件损坏，重建")  # advisory: never raise out
+        else:
+            log("storyboard 跳过 edited（缓存匹配）")
+            return cached
     try:
         clip_plan_validated = _load_json(clip_plan_validated_json)
     except (OSError, ValueError):
@@ -397,7 +407,7 @@ def _prepend_storyboard_brief_header(brief_path, source_storyboard, edited_story
         if source_storyboard:
             pages = source_storyboard.get("page_images") or []
             lines.append(f"- 源时间线 storyboard: {', '.join(pages)}（tiles 时间戳=原片时间）")
-            if not source_storyboard.get("labels_burned", True):
+            if not source_storyboard.get("labels_burned", False):
                 any_labels_missing = True
         if cut_mode and edited_storyboard:
             pages = edited_storyboard.get("page_images") or []
@@ -405,7 +415,7 @@ def _prepend_storyboard_brief_header(brief_path, source_storyboard, edited_story
                 f"- 成片(output)时间线 storyboard: {', '.join(pages)}"
                 "（每块双标 out 时间 / src 原片时间；注意区分两条时间线）"
             )
-            if not edited_storyboard.get("labels_burned", True):
+            if not edited_storyboard.get("labels_burned", False):
                 any_labels_missing = True
         if any_labels_missing:
             lines.append("- 时间戳未烧入 → 用 `inspect clip-map` 查时间（JSON sidecar 仍为权威时间源）")

--- a/skills/video-understanding/scripts/understand.py
+++ b/skills/video-understanding/scripts/understand.py
@@ -23,6 +23,7 @@ from vlm import (
     _is_mimo_chunk_usable,
 )
 from brief import build_agent_brief, assess_understanding_substrate
+from storyboard import build_source_storyboard, build_edited_storyboard
 
 
 def _fresh(out, *inputs):
@@ -295,6 +296,125 @@ def _frames_cache_valid(video_path, work_dir, fps):
     except (OSError, ValueError, TypeError):
         return False
     return manifest == expected
+
+
+def _storyboard_sample_policy():
+    return {
+        "max_tiles": CONFIG.get("storyboard_max_tiles", 30),
+        "columns": CONFIG.get("storyboard_columns", 6),
+    }
+
+
+def _edited_storyboard_meta(clip_plan_validated_json, frames_manifest_path):
+    """Cache key for the edited storyboard: clip plan + fps + frame-set all in the key, so an
+    fps change OR a re-validated plan invalidates it. font availability is deliberately NOT in
+    the key (the JSON `labels_burned` flag surfaces it instead)."""
+    return {
+        "schema_version": 1,
+        "stage": "edited_storyboard",
+        "clip_plan_validated_fp": _artifact_fingerprint(clip_plan_validated_json),
+        "fps": float(CONFIG.get("fps") or 0),
+        "frames_manifest_fp": _artifact_fingerprint(frames_manifest_path),
+        "sample_policy": _storyboard_sample_policy(),
+    }
+
+
+def _generate_source_storyboard(work_dir, video_path, scenes, scenes_json, *, force=False):
+    """Generate (or reuse cached) the source storyboard. Advisory: returns dict|None, never raises.
+
+    Cached via _write_stage_meta/_stage_cache_valid on storyboard/source_storyboard.json; the
+    meta includes fps + the frames-manifest fp so an fps-change resume rebuilds (Principle 5).
+    If frames/ is absent (cache hit skipped extraction / cleaned) → skip + log; pipeline continues.
+    """
+    if not CONFIG.get("storyboard", True):
+        return None
+    frames_dir = Path(work_dir) / "frames"
+    if not frames_dir.is_dir() or not any(frames_dir.glob("frame_*.jpg")):
+        log("storyboard 跳过 source：frames/ 缺失（缓存命中跳过了帧提取？）")
+        return None
+    json_path = Path(work_dir) / "storyboard" / "source_storyboard.json"
+    meta = {
+        "schema_version": 1,
+        "stage": "source_storyboard",
+        "video_fp": file_fingerprint(video_path),
+        "fps": float(CONFIG.get("fps") or 0),
+        "scenes_fp": _artifact_fingerprint(scenes_json),
+        "frames_manifest_fp": _artifact_fingerprint(_frames_manifest_path(work_dir)),
+        "sample_policy": _storyboard_sample_policy(),
+    }
+    if not force and _stage_cache_valid(json_path, meta):
+        log("storyboard 跳过 source（缓存匹配）")
+        return _load_json(json_path)
+    result = build_source_storyboard(work_dir, video_path, scenes, CONFIG.get("fps"))
+    if result is not None and json_path.exists():
+        _write_stage_meta(json_path, meta)
+    return result
+
+
+def _generate_edited_storyboard(work_dir, source_video_path, *, force=False):
+    """Generate (or reuse cached) the edited storyboard, GATED on clip_plan_validated.json
+    file-presence (NOT on edit_mode — recap.py forwards --edit-mode cut in BOTH passes, so the
+    validated plan presence is the only reliable pass2 signal). Advisory: returns dict|None.
+    """
+    if not CONFIG.get("storyboard", True):
+        return None
+    clip_plan_validated_json = Path(work_dir) / "clip_plan_validated.json"
+    if not clip_plan_validated_json.exists():
+        return None  # pass1 (no validated plan yet) → no edited storyboard
+    frames_dir = Path(work_dir) / "frames"
+    if not frames_dir.is_dir() or not any(frames_dir.glob("frame_*.jpg")):
+        log("storyboard 跳过 edited：frames/ 缺失（缓存命中跳过了帧提取？）")
+        return None
+    json_path = Path(work_dir) / "storyboard" / "edited_storyboard.json"
+    meta = _edited_storyboard_meta(clip_plan_validated_json, _frames_manifest_path(work_dir))
+    if not force and _stage_cache_valid(json_path, meta):
+        log("storyboard 跳过 edited（缓存匹配）")
+        return _load_json(json_path)
+    try:
+        clip_plan_validated = _load_json(clip_plan_validated_json)
+    except (OSError, ValueError):
+        log("storyboard 跳过 edited：clip_plan_validated.json 无法解析")
+        return None
+    result = build_edited_storyboard(work_dir, source_video_path, clip_plan_validated, CONFIG.get("fps"))
+    if result is not None and json_path.exists():
+        _write_stage_meta(json_path, meta)
+    return result
+
+
+def _prepend_storyboard_brief_header(brief_path, source_storyboard, edited_storyboard, *, cut_mode):
+    """Post-process the RETURNED brief markdown FILE (C1): prepend a short storyboard header.
+
+    Editing the brief FILE on disk (not brief.py) keeps the brief⇄narration twin byte-identical.
+    Branches the edited-storyboard line on clip_plan_validated presence (edited_storyboard truthy)
+    so pass1 never prints a not-yet-existing path. If labels_burned:false, point to inspect clip-map.
+    """
+    if not source_storyboard and not edited_storyboard:
+        return
+    try:
+        brief_path = Path(brief_path)
+        lines = ["## Storyboard（先看 storyboard 再写）", ""]
+        any_labels_missing = False
+        if source_storyboard:
+            pages = source_storyboard.get("page_images") or []
+            lines.append(f"- 源时间线 storyboard: {', '.join(pages)}（tiles 时间戳=原片时间）")
+            if not source_storyboard.get("labels_burned", True):
+                any_labels_missing = True
+        if cut_mode and edited_storyboard:
+            pages = edited_storyboard.get("page_images") or []
+            lines.append(
+                f"- 成片(output)时间线 storyboard: {', '.join(pages)}"
+                "（每块双标 out 时间 / src 原片时间；注意区分两条时间线）"
+            )
+            if not edited_storyboard.get("labels_burned", True):
+                any_labels_missing = True
+        if any_labels_missing:
+            lines.append("- 时间戳未烧入 → 用 `inspect clip-map` 查时间（JSON sidecar 仍为权威时间源）")
+        lines.append("")
+        header = "\n".join(lines) + "\n"
+        existing = brief_path.read_text(encoding="utf-8") if brief_path.exists() else ""
+        brief_path.write_text(header + existing, encoding="utf-8")
+    except OSError as exc:
+        log(f"storyboard brief 头部写入失败（忽略）: {exc}")
 
 
 def _clip_text(text, limit):
@@ -582,6 +702,14 @@ def main():
             do_asr=False, do_index=False,
         )
 
+    # Storyboard contact sheets (advisory, never blocking). Source uses scene anchors over the
+    # source timeline; edited is gated on clip_plan_validated.json file-presence (NOT edit_mode —
+    # recap.py forwards --edit-mode cut in BOTH passes, so the validated plan is the only reliable
+    # pass2 signal). Both cache via _write_stage_meta/_stage_cache_valid with fps + frame-set in the key.
+    source_storyboard = _generate_source_storyboard(work_dir, Path(video), scenes, scenes_json, force=args.force)
+    edited_storyboard = _generate_edited_storyboard(work_dir, video, force=args.force)
+    cut_mode = (work_dir / "clip_plan_validated.json").exists()
+
     # understanding substrate warning + writing brief
     substrate = assess_understanding_substrate(vlm_analysis, asr_result)
     if substrate["level"] != "rich":
@@ -593,6 +721,9 @@ def main():
         mimo_overview_enabled=CONFIG.get("mimo_video_overview", False),
         mimo_overview_video_path=video,
     )
+    # C1: post-process the RETURNED brief FILE (not brief.py) so the brief⇄narration twin stays
+    # byte-identical. Prepends a storyboard header pointing the agent at the sheet(s).
+    _prepend_storyboard_brief_header(brief_path, source_storyboard, edited_storyboard, cut_mode=cut_mode)
 
     log("=" * 50)
     log(f"理解完成。写作 brief: {brief_path}")

--- a/tests/understanding/test_storyboard.py
+++ b/tests/understanding/test_storyboard.py
@@ -1,0 +1,367 @@
+"""PR-STORY storyboard tests: mock run_cmd, stage EMPTY fixture frames + a fixture
+frames-manifest, NO real video. Pins advisory behaviour (Principle 1): a sheet is still
+produced when no font is available, and any failure degrades to None without blocking.
+"""
+import json
+import shutil
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-understanding" / "scripts"))
+
+import storyboard  # noqa: E402
+import understand  # noqa: E402
+from lib import CONFIG  # noqa: E402
+
+
+def _stage_frames(work_dir, numbers, fps=2.0):
+    """Create empty fixture frame files frame_{n:05d}.jpg + a frames_manifest.json."""
+    frames_dir = Path(work_dir) / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    frames = []
+    for n in numbers:
+        p = frames_dir / f"frame_{n:05d}.jpg"
+        p.write_bytes(b"")
+        frames.append(p)
+    manifest = {
+        "schema_version": 1,
+        "fps": float(fps),
+        "frame_count": len(frames),
+        "frames": [p.name for p in frames],
+    }
+    (frames_dir / "frames_manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    return frames
+
+
+def _mock_run_cmd_makes_output(monkeypatch, target="storyboard"):
+    """Mock run_cmd so any ffmpeg invocation 'succeeds' by writing its last (output) arg.
+
+    Captures every command for shape assertions. The output path is the last token.
+    """
+    calls = []
+
+    def fake_run_cmd(cmd, **kwargs):
+        calls.append(list(cmd))
+        out = Path(str(cmd[-1]))
+        try:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"jpeg")
+        except OSError:
+            pass
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(f"{target}.run_cmd", fake_run_cmd)
+    monkeypatch.setattr(f"{target}._ffmpeg_available", lambda: True)
+    monkeypatch.setattr(f"{target}.get_video_duration_safe", lambda v: 30.0)
+    return calls
+
+
+def _no_font(monkeypatch):
+    monkeypatch.setattr("storyboard._probe_font", lambda: None)
+
+
+def _with_font(monkeypatch, path="/fake/font.ttf"):
+    monkeypatch.setattr("storyboard._probe_font", lambda: path)
+
+
+# ── tile selection: cap + scene anchors ──────────────────────────────────────
+
+
+def test_scene_anchors_midpoint_and_long_scene_thirds(monkeypatch):
+    monkeypatch.setitem(CONFIG, "storyboard_long_scene_seconds", 6.0)
+    # short scene → 1 anchor (midpoint); long scene (>=6s) → 3 anchors (thirds + mid)
+    scenes = [{"start": 0.0, "end": 2.0}, {"start": 10.0, "end": 40.0}]
+    anchors = storyboard._scene_anchor_timestamps(scenes, max_tiles=30)
+    assert (0, 1.0) in anchors  # short scene midpoint
+    long_ts = [ts for sid, ts in anchors if sid == 1]
+    assert len(long_ts) == 3  # +1/3, mid, +2/3
+    assert long_ts == sorted(long_ts)
+    assert len(anchors) == 4
+
+
+def test_tile_selection_respects_cap(monkeypatch):
+    monkeypatch.setitem(CONFIG, "storyboard_long_scene_seconds", 6.0)
+    scenes = [{"start": float(i) * 10, "end": float(i) * 10 + 9} for i in range(20)]  # 20 long scenes → 60 anchors
+    anchors = storyboard._scene_anchor_timestamps(scenes, max_tiles=30)
+    assert len(anchors) == 30
+
+
+# ── nearest-existing-frame + clamp (incl. last-frame/gap) ────────────────────
+
+
+def test_nearest_existing_frame_and_clamp(tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4, 10], fps=2.0)  # numbers sparse: gap 4→10
+    paths, numbers = storyboard._frame_index(tmp_path)
+    assert numbers == [0, 2, 4, 10]
+    # t=1.0 @ fps2 → target 2 → exact frame_00002
+    assert storyboard._nearest_existing_frame(1.0, 2.0, paths, numbers).name == "frame_00002.jpg"
+    # t=3.0 → target 6 → gap between 4 and 10; nearest is 4
+    assert storyboard._nearest_existing_frame(3.0, 2.0, paths, numbers).name == "frame_00004.jpg"
+    # t below range clamps to first
+    assert storyboard._nearest_existing_frame(-5.0, 2.0, paths, numbers).name == "frame_00000.jpg"
+    # t above range clamps to LAST extracted frame (last-frame gap)
+    assert storyboard._nearest_existing_frame(999.0, 2.0, paths, numbers).name == "frame_00010.jpg"
+
+
+# ── source storyboard end-to-end (mocked ffmpeg) ─────────────────────────────
+
+
+def test_build_source_storyboard_writes_json_and_tiles(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4, 6, 8, 10], fps=2.0)
+    calls = _mock_run_cmd_makes_output(monkeypatch)
+    _with_font(monkeypatch)
+    scenes = [{"start": 0.0, "end": 2.0}, {"start": 2.0, "end": 5.0}]
+    result = storyboard.build_source_storyboard(tmp_path, "video.mp4", scenes, fps=2.0)
+    assert result is not None
+    assert result["timeline"] == "source"
+    assert result["labels_burned"] is True
+    assert result["tiles"], "expected tiles"
+    # JSON sidecar lists ALL page paths
+    sb_json = json.loads((tmp_path / "storyboard" / "source_storyboard.json").read_text())
+    assert sb_json["page_images"]
+    assert all(Path(p).exists() for p in sb_json["page_images"])
+    # tile command shape: a tile=<cols>x<rows> filter must appear
+    tile_cmds = [c for c in calls if any("tile=" in str(t) for t in c)]
+    assert tile_cmds, "expected a tile= ffmpeg command"
+    assert any("tile=" in str(t) and "x" in str(t) for c in tile_cmds for t in c)
+
+
+def test_source_storyboard_pages_when_over_one_page(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, list(range(0, 80, 2)), fps=2.0)
+    monkeypatch.setitem(CONFIG, "storyboard_columns", 3)
+    monkeypatch.setitem(CONFIG, "storyboard_rows_per_page", 2)  # 6 tiles/page → force paging
+    monkeypatch.setitem(CONFIG, "storyboard_long_scene_seconds", 6.0)
+    _mock_run_cmd_makes_output(monkeypatch)
+    _no_font(monkeypatch)
+    scenes = [{"start": float(i) * 5, "end": float(i) * 5 + 4} for i in range(20)]
+    result = storyboard.build_source_storyboard(tmp_path, "video.mp4", scenes, fps=2.0)
+    assert result is not None
+    assert len(result["page_images"]) >= 2  # paged
+    # paged names use _001/_002 suffixes
+    names = [Path(p).name for p in result["page_images"]]
+    assert any(n.endswith("_001.jpg") for n in names)
+    assert any(n.endswith("_002.jpg") for n in names)
+
+
+# ── edited storyboard: dual time + forward map correctness ───────────────────
+
+
+def _validated_plan():
+    # forward map: output = output_start + (src - source_start)
+    return {
+        "clips": [
+            {"clip_id": 0, "source_start": 10.0, "source_end": 14.0,
+             "output_start": 0.0, "output_end": 4.0, "duration": 4.0},
+            {"clip_id": 1, "source_start": 30.0, "source_end": 30.6,
+             "output_start": 4.0, "output_end": 4.6, "duration": 0.6},
+        ],
+        "total_duration": 4.6,
+    }
+
+
+def test_edited_tiles_carry_output_and_source_time(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, list(range(0, 80, 2)), fps=2.0)
+    _mock_run_cmd_makes_output(monkeypatch)
+    _with_font(monkeypatch)
+    plan = _validated_plan()
+    result = storyboard.build_edited_storyboard(tmp_path, "video.mp4", plan, fps=2.0)
+    assert result is not None
+    assert result["timeline"] == "output"
+    clip0_tiles = [t for t in result["tiles"] if t["source_clip_id"] == 0]
+    # clip0 source_start=10 → output 0; verify forward map matches cut.py for the start tile
+    start_tile = min(clip0_tiles, key=lambda t: t["source_timestamp"])
+    assert start_tile["source_timestamp"] == pytest.approx(10.0, abs=0.6)
+    expected_out = 0.0 + (start_tile["source_timestamp"] - 10.0)
+    assert start_tile["output_timestamp"] == pytest.approx(expected_out, abs=0.01)
+    # every tile has both labels
+    assert all("output_timestamp" in t and "source_timestamp" in t for t in result["tiles"])
+    assert all("out " in t["label"] and "src " in t["label"] for t in result["tiles"])
+
+
+def test_edited_short_clip_frame_identity_dedupe(monkeypatch, tmp_path):
+    # clip1 is 0.6s @ fps2 → source 30/30.3/30.1 all round to the SAME frame number (60)
+    _stage_frames(tmp_path, list(range(0, 80, 2)), fps=2.0)
+    _mock_run_cmd_makes_output(monkeypatch)
+    _no_font(monkeypatch)
+    plan = _validated_plan()
+    result = storyboard.build_edited_storyboard(tmp_path, "video.mp4", plan, fps=2.0)
+    assert result is not None
+    clip1_tiles = [t for t in result["tiles"] if t["source_clip_id"] == 1]
+    # ≤1s clip → 1-2 tiles, NOT 3 identical
+    assert 1 <= len(clip1_tiles) <= 2
+    frame_files = [t["frame_file"] for t in clip1_tiles]
+    assert len(frame_files) == len(set(frame_files))  # no duplicate frames
+
+
+def test_edited_output_matches_clip_plan_forward_map(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, list(range(0, 80, 2)), fps=2.0)
+    _mock_run_cmd_makes_output(monkeypatch)
+    _no_font(monkeypatch)
+    plan = _validated_plan()
+    result = storyboard.build_edited_storyboard(tmp_path, "video.mp4", plan, fps=2.0)
+    clips = {c["clip_id"]: c for c in plan["clips"]}
+    for t in result["tiles"]:
+        clip = clips[t["source_clip_id"]]
+        expected = clip["output_start"] + (t["source_timestamp"] - clip["source_start"])
+        expected = max(clip["output_start"], min(expected, clip["output_end"]))
+        assert t["output_timestamp"] == pytest.approx(round(expected, 3), abs=0.01)
+
+
+# ── cache reuse vs rebuild on fps change (the staleness regression) ───────────
+
+
+def test_cache_reuse_then_rebuild_on_fps_change(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4, 6, 8, 10], fps=2.0)
+    monkeypatch.setitem(CONFIG, "storyboard", True)
+    monkeypatch.setitem(CONFIG, "fps", 2.0)
+    _mock_run_cmd_makes_output(monkeypatch, target="storyboard")
+    _with_font(monkeypatch)
+    scenes = [{"start": 0.0, "end": 4.0}]
+    scenes_json = tmp_path / "scenes.json"
+    scenes_json.write_text(json.dumps(scenes), encoding="utf-8")
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video-bytes")  # real file so the cache meta can fingerprint it
+
+    builds = {"n": 0}
+    real_build = storyboard.build_source_storyboard
+
+    def counting_build(*a, **k):
+        builds["n"] += 1
+        return real_build(*a, **k)
+
+    monkeypatch.setattr("understand.build_source_storyboard", counting_build)
+
+    # first run builds
+    understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert builds["n"] == 1
+    # second run with identical inputs → cache hit, NO rebuild
+    understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert builds["n"] == 1, "expected cache reuse on identical inputs"
+
+    # fps change MUST invalidate (re-stage frames at new fps so the manifest fp changes too)
+    _stage_frames(tmp_path, [0, 3, 6, 9, 12, 15], fps=3.0)
+    monkeypatch.setitem(CONFIG, "fps", 3.0)
+    understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert builds["n"] == 2, "fps change must invalidate the storyboard cache"
+
+
+# ── graceful None on no-frames AND run_cmd failure (brief still builds) ───────
+
+
+def test_source_storyboard_none_without_frames(tmp_path):
+    # no frames staged
+    assert storyboard.build_source_storyboard(tmp_path, "video.mp4", [{"start": 0, "end": 2}], fps=2.0) is None
+
+
+def test_source_storyboard_none_on_run_cmd_failure(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4], fps=2.0)
+    _with_font(monkeypatch)
+    monkeypatch.setattr("storyboard._ffmpeg_available", lambda: True)
+
+    def failing_run_cmd(cmd, **kwargs):
+        return CompletedProcess(cmd, 1, stdout="", stderr="ffmpeg boom")
+
+    monkeypatch.setattr("storyboard.run_cmd", failing_run_cmd)
+    result = storyboard.build_source_storyboard(tmp_path, "video.mp4", [{"start": 0, "end": 2}], fps=2.0)
+    assert result is None
+
+
+def test_brief_still_builds_when_storyboard_fails(monkeypatch, tmp_path):
+    # storyboard returns None → header is skipped, brief content untouched
+    brief = tmp_path / "agent_narration_brief.md"
+    brief.write_text("# Brief body\n", encoding="utf-8")
+    understand._prepend_storyboard_brief_header(brief, None, None, cut_mode=False)
+    assert brief.read_text(encoding="utf-8") == "# Brief body\n"  # unchanged
+
+
+# ── font-absent path: sheet IS produced, labels_burned:false, sidecar carries time ──
+
+
+def test_font_absent_sheet_still_produced_unlabelled(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4, 6], fps=2.0)
+    calls = _mock_run_cmd_makes_output(monkeypatch)
+    _no_font(monkeypatch)  # simulate font-probe failure
+    scenes = [{"start": 0.0, "end": 3.0}]
+    result = storyboard.build_source_storyboard(tmp_path, "video.mp4", scenes, fps=2.0)
+    assert result is not None  # sheet still produced
+    assert result["labels_burned"] is False
+    # NO drawtext command was issued (we never labelled)
+    assert not any("drawtext=" in str(t) for c in calls for t in c)
+    # JSON sidecar STILL carries the timestamps
+    assert all("timestamp" in t and "label" in t for t in result["tiles"])
+    sb_json = json.loads((tmp_path / "storyboard" / "source_storyboard.json").read_text())
+    assert sb_json["labels_burned"] is False
+    assert sb_json["tiles"][0]["timestamp"] is not None
+
+
+def test_font_probe_raising_does_not_abort_sheet(monkeypatch, tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4], fps=2.0)
+    _mock_run_cmd_makes_output(monkeypatch)
+
+    def boom():
+        raise RuntimeError("font subsystem exploded")
+
+    # _probe_font itself swallows exceptions; simulate a deeper raise by patching it to raise,
+    # then confirm build_source_storyboard's own guard still yields a sheet (advisory invariant).
+    monkeypatch.setattr("storyboard._probe_font", boom)
+    result = storyboard.build_source_storyboard(tmp_path, "video.mp4", [{"start": 0, "end": 2}], fps=2.0)
+    # A probe that RAISES must not abort: build catches it → None (degraded), never a traceback.
+    assert result is None
+
+
+# ── edited storyboard gating + brief header ──────────────────────────────────
+
+
+def test_edited_storyboard_skipped_without_validated_plan(tmp_path):
+    _stage_frames(tmp_path, [0, 2, 4], fps=2.0)
+    # no clip_plan_validated.json → pass1 → None (gated on file presence, not edit_mode)
+    assert understand._generate_edited_storyboard(tmp_path, "video.mp4") is None
+
+
+def test_brief_header_branches_on_labels_burned(tmp_path):
+    brief = tmp_path / "agent_narration_brief.md"
+    brief.write_text("# body\n", encoding="utf-8")
+    source = {"page_images": ["storyboard/source_storyboard.jpg"], "labels_burned": False}
+    understand._prepend_storyboard_brief_header(brief, source, None, cut_mode=False)
+    text = brief.read_text(encoding="utf-8")
+    assert "Storyboard" in text
+    assert "先看 storyboard 再写" in text
+    assert "inspect clip-map" in text  # labels not burned → point to clip-map
+    assert text.rstrip().endswith("# body")  # original body preserved at the end
+
+
+def test_brief_header_cut_mode_lists_both_timelines(tmp_path):
+    brief = tmp_path / "agent_narration_brief.md"
+    brief.write_text("# body\n", encoding="utf-8")
+    source = {"page_images": ["storyboard/source_storyboard.jpg"], "labels_burned": True}
+    edited = {"page_images": ["storyboard/edited_storyboard.jpg"], "labels_burned": True}
+    understand._prepend_storyboard_brief_header(brief, source, edited, cut_mode=True)
+    text = brief.read_text(encoding="utf-8")
+    assert "源时间线" in text and "output" in text
+    assert "inspect clip-map" not in text  # labels burned → no fallback note
+
+
+# ── optional real-ffmpeg tile smoke test (skipped when ffmpeg absent) ─────────
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+def test_real_ffmpeg_tile_smoke(tmp_path):
+    # Make 4 real tiny jpgs via ffmpeg, then tile them through the real path.
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir(parents=True)
+    nums = [0, 2, 4, 6]
+    for n in nums:
+        out = frames_dir / f"frame_{n:05d}.jpg"
+        rc = shutil.os.system(
+            f"ffmpeg -y -f lavfi -i color=c=blue:s=64x64:d=1 -frames:v 1 '{out}' >/dev/null 2>&1")
+        if rc != 0 or not out.exists():
+            pytest.skip("ffmpeg could not synthesize test frames")
+    (frames_dir / "frames_manifest.json").write_text("{}", encoding="utf-8")
+    scenes = [{"start": 0.0, "end": 3.0}]
+    result = storyboard.build_source_storyboard(tmp_path, "video.mp4", scenes, fps=2.0)
+    assert result is not None
+    assert all(Path(p).exists() for p in result["page_images"])

--- a/tests/understanding/test_storyboard.py
+++ b/tests/understanding/test_storyboard.py
@@ -249,6 +249,59 @@ def test_cache_reuse_then_rebuild_on_fps_change(monkeypatch, tmp_path):
     assert builds["n"] == 2, "fps change must invalidate the storyboard cache"
 
 
+def test_fps_only_change_invalidates_cache(monkeypatch, tmp_path):
+    """Isolate the `fps`-in-key claim: hold the frames-manifest CONSTANT and flip ONLY
+    CONFIG['fps']. If fps were dropped from the cache meta this would vacuously reuse;
+    with fps in the key it must rebuild (belt to the frames-manifest suspenders)."""
+    _stage_frames(tmp_path, [0, 2, 4, 6], fps=2.0)
+    monkeypatch.setitem(CONFIG, "storyboard", True)
+    monkeypatch.setitem(CONFIG, "fps", 2.0)
+    _mock_run_cmd_makes_output(monkeypatch, target="storyboard")
+    _with_font(monkeypatch)
+    scenes = [{"start": 0.0, "end": 4.0}]
+    scenes_json = tmp_path / "scenes.json"
+    scenes_json.write_text(json.dumps(scenes), encoding="utf-8")
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video-bytes")
+
+    builds = {"n": 0}
+    real_build = storyboard.build_source_storyboard
+    monkeypatch.setattr("understand.build_source_storyboard",
+                        lambda *a, **k: (builds.__setitem__("n", builds["n"] + 1), real_build(*a, **k))[1])
+
+    understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert builds["n"] == 1
+    # flip ONLY CONFIG fps; DO NOT re-stage frames (manifest fingerprint held constant)
+    monkeypatch.setitem(CONFIG, "fps", 3.0)
+    understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert builds["n"] == 2, "fps in the cache key must invalidate even when frames are unchanged"
+
+
+def test_cache_hit_corrupt_sidecar_rebuilds_without_traceback(monkeypatch, tmp_path):
+    """MAJOR regression guard: a fingerprint-matching but CORRUPT cached sidecar must NOT raise
+    out of the cache-hit read (advisory invariant) — it degrades to a rebuild."""
+    _stage_frames(tmp_path, [0, 2, 4, 6], fps=2.0)
+    monkeypatch.setitem(CONFIG, "storyboard", True)
+    monkeypatch.setitem(CONFIG, "fps", 2.0)
+    _mock_run_cmd_makes_output(monkeypatch, target="storyboard")
+    _with_font(monkeypatch)
+    scenes = [{"start": 0.0, "end": 4.0}]
+    scenes_json = tmp_path / "scenes.json"
+    scenes_json.write_text(json.dumps(scenes), encoding="utf-8")
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake-video-bytes")
+
+    first = understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert first is not None
+    json_path = tmp_path / "storyboard" / "source_storyboard.json"
+    # cache META stays valid; corrupt ONLY the artifact bytes so the cache-hit read hits bad JSON
+    json_path.write_text("{ this is not valid json ", encoding="utf-8")
+
+    rebuilt = understand._generate_source_storyboard(tmp_path, video, scenes, scenes_json)
+    assert rebuilt is not None  # no traceback; rebuilt
+    assert json.loads(json_path.read_text(encoding="utf-8"))["timeline"] == "source"
+
+
 # ── graceful None on no-frames AND run_cmd failure (brief still builds) ───────
 
 


### PR DESCRIPTION
## What

PR-STORY from the storyboard/inspect plan (learn.md Phase 2). Contact-sheet "visual maps" that let the writing agent orient by **scanning one image** instead of opening dozens of frames. Generated entirely in **video-understanding** (the only skill that owns frames + fps + the stage-cache helper); reuses already-extracted frames, never re-extracts. **Advisory: every path degrades to None + log, never blocks the pipeline.**

- **`storyboard.py`** — `build_source_storyboard` (scene-anchored tiles over the SOURCE timeline) + `build_edited_storyboard` (one row per kept clip over the cut OUTPUT timeline; each tile **dual-labelled** output/source time via the same forward map as `cut.py`; frame-identity deduped). Nearest-existing-frame + clamp handles fps-boundary/last-frame gaps. drawtext `mm:ss` labels attempted with a font probe; no font → sheet still produced unlabelled (`labels_burned:false`) with timestamps authoritative in the JSON sidecar.
- **`understand.py`** — source storyboard after scenes; edited storyboard in pass2 **gated on `clip_plan_validated.json` presence** (NOT `edit_mode`, which is already "cut" in pass1). Both cached with **fps + frames-manifest in the key**, so an fps-change resume invalidates and never serves stale tiles. C1 brief pointer post-processes the returned brief **file only** → brief⇄narration byte-parity untouched (md5 unchanged).
- **CONFIG** — `storyboard` / `storyboard_max_tiles`(30) / `storyboard_columns`(6) added to video-understanding's `lib.py` only (`video-cut/lib.py` proves the convention is per-skill keys, not a shared superset).

## Why

A labelled visual map fixes scan-time orientation (catching a missed 转场/反转) that pure-text briefs can't convey; complements `inspect clip-map`'s query-time lookups (PR-INSPECT).

## Tests / quality

20 storyboard tests (mock ffmpeg, no real video) incl. **fps-only cache-invalidation** (isolates the fps-in-key claim), **font-absent fallback**, and a **corrupt-cache → rebuild** regression. Understanding group 129; full suite green; ruff clean; brief⇄narration md5 identical.

Plan: ralplan consensus (Planner→Architect→Critic) → independent code-review. Review found one MAJOR (unguarded cache-hit read could raise out of the advisory path) — **fixed** + regression-tested in this branch. Advisory only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)