### PR TITLE
Tighten lagging original-gap subtitle timing (coarse-ASR fallback + ASR window)

### DIFF
--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -509,6 +509,7 @@ _MIN_GAP_TO_SUBTITLE = 0.8       # shortest original-audio gap (s) worth subtitl
 _MIN_READABLE_SECONDS = 0.3      # shortest on-screen time (s) for an original-dialogue line
 _MIN_ASR_CLIP_OVERLAP = 0.05     # shortest ASR↔clip overlap (s) to keep when remapping to output
 _MAX_ORIGINAL_READ_CPS = 9.0     # densest an AUTO (uncalibrated) original line may be shown — skip cram
+_AUTO_ORIGINAL_READ_CPS = 6.0    # comfortable read rate when packing coarse-ASR lines from a gap start
 
 
 def _distribute_chunks(chunks, start, end):
@@ -880,33 +881,48 @@ def _split_sentences_keep_delims(text):
 
 
 def _fallback_gap_entries(candidates, gaps, max_chars):
-    """Coarse-ASR fallback: assign each line to the ONE gap its midpoint falls in, then clip to that
-    gap — so a long source line never shows in several gaps or where it isn't actually spoken.
-    Hardened: multi-sentence entries are pre-split (on 。！？) so each sentence is placed by its own
-    midpoint; and an over-dense line is FRONT-TRUNCATED to fit its gap at the max read rate (shown
-    truncated) instead of being dropped to blank."""
-    entries = []
+    """Coarse-ASR fallback. Each coarse-ASR line spans a whole window with no per-sentence onset, so
+    it is split into WHOLE sentences (never mid-word); each sentence is assigned to the gap its
+    char-proportional midpoint lands in, and within a gap the assigned sentences are packed
+    SEQUENTIALLY from the first one's estimated onset at a comfortable read rate — so two lines in
+    one gap never overlap or scatter to char-proportional tail slots — capped at the gap end. An
+    over-dense gap front-truncates (shown) rather than dropping to blank."""
+    # 1) split each coarse line into WHOLE sentences (never mid-word) and assign each to the gap
+    #    its char-proportional midpoint lands in (the only "which gap" signal coarse ASR gives).
+    buckets = {}  # gap_index -> [(estimated_onset, sentence_text)]
     for seg in candidates:
         for sentence in _split_sentences_keep_delims(seg["text"]) or [str(seg["text"]).strip()]:
-            # distribute the sentence's window proportionally inside the parent line's span
-            sub = _sentence_subspan(seg, sentence)
-            mid = (sub["start"] + sub["end"]) / 2.0
-            gap = next(((gs, ge) for gs, ge in gaps if gs <= mid < ge), None)
-            if gap is None:
-                continue
-            cs, ce = max(sub["start"], gap[0]), min(sub["end"], gap[1])
-            if ce - cs < _MIN_READABLE_SECONDS:
-                continue
             text = sentence.strip()
             if not text:
                 continue
-            max_len = int((ce - cs) * _MAX_ORIGINAL_READ_CPS)
-            if max_len <= 0:
+            sub = _sentence_subspan(seg, sentence)
+            mid = (sub["start"] + sub["end"]) / 2.0
+            gi = next((i for i, (gs, ge) in enumerate(gaps) if gs <= mid < ge), None)
+            if gi is None:
                 continue
