### PR TITLE
review.py: auto-detect cut mode so manual review grounds on the output timeline

### DIFF
--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -123,9 +123,10 @@ def _run_narration_review(work_dir, args, *, timeline="source"):
         return False
     try:
         _clear_narration_review_artifacts(work_dir)
-        rargs = ["--work-dir", work_dir]
-        if timeline != "source":
-            rargs += ["--timeline", timeline]
+        # Always pin the grounding timeline explicitly so the orchestrated review never falls
+        # through to review.py's auto-detect (which could flip on stale cut artifacts left in a
+        # reused full-mode work_dir).
+        rargs = ["--work-dir", work_dir, "--timeline", timeline]
         _run("video-script", "review.py", *rargs)
     except SystemExit as exc:
         if strict:

--- a/skills/video-script/SKILL.md
+++ b/skills/video-script/SKILL.md
@@ -64,7 +64,7 @@ conservative auto-ASR mapping. See the brief's `原声留白字幕` section.
 
 A separate **quality** pass (LLM-as-judge), distinct from the mechanical lint below. Needs the chat API key (same as VLM).
 
-1. Run: `python3 scripts/review.py --work-dir <work_dir>`
+1. Run: `python3 scripts/review.py --work-dir <work_dir>` (auto-detects cut mode and grounds against the OUTPUT timeline when a validated cut is present; pass `--timeline source` to force source grounding)
 2. Open `narration_review.md`. For every `error` finding (ESPECIALLY `category=hallucination` — a claim
    not grounded in the visual/ASR evidence), revise `narration.json` and re-run review until either:
    - (a) verdict == `OK` with zero `error` findings, OR

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -453,12 +453,31 @@ def review_narration(work_dir, *, timeline="source"):
 
 def _auto_timeline(work_dir):
     """Default the grounding timeline so a manual `review.py --work-dir` matches what the
-    orchestrator does: cut_output when this is a validated cut (clip_plan_validated.json +
-    edited_source.mp4 both present), else source. Without this, reviewing a cut narration on
-    the default 'source' timeline compares OUTPUT-time narration against SOURCE-time evidence
-    and floods false-positive 'hallucination' findings."""
+    orchestrator does: cut_output when narration.json is in the cut OUTPUT timeline, else
+    source. Without this, reviewing a cut narration on the default 'source' timeline compares
+    OUTPUT-time narration against SOURCE-time evidence and floods false-positive 'hallucination'
+    findings (and the inverse flood for a legacy source-time narration mis-read as cut_output).
+
+    Detection is authoritative-first: the orchestrator records the run's edit_mode in
+    recap_run_manifest.json. In orchestrated cut mode narration.json is OUTPUT time; in full
+    mode it is SOURCE time. Trusting edit_mode is correct even when stale cut artifacts from a
+    prior run linger in a reused work_dir. Only when no manifest is present (standalone review
+    or a hand-built work_dir) do we fall back to artifact sniffing — and even then the legacy
+    direct video-cut single-pass path writes a SOURCE-time narration.json alongside a separate
+    output-time narration_mapped.json, so its presence pins us back to source."""
     work_dir = Path(work_dir)
-    if (work_dir / "clip_plan_validated.json").exists() and (work_dir / "edited_source.mp4").exists():
+    manifest = work_dir / "recap_run_manifest.json"
+    if manifest.exists():
+        try:
+            mode = json.loads(manifest.read_text(encoding="utf-8")).get("settings", {}).get("edit_mode")
+        except (ValueError, OSError):
+            mode = None
+        if mode == "cut":
+            return "cut_output"
+        if mode:  # "full" or any non-cut mode → narration.json is source time
+            return "source"
+    has_cut = (work_dir / "clip_plan_validated.json").exists() and (work_dir / "edited_source.mp4").exists()
+    if has_cut and not (work_dir / "narration_mapped.json").exists():
         return "cut_output"
     return "source"
 

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -451,13 +451,30 @@ def review_narration(work_dir, *, timeline="source"):
     return review
 
 
+def _auto_timeline(work_dir):
+    """Default the grounding timeline so a manual `review.py --work-dir` matches what the
+    orchestrator does: cut_output when this is a validated cut (clip_plan_validated.json +
+    edited_source.mp4 both present), else source. Without this, reviewing a cut narration on
+    the default 'source' timeline compares OUTPUT-time narration against SOURCE-time evidence
+    and floods false-positive 'hallucination' findings."""
+    work_dir = Path(work_dir)
+    if (work_dir / "clip_plan_validated.json").exists() and (work_dir / "edited_source.mp4").exists():
+        return "cut_output"
+    return "source"
+
+
 def main():
     ap = argparse.ArgumentParser(description="Review an agent-written narration.json for quality (LLM-as-judge).")
     ap.add_argument("--work-dir", required=True)
-    ap.add_argument("--timeline", choices=["source", "cut_output"], default="source",
-                    help="grounding timeline for narration.json; cut_output remaps source VLM/ASR via clip_plan_validated.json")
+    ap.add_argument("--timeline", choices=["source", "cut_output"], default=None,
+                    help="grounding timeline for narration.json; DEFAULT auto-detects cut_output when a "
+                         "validated cut (clip_plan_validated.json + edited_source.mp4) is present, else source. "
+                         "cut_output remaps source VLM/ASR to the cut output timeline via clip_plan_validated.json")
     args = ap.parse_args()
-    review = review_narration(args.work_dir, timeline=args.timeline)
+    timeline = args.timeline or _auto_timeline(args.work_dir)
+    if args.timeline is None and timeline != "source":
+        log(f"评审 grounding 时间轴自动判定为 {timeline}（检测到已校验的剪辑产物）")
+    review = review_narration(args.work_dir, timeline=timeline)
     print(json.dumps({
         "status": "reviewed",
         "verdict": review["verdict"],

--- a/tests/script/test_review.py
+++ b/tests/script/test_review.py
@@ -132,6 +132,32 @@ def test_auto_timeline_detects_validated_cut(tmp_path):
     assert review._auto_timeline(tmp_path) == "cut_output"
 
 
+def _write_manifest(work_dir, edit_mode):
+    (work_dir / "recap_run_manifest.json").write_text(
+        json.dumps({"settings": {"edit_mode": edit_mode}}, ensure_ascii=False), encoding="utf-8")
+
+
+def test_auto_timeline_legacy_single_pass_stays_source(tmp_path):
+    """The legacy direct video-cut single-pass path writes a SOURCE-time narration.json next to
+    an output-time narration_mapped.json. The cut artifacts are present but narration.json is NOT
+    output time, so auto-detect must stay on source (else it inverts the review)."""
+    (tmp_path / "clip_plan_validated.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "edited_source.mp4").write_bytes(b"")
+    (tmp_path / "narration_mapped.json").write_text("[]", encoding="utf-8")
+    assert review._auto_timeline(tmp_path) == "source"
+
+
+def test_auto_timeline_trusts_manifest_edit_mode(tmp_path):
+    """recap_run_manifest.json is authoritative: full mode stays source even with stale cut
+    artifacts in a reused work_dir, and cut mode selects cut_output."""
+    (tmp_path / "clip_plan_validated.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "edited_source.mp4").write_bytes(b"")
+    _write_manifest(tmp_path, "full")
+    assert review._auto_timeline(tmp_path) == "source"  # stale cut artifacts must not flip it
+    _write_manifest(tmp_path, "cut")
+    assert review._auto_timeline(tmp_path) == "cut_output"
+
+
 def test_cut_output_review_remaps_grounding_to_output_timeline():
     spans = [{"source_start": 10.0, "source_end": 20.0, "output_start": 0.0, "output_end": 10.0}]
     vlm, asr = review.remap_grounding_to_output_timeline(

--- a/tests/script/test_review.py
+++ b/tests/script/test_review.py
@@ -122,6 +122,16 @@ def test_review_scene_grounding_tolerates_non_numeric_frame_fact_keys():
     assert "非数字锚点" in content
     assert "数字锚点" in content
 
+def test_auto_timeline_detects_validated_cut(tmp_path):
+    """A bare work_dir reviews on the source timeline; a validated cut (clip_plan_validated.json
+    + edited_source.mp4) auto-selects cut_output so manual review matches the orchestrator."""
+    assert review._auto_timeline(tmp_path) == "source"
+    (tmp_path / "clip_plan_validated.json").write_text("{}", encoding="utf-8")
+    assert review._auto_timeline(tmp_path) == "source"  # plan alone is not enough
+    (tmp_path / "edited_source.mp4").write_bytes(b"")
+    assert review._auto_timeline(tmp_path) == "cut_output"
+
+
 def test_cut_output_review_remaps_grounding_to_output_timeline():
     spans = [{"source_start": 10.0, "source_end": 20.0, "output_start": 0.0, "output_end": 10.0}]
     vlm, asr = review.remap_grounding_to_output_timeline(


### PR DESCRIPTION
## What

Found by the 盘龙 S1E1 demo. `review.py` **already** remaps source VLM/ASR evidence to the cut OUTPUT timeline (`--timeline cut_output` → `remap_grounding_to_output_timeline`), and `recap.py` already passes it in cut mode. But the CLI **default was `--timeline source`**, so a manual `review.py --work-dir <wd>` — exactly what `video-script/SKILL.md` Step 2.5 documents — reviewed cut-mode narration against **source-time** evidence and flooded false-positive "hallucination" findings (it called output 0–11s "片头/credits" when clip-map proves that window is source 150–168 = the rain-bullying scene).

## Fix

Default `--timeline` to **auto**: `cut_output` when a validated cut (`clip_plan_validated.json` + `edited_source.mp4`) is present, else `source`. The orchestrator's explicit `cut_output` still wins; `--timeline source` forces the old behavior.

On the demo work_dir this drops the manual-review verdict from **4 errors (all verified false positives) to 1** (a real "轰碎 vs 裂痕" overstatement nit) — i.e. it stops the false positives while still catching real issues.

## Tests
`test_auto_timeline_detects_validated_cut` (source when bare / plan-alone, cut_output only when both cut artifacts exist); full suite green; ruff clean; SKILL.md Step 2.5 note added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)