### PR TITLE
Make VLM scene analysis resumable + rate-limit resilient (long-video 429 fix)

### DIFF
--- a/skills/video-understanding/scripts/understand.py
+++ b/skills/video-understanding/scripts/understand.py
@@ -500,7 +500,7 @@ def main():
         log("VLM API 连通性预检...")
         api_call({"model": CONFIG.get("vlm_model", ""),
                   "messages": [{"role": "user", "content": "hi"}], "max_tokens": 5})
-        vlm_analysis = analyze_scenes(scenes, frames, work_dir)
+        vlm_analysis = analyze_scenes(scenes, frames, work_dir, resume=not args.force)
         _write_stage_meta(vlm_json, vlm_meta)
 
     # Step 4.1: optional MiMo scene-chunk video understanding

--- a/skills/video-understanding/scripts/vlm.py
+++ b/skills/video-understanding/scripts/vlm.py
@@ -56,7 +56,41 @@ def _max_frames_for_duration(duration):
     return max(3, min(ceiling, round(max(0.0, float(duration)) / spf)))
 
 
-def analyze_scenes(scenes, frames, work_dir):
+def _vlm_scene_cache_path(work_dir):
+    return Path(work_dir) / "vlm_scene_cache.json"
+
+
+def _load_vlm_scene_cache(work_dir):
+    """Per-scene VLM resume cache (scene_key -> analysis). Tolerant: {} if absent/corrupt."""
+    path = _vlm_scene_cache_path(work_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _flush_vlm_scene_cache(work_dir, cache):
+    """Persist the resume cache atomically (temp + rename) so an abort/crash never corrupts it."""
+    path = _vlm_scene_cache_path(work_dir)
+    try:
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(cache, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        log(f"VLM 场景缓存写入失败（忽略）: {exc}")
+
+
+def _looks_rate_limited(message):
+    """Heuristic: was a scene failure a transient rate-limit (worth a low-concurrency retry) rather
+    than a persistent error (empty response / parse failure) that re-running would not fix?"""
+    m = str(message).lower()
+    return "429" in m or "too many requests" in m or "rate limit" in m or "限流" in m
+
+
+def analyze_scenes(scenes, frames, work_dir, *, resume=True):
     """对每个场景的关键帧调用 VLM 进行视觉分析（并行）"""
     if not scenes:
         analyses = []
@@ -176,34 +210,71 @@ def analyze_scenes(scenes, frames, work_dir):
 
         return i, result
 
-    # 并行调用 VLM
-    analyses = [None] * len(scenes)
-    max_workers = min(len(scenes), CONFIG.get("vlm_workers", 4))
-    log(f"VLM 并行分析 {len(scenes)} 个场景 (workers={max_workers})...")
+    # 断点续传：逐场景持久化分析结果，避免少数场景失败（多为 429 限流）时整批画面理解全部作废。
+    cache = _load_vlm_scene_cache(work_dir) if resume else {}
+    prompt_fp = stable_hash(vlm_prompt)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(_analyze_single_scene, i, s): i for i, s in enumerate(scenes)}
+    def _scene_cache_key(i, scene):
+        return "|".join(str(x) for x in (
+            i, round(float(scene["start"]), 3), round(float(scene["end"]), 3),
+            CONFIG.get("vlm_model"), prompt_fp, CONFIG.get("vlm_max_tokens"),
+            CONFIG.get("vlm_seconds_per_frame"), CONFIG.get("vlm_max_frames"),
+            round(float(fps), 3),
+        ))
+
+    analyses = [None] * len(scenes)
+    todo = []
+    for i, s in enumerate(scenes):
+        cached = cache.get(_scene_cache_key(i, s))
+        analyses[i] = cached if isinstance(cached, dict) else None
+        if analyses[i] is None:
+            todo.append(i)
+    if todo and len(todo) < len(scenes):
+        log(f"VLM 复用 {len(scenes) - len(todo)} 个已缓存场景，待分析 {len(todo)} 个")
+
+    def _run_pass(indices, workers):
+        """分析给定场景索引；每完成一个就把结果写入续传缓存（在主线程，无需加锁）。返回 (i, err) 失败列表。"""
+        if not indices:
+            return []
         failures = []
-        for future in as_completed(futures):
-            try:
-                idx, result = future.result()
-                analyses[idx] = result
-            except Exception as e:
+        with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
+            futures = {executor.submit(_analyze_single_scene, i, scenes[i]): i for i in indices}
+            for future in as_completed(futures):
                 i = futures[future]
-                log(f"VLM 场景 {i+1} 分析失败: {e}")
-                failures.append((i, str(e)))
+                try:
+                    idx, result = future.result()
+                    analyses[idx] = result
+                    cache[_scene_cache_key(idx, scenes[idx])] = result
+                    _flush_vlm_scene_cache(work_dir, cache)  # 持久化进度，崩溃/中止后可续传
+                except Exception as e:  # noqa: BLE001 - 单个场景失败不能拖垮其余已完成的
+                    log(f"VLM 场景 {i+1} 分析失败: {e}")
+                    failures.append((i, str(e)))
+        return failures
+
+    base_workers = min(len(todo) or 1, int(CONFIG.get("vlm_workers", 4) or 4))
+    log(f"VLM 并行分析 {len(todo)} 个场景 (workers={base_workers})...")
+    failures = _run_pass(todo, base_workers)
+    if failures:
+        # 限流(429)多是并发瞬时拥塞，降并发重试一轮（已成功的从缓存跳过）；其它错误（空响应/解析失败）
+        # 重试无益，直接保留为失败，不浪费一轮调用。
+        rate_limited = [i for i, msg in failures if _looks_rate_limited(msg)]
+        persistent = [(i, msg) for i, msg in failures if not _looks_rate_limited(msg)]
+        if rate_limited:
+            retry_workers = max(1, base_workers // 4)
+            log(f"VLM {len(rate_limited)} 个场景疑似限流(429)，降并发到 {retry_workers} 重试...")
+            persistent += _run_pass(rate_limited, retry_workers)
+        failures = persistent
 
     if failures:
         sample = "; ".join(f"场景 {i+1}: {msg}" for i, msg in failures[:3])
         raise RuntimeError(
-            f"VLM 分析失败 {len(failures)}/{len(scenes)} 个场景，已中止以避免缓存不完整画面理解。"
-            f"示例: {sample}"
+            f"VLM 分析失败 {len(failures)}/{len(scenes)} 个场景。其余已缓存到 vlm_scene_cache.json，"
+            f"重跑可断点续传（只重试失败场景）。示例: {sample}"
         )
 
-    # 保存
     vlm_file = work_dir / "vlm_analysis.json"
     vlm_file.write_text(json.dumps(analyses, ensure_ascii=False, indent=2), encoding="utf-8")
-
+    _vlm_scene_cache_path(work_dir).unlink(missing_ok=True)  # 完整理解已生成，续传缓存可清理
     log(f"VLM 分析完成: {len(analyses)} 个场景")
     return analyses
 

--- a/skills/video-understanding/scripts/vlm.py
+++ b/skills/video-understanding/scripts/vlm.py
@@ -215,11 +215,18 @@ def analyze_scenes(scenes, frames, work_dir, *, resume=True):
     prompt_fp = stable_hash(vlm_prompt)
 
     def _scene_cache_key(i, scene):
+        # Must invalidate on the SAME output-affecting settings the outer stage gate tracks
+        # (understand.py:_vlm_cache_payload). prompt_fp already covers vlm_prompt + context_info
+        # (which folds in background_research). The three below change the request/endpoint but
+        # are NOT in vlm_prompt, so they must be keyed explicitly — otherwise a partial-failure
+        # cache reused after flipping e.g. mimo_disable_thinking yields a stale/mixed analysis.
         return "|".join(str(x) for x in (
             i, round(float(scene["start"]), 3), round(float(scene["end"]), 3),
             CONFIG.get("vlm_model"), prompt_fp, CONFIG.get("vlm_max_tokens"),
             CONFIG.get("vlm_seconds_per_frame"), CONFIG.get("vlm_max_frames"),
             round(float(fps), 3),
+            CONFIG.get("api_url"), CONFIG.get("mimo_disable_thinking", True),
+            CONFIG.get("mimo_media_resolution"),
         ))
 
     analyses = [None] * len(scenes)

--- a/tests/understanding/test_io_fixes.py
+++ b/tests/understanding/test_io_fixes.py
@@ -192,7 +192,7 @@ def test_understand_reextracts_frames_when_source_video_changes(monkeypatch, tmp
     monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
     monkeypatch.setattr(
         "understand.analyze_scenes",
-        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+        lambda scenes, frames, work_dir, **kwargs: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
     )
     monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
     monkeypatch.setattr(sys, "argv", ["understand.py", str(new_video), "--work-dir", str(tmp_path), "--skip-asr"])
@@ -233,7 +233,7 @@ def test_understand_removes_stale_mimo_overview_before_failed_recompute(monkeypa
     monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
     monkeypatch.setattr(
         "understand.analyze_scenes",
-        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+        lambda scenes, frames, work_dir, **kwargs: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
     )
     monkeypatch.setattr("understand.analyze_video_overview", fail_overview)
     monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
@@ -274,7 +274,7 @@ def test_understand_writes_overview_status_when_key_missing(monkeypatch, tmp_pat
     monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
     monkeypatch.setattr(
         "understand.analyze_scenes",
-        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+        lambda scenes, frames, work_dir, **kwargs: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
     )
     monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
     monkeypatch.setattr(sys, "argv", ["understand.py", str(video), "--work-dir", str(tmp_path), "--skip-asr", "--no-consolidate"])
@@ -312,7 +312,7 @@ def test_understand_writes_failed_consolidation_status(monkeypatch, tmp_path):
     monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
     monkeypatch.setattr(
         "understand.analyze_scenes",
-        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+        lambda scenes, frames, work_dir, **kwargs: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
     )
     monkeypatch.setattr("understand.build_agent_brief", lambda *a, **k: tmp_path / "agent_narration_brief.md")
     monkeypatch.setattr("consolidate.consolidate", fake_consolidate, raising=False)
@@ -482,7 +482,7 @@ def test_understand_recomputes_vlm_when_context_changes(monkeypatch, tmp_path):
     video.write_bytes(b"video")
     calls = []
 
-    def fake_vlm(scenes, frames, work_dir):
+    def fake_vlm(scenes, frames, work_dir, **kwargs):
         calls.append(understand.CONFIG.get("context_info", ""))
         result = [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": calls[-1]}]
         (Path(work_dir) / "vlm_analysis.json").write_text(json.dumps(result), encoding="utf-8")
@@ -506,7 +506,7 @@ def test_understand_recomputes_vlm_when_api_endpoint_changes(monkeypatch, tmp_pa
     video.write_bytes(b"video")
     calls = []
 
-    def fake_vlm(scenes, frames, work_dir):
+    def fake_vlm(scenes, frames, work_dir, **kwargs):
         calls.append(understand.CONFIG.get("api_url", ""))
         result = [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": calls[-1]}]
         (Path(work_dir) / "vlm_analysis.json").write_text(json.dumps(result), encoding="utf-8")
@@ -530,7 +530,7 @@ def test_understand_recomputes_vlm_when_thinking_behavior_changes(monkeypatch, t
     video.write_bytes(b"video")
     calls = []
 
-    def fake_vlm(scenes, frames, work_dir):
+    def fake_vlm(scenes, frames, work_dir, **kwargs):
         calls.append(understand.CONFIG.get("mimo_disable_thinking"))
         result = [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": str(calls[-1])}]
         (Path(work_dir) / "vlm_analysis.json").write_text(json.dumps(result), encoding="utf-8")
@@ -592,7 +592,7 @@ def test_understand_omits_stale_mimo_overview_when_overview_disabled(monkeypatch
     monkeypatch.setattr("understand.detect_silence_periods", lambda *a, **k: [])
     monkeypatch.setattr(
         "understand.analyze_scenes",
-        lambda scenes, frames, work_dir: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
+        lambda scenes, frames, work_dir, **kwargs: [{"scene_id": 0, "start": 0.0, "end": 10.0, "description": "fresh"}],
     )
     monkeypatch.setattr(sys, "argv", ["understand.py", str(video), "--work-dir", str(tmp_path), "--skip-asr"])
 

--- a/tests/understanding/test_vlm_fixes.py
+++ b/tests/understanding/test_vlm_fixes.py
@@ -115,6 +115,37 @@ def test_vlm_resume_cache_persists_on_failure_and_resumes(monkeypatch, tmp_path)
     assert not (tmp_path / "vlm_scene_cache.json").exists()  # resume cache cleaned on full success
 
 
+def test_vlm_resume_cache_invalidates_on_request_setting_flip(monkeypatch, tmp_path):
+    """A leftover partial cache must NOT be reused after an output-affecting request setting
+    (mimo_disable_thinking) changes — otherwise the succeeded scenes would carry the OLD setting
+    while only the failed scene gets the NEW one, yielding a silent mixed/stale analysis."""
+    scenes, frames = _three_scene_setup(monkeypatch, tmp_path, workers=1)
+    monkeypatch.setitem(CONFIG, "mimo_disable_thinking", True)
+    state = {"fail_mid": True, "calls": 0}
+
+    def fake_api_call(payload):
+        state["calls"] += 1
+        text = payload["messages"][0]["content"][-1]["text"]
+        if state["fail_mid"] and "2.0s" in text:   # scene index 1 fails → leaves a 2-scene cache
+            raise RuntimeError("HTTP 429 — Too many requests")
+        return {"choices": [{"message": {"content": "【描述】测试画面"}}]}
+
+    monkeypatch.setattr("vlm.api_call", fake_api_call)
+
+    with pytest.raises(RuntimeError, match="断点续传"):
+        analyze_scenes(scenes, frames, tmp_path)
+    assert len(json.loads((tmp_path / "vlm_scene_cache.json").read_text())) == 2
+
+    # Flip the request setting and re-run with a non-failing API. The per-scene key now differs,
+    # so NONE of the 2 cached scenes are reused — all 3 are re-analyzed under the new setting.
+    state["fail_mid"] = False
+    monkeypatch.setitem(CONFIG, "mimo_disable_thinking", False)
+    calls_before = state["calls"]
+    analyses = analyze_scenes(scenes, frames, tmp_path)
+    assert len(analyses) == 3 and all(a and a["description"] == "测试画面" for a in analyses)
+    assert state["calls"] - calls_before == 3   # all re-analyzed; no stale reuse of old-setting scenes
+
+
 def test_vlm_auto_throttle_retry_recovers_transient_429(monkeypatch, tmp_path):
     """A scene that 429s on the first pass but succeeds when retried at lower concurrency is
     recovered within ONE run — no abort. (Default 8 workers no longer dooms a long video.)"""

--- a/tests/understanding/test_vlm_fixes.py
+++ b/tests/understanding/test_vlm_fixes.py
@@ -73,6 +73,67 @@ def test_null_content_falls_back_to_reasoning(monkeypatch, tmp_path):
     assert analyses[0]["description"] == "男子拿起茶壶"
 
 
+def _three_scene_setup(monkeypatch, tmp_path, workers):
+    frames = []
+    for n in (1, 2, 3):
+        f = tmp_path / f"frame_{n:05d}.jpg"
+        f.write_bytes(b"\xff\xd8\xff\xd9")
+        frames.append(f)
+    scenes = [{"start": 0.5, "end": 1.5}, {"start": 1.5, "end": 2.5}, {"start": 2.5, "end": 3.5}]
+    monkeypatch.setitem(CONFIG, "fps", 1.0)        # frame_0000N -> t = N seconds, one frame per scene
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_workers", workers)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    return scenes, frames
+
+
+def test_vlm_resume_cache_persists_on_failure_and_resumes(monkeypatch, tmp_path):
+    """A scene that keeps failing (e.g. 429) aborts the batch, but the succeeded scenes persist to
+    vlm_scene_cache.json so a re-run RESUMES — only the failed scene is re-analyzed, not all three."""
+    scenes, frames = _three_scene_setup(monkeypatch, tmp_path, workers=1)
+    state = {"fail_mid": True, "calls": 0}
+
+    def fake_api_call(payload):
+        state["calls"] += 1
+        text = payload["messages"][0]["content"][-1]["text"]
+        if state["fail_mid"] and "2.0s" in text:   # scene index 1 (the [1.5,2.5] window)
+            raise RuntimeError("HTTP 429 — Too many requests")
+        return {"choices": [{"message": {"content": "【描述】测试画面"}}]}
+
+    monkeypatch.setattr("vlm.api_call", fake_api_call)
+
+    with pytest.raises(RuntimeError, match="断点续传"):
+        analyze_scenes(scenes, frames, tmp_path)
+    cache = json.loads((tmp_path / "vlm_scene_cache.json").read_text())
+    assert len(cache) == 2  # the two scenes that succeeded are cached for resume
+
+    state["fail_mid"] = False
+    calls_before = state["calls"]
+    analyses = analyze_scenes(scenes, frames, tmp_path)
+    assert len(analyses) == 3 and all(a and a["description"] == "测试画面" for a in analyses)
+    assert state["calls"] - calls_before == 1   # only the previously-failed scene re-analyzed
+    assert not (tmp_path / "vlm_scene_cache.json").exists()  # resume cache cleaned on full success
+
+
+def test_vlm_auto_throttle_retry_recovers_transient_429(monkeypatch, tmp_path):
+    """A scene that 429s on the first pass but succeeds when retried at lower concurrency is
+    recovered within ONE run — no abort. (Default 8 workers no longer dooms a long video.)"""
+    scenes, frames = _three_scene_setup(monkeypatch, tmp_path, workers=4)
+    fired = {"once": False}
+
+    def fake_api_call(payload):
+        text = payload["messages"][0]["content"][-1]["text"]
+        if "2.0s" in text and not fired["once"]:
+            fired["once"] = True
+            raise RuntimeError("HTTP 429 — Too many requests")
+        return {"choices": [{"message": {"content": "【描述】测试画面"}}]}
+
+    monkeypatch.setattr("vlm.api_call", fake_api_call)
+    analyses = analyze_scenes(scenes, frames, tmp_path)  # must NOT raise
+    assert len(analyses) == 3 and all(a["description"] == "测试画面" for a in analyses)
+    assert not (tmp_path / "vlm_scene_cache.json").exists()
+
+
 def test_null_content_and_null_reasoning_coerce_to_empty_then_retry(monkeypatch, tmp_path):
     """content=null AND reasoning_content=null must coerce to "" so the empty-retry loop runs."""
     frame = _make_frame(tmp_path)

--- a/tests/understanding/test_vlm_fixes.py
+++ b/tests/understanding/test_vlm_fixes.py
@@ -104,7 +104,7 @@ def test_vlm_resume_cache_persists_on_failure_and_resumes(monkeypatch, tmp_path)
 
     with pytest.raises(RuntimeError, match="断点续传"):
         analyze_scenes(scenes, frames, tmp_path)
-    cache = json.loads((tmp_path / "vlm_scene_cache.json").read_text())
+    cache = json.loads((tmp_path / "vlm_scene_cache.json").read_text(encoding="utf-8"))
     assert len(cache) == 2  # the two scenes that succeeded are cached for resume
 
     state["fail_mid"] = False
@@ -134,7 +134,7 @@ def test_vlm_resume_cache_invalidates_on_request_setting_flip(monkeypatch, tmp_p
 
     with pytest.raises(RuntimeError, match="断点续传"):
         analyze_scenes(scenes, frames, tmp_path)
-    assert len(json.loads((tmp_path / "vlm_scene_cache.json").read_text())) == 2
+    assert len(json.loads((tmp_path / "vlm_scene_cache.json").read_text(encoding="utf-8"))) == 2
 
     # Flip the request setting and re-run with a non-failing API. The per-scene key now differs,
     # so NONE of the 2 cached scenes are reused — all 3 are re-analyzed under the new setting.


### PR DESCRIPTION
## Problem (from the 70-min Long Vacation demo)

A 70-min episode → **268 scenes** × default **8 concurrent VLM workers** burst MiMo's shared token-plan cluster → **HTTP 429**. 2 scenes failed after retries, and `analyze_scenes` **aborted the entire understanding** — with **no per-scene cache**, a re-run redid all 268. I had to hand-set `VLM_WORKERS=3`.

## Fix

- **Resumable per-scene cache** (`vlm_scene_cache.json`, atomic temp+rename writes): each scene's analysis is persisted as it completes. A partial failure no longer discards the rest; a re-run reuses cached scenes and only re-analyzes the missing/failed ones. Keyed on scene span + frames(fps) + prompt + model + vlm config; cleaned up on full success; `resume = not --force`.
- **Auto-throttle retry**: scenes failing with a **rate-limit (429)** error are retried once at **¼ concurrency** (successes skipped via the cache). **Persistent** errors (empty response / parse failure) are NOT retried — no wasted calls. So the default 8 workers no longer dooms a long video.

## Tests
2 new (`test_vlm_resume_cache_persists_on_failure_and_resumes`, `test_vlm_auto_throttle_retry_recovers_transient_429`); existing `analyze_scenes` mocks updated for the new `resume` kwarg. Full suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)