-            if len(text) > max_len:
-                # over-dense: show the leading portion that fits the gap, not a blank
-                text = text[:max_len]
-            entries.extend(_bracketed_original_chunks(text, cs, ce, max_chars))
+            buckets.setdefault(gi, []).append((sub["start"], text))
+    # 2) within each gap, pack the assigned sentences SEQUENTIALLY from the gap onset at a
+    #    comfortable read rate. Anchoring to the gap onset (vs each sentence's char-proportional
+    #    tail position) stops a line heard early from being shoved to the END of its window — the
+    #    coarse-ASR lag. Full mode keeps the real ASR onset (the first sentence's own start); an
+    #    over-dense gap front-truncates (shown) rather than dropping to blank.
+    entries = []
+    for gi, items in buckets.items():
+        gs, ge = gaps[gi]
+        items.sort(key=lambda it: it[0])
+        # start at the first assigned sentence's estimated onset (clamped into the gap), then pack
+        # the rest sequentially so they never overlap or scatter to char-proportional tail slots.
+        cursor = min(ge, max(gs, min(start for start, _ in items)))
+        for _, text in items:
+            if cursor >= ge - _MIN_READABLE_SECONDS:
+                break
+            ce2 = min(ge, cursor + max(_MIN_READABLE_SECONDS, len(text) / _AUTO_ORIGINAL_READ_CPS))
+            if ce2 - cursor < _MIN_READABLE_SECONDS:
+                break
+            max_len = int((ce2 - cursor) * _MAX_ORIGINAL_READ_CPS)
+            shown = text if len(text) <= max_len else text[:max_len]
+            entries.extend(_bracketed_original_chunks(shown, cursor, ce2, max_chars))
+            cursor = ce2
     return entries
 
 

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -150,7 +150,7 @@ CONFIG = {
     # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 30.0, minimum=5.0),
+    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
     "scene_threshold": 0.1,
     "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -147,7 +147,7 @@ CONFIG = {
     "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
     "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
+    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
     "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -13,7 +13,7 @@ Defaults below are bundle-level defaults unless a note scopes them to a specific
 | VLM / chat model | `MIMO_MODEL` | `mimo-v2.5` | frame VLM + reviewer + consolidate |
 | ASR model | `MIMO_ASR_MODEL` | `mimo-v2.5-asr` | speech-to-text |
 | ASR language | `MIMO_ASR_LANGUAGE` | `auto` | `auto` / `zh` / `en` |
-| ASR window | `ASR_SEGMENT_SECONDS` | `30` | smaller → finer dialogue timestamps (stays under MiMo's 10MB base64 cap) |
+| ASR window | `ASR_SEGMENT_SECONDS` | `15` | smaller → finer dialogue timestamps (stays under MiMo's 10MB base64 cap) |
 | TTS model | `MIMO_TTS_MODEL` | `mimo-v2.5-tts` | the only TTS engine |
 | MiMo voice | `MIMO_TTS_VOICE` / `--mimo-tts-voice` | `冰糖` | |
 | Narration block coverage | `NARRATION_COVERAGE_TARGET` / `NARRATION_BLOCK_SECONDS` | `0.7` / `9.0` | current block-recap density controls; old `TARGET_SEGMENTS_PER_MINUTE` applies only to legacy single-pass cut mapping reports |

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -146,7 +146,7 @@ CONFIG = {
     "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
     "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
+    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
     "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -149,7 +149,7 @@ CONFIG = {
     # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 30.0, minimum=5.0),
+    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
     "scene_threshold": 0.1,
     "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -159,7 +159,7 @@ CONFIG = {
     # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 30.0, minimum=5.0),
+    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
     "scene_threshold": 0.1,
     "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -156,7 +156,7 @@ CONFIG = {
     "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
     "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
+    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
     "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -159,7 +159,7 @@ CONFIG = {
     # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 30.0, minimum=5.0),
+    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
     "scene_threshold": 0.1,
     "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -156,7 +156,7 @@ CONFIG = {
     "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
     "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
+    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
     "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -159,7 +159,7 @@ CONFIG = {
     # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 30.0, minimum=5.0),
+    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
     "scene_threshold": 0.1,
     "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -156,7 +156,7 @@ CONFIG = {
     "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
     "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 30s）。旧值 180s 会把 >3min
+    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
     # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
     "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),

--- a/tests/assemble/test_original_gap_subtitles.py
+++ b/tests/assemble/test_original_gap_subtitles.py
@@ -148,8 +148,8 @@ def test_generate_ass_includes_original_only_with_duration(monkeypatch, tmp_path
 
 
 def test_original_line_assigned_to_single_gap_by_midpoint(monkeypatch, tmp_path):
-    # a line whose MIDPOINT sits in a narration window is dropped by the fallback (conservative) —
-    # it is not shown in several gaps or crammed where it isn't actually spoken
+    # a WHOLE sentence whose char-proportional midpoint sits in a narration window is dropped by the
+    # fallback (conservative) — it is not shown in several gaps or crammed where it isn't spoken.
     _burn_on(monkeypatch)
     (tmp_path / "asr_result.json").write_text(
         json.dumps([{"start": 3.0, "end": 10.0, "text": "一句横跨解说块的原声"}]), encoding="utf-8")
@@ -211,17 +211,17 @@ def test_over_dense_asr_line_truncated_and_shown_in_fallback(monkeypatch, tmp_pa
     # R3: a long ASR block landing in a tiny gap is FRONT-TRUNCATED to fit the gap at the max read
     # rate and shown truncated — not dropped to blank (the old behavior was to skip it entirely).
     _burn_on(monkeypatch)
-    dense = "我既然回来了京都就是最安全的小姐遇害你和你的黑骑为什么不在京都我听命行事"  # ~34 chars, no sentence marks
+    dense = "我既然回来了京都就是最安全的小姐遇害你和你的黑骑为什么不在京都我听命行事"  # 36 chars, no sentence marks
     (tmp_path / "asr_result.json").write_text(
-        json.dumps([{"start": 2.0, "end": 4.0, "text": dense}]), encoding="utf-8")  # 34 chars in a 2s slot
-    segs = [{"actual_place_start": 6.0, "actual_place_end": 9.0, "narration": "解说"}]
-    # 2s slot * 9 ch/s = 18 chars max → shown truncated to the leading 18 chars, wrapped in 「」
+        json.dumps([{"start": 0.5, "end": 2.0, "text": dense}]), encoding="utf-8")
+    # narration fills [2, 9.7]; the dense line sits in the small [0,2] gap (~1.5s from its 0.5 onset)
+    segs = [{"actual_place_start": 2.0, "actual_place_end": 9.7, "narration": "解说"}]
     entries = assemble._original_gap_subtitle_entries(segs, tmp_path, 10.0)
     assert entries  # shown, not dropped
     joined = "".join(e["text"] for e in entries)
     assert joined.startswith("「") and joined.endswith("」")
     body = joined.strip("「」")
-    assert body and len(body) <= 18  # truncated to fit the gap at the max read rate
+    assert body and len(body) <= 14  # ~1.5s * 9 ch/s → front-truncated to fit the gap
     assert dense.startswith(body)   # it is the LEADING (front) portion of the dense line
 
 


### PR DESCRIPTION
## Problem (from the 盘龙 demo)

The 「」 original-dialogue subtitles in the original-audio gaps lagged the picture/audio. A background workflow diagnosed the root cause with a concrete trace:

- **MiMo ASR is text-only** — it returns no word/sentence timestamps (confirmed against the MiMo-V2.5-ASR repo). So `asr_result.json` is **uniform clock-grid bins** (was 30s); each bin's only timing is its window bounds.
- The assemble fallback (`_fallback_gap_entries`) placed each sentence by its **character position** inside the 30s bin, so a line heard at ~3.5s displayed at ~10.5s (**6–8s lag**), worsened by leading narrator-VO text eating the front of the bin.

## Fix (two levers)

1. **assemble** — `_fallback_gap_entries` assigns each **whole sentence** (never mid-word) to the gap its char-proportional midpoint lands in, then packs the gap's sentences **sequentially from the first onset** at a comfortable read rate, so multi-sentence gaps no longer overlap or scatter to char-proportional tail slots.
2. **ASR** — halve `asr_segment_seconds` default **30 → 15s** (env-overridable `ASR_SEGMENT_SECONDS`): roughly halves worst-case timestamp error and re-enables the silence/ASR cross-check (avg-seg gate at 45s). Trade-off: ~2× sequential MiMo ASR calls per video.

## What this does NOT fix (documented follow-ups)

Coarse ASR fundamentally can't carry real onsets, so:
- **bring-your-own subtitles** (`work_dir/user_subtitles.{srt,ass,json}`) remain the precise, zero-code path — a source-time SRT is auto-remapped onto the cut output timeline. (No ready-made 盘龙 S1E1 Chinese subtitle file exists on the CN repos — it is a 2026 licensed donghua with publisher captions on iQiyi/Tencent; the only accurate source is extracting that platform caption track.)
- **silence/VAD-aligned ASR windows** (snap each ASR cut to a detected silence) is the structural fix — deferred (effort M).

## Tests
Full suite green; the 2 gap-subtitle tests updated to the new (sequential-pack) behavior; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)