### PR TITLE
Fix cut-mode pass2 brief crash on mixed int/str scene_ids

### DIFF
--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -179,7 +179,7 @@ def _chunk_asr_for_writing(segments, scenes_analysis=None, min_chars=None, max_c
             "chunk_id": len(chunks),
             "start": round(float(current[0]["start"]), 2),
             "end": round(float(current[-1]["end"]), 2),
-            "scene_ids": sorted(current_scene_ids),
+            "scene_ids": sorted(current_scene_ids, key=lambda sid: (isinstance(sid, str), sid)),
             "char_count": current_units,
             "text": " ".join(piece["text"] for piece in current).strip(),
             "segments": current,

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -179,7 +179,7 @@ def _chunk_asr_for_writing(segments, scenes_analysis=None, min_chars=None, max_c
             "chunk_id": len(chunks),
             "start": round(float(current[0]["start"]), 2),
             "end": round(float(current[-1]["end"]), 2),
-            "scene_ids": sorted(current_scene_ids),
+            "scene_ids": sorted(current_scene_ids, key=lambda sid: (isinstance(sid, str), sid)),
             "char_count": current_units,
             "text": " ".join(piece["text"] for piece in current).strip(),
             "segments": current,

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -37,6 +37,20 @@ def test_brief_noop_without_consolidation(tmp_path):
     assert (tmp_path / "timeline_fusion.json").exists()
 
 
+def test_chunk_asr_tolerates_mixed_int_str_scene_ids():
+    """Regression (cut-mode pass2): _remap_brief_evidence_to_output_timeline gives a SPLIT
+    scene a str id like '5.0' while unsplit scenes keep int ids. A chunk spanning both must
+    not crash sorted(current_scene_ids) with 'int < str'."""
+    scenes = [
+        {"scene_id": 5, "start": 0.0, "end": 3.0, "description": "a"},
+        {"scene_id": "5.0", "start": 3.0, "end": 6.0, "description": "b"},
+    ]
+    asr = [{"start": 1.0, "end": 5.0, "text": "一句横跨两个场景的较长原声对白内容。"}]
+    chunks = _chunk_asr_for_writing(asr, scenes)  # must not raise TypeError
+    ids = chunks[0]["scene_ids"]
+    assert 5 in ids and "5.0" in ids  # both id types survive the type-safe sort
+
+
 def test_optional_stage_warnings_surface_failed_overview_and_consolidation(tmp_path):
     (tmp_path / "mimo_video_overview.status.json").write_text(json.dumps({
         "stage": "mimo_video_overview",


### PR DESCRIPTION
## What

Found by a live cut-mode demo (盘龙 S1E1). In cut mode, pass-2 brief building crashed before the narration pause:

```
File brief.py:182 in flush
    "scene_ids": sorted(current_scene_ids),
TypeError: '<' not supported between instances of 'int' and 'str'
```

`_remap_brief_evidence_to_output_timeline` gives a **split** scene a string id (`f"{scene_id}.{part}"`, e.g. `"5.0"`) while unsplit scenes keep their `int` id — so `current_scene_ids` holds both types and `sorted()` dies. Pass-1 never hits it (no remap path).

## Fix

Type-safe sort key (`key=lambda sid: (isinstance(sid, str), sid)` — ints first, then split-part strings), applied **identically to the byte-identical `brief.py` ⇄ `narration.py` twins** (md5 stays in lockstep; the parity guard enforces it). Plus a regression test that feeds a chunk spanning an int scene and a `"5.0"` split scene.

## Tests
Full suite green (understanding 110 incl. the new `test_chunk_asr_tolerates_mixed_int_str_scene_ids`); brief⇄narration md5 unchanged; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)