### PR TITLE
Snap clip boundaries off original shot-changes (kill edit-point flicker)

### DIFF
--- a/skills/video-cut/SKILL.md
+++ b/skills/video-cut/SKILL.md
@@ -13,7 +13,7 @@ description: >
 ## What this does
 
 Takes an agent-authored **clip plan** (which source ranges to keep, in order) and:
-1. Validates + enriches it into `clip_plan_validated.json` (clip ids, source/output times, total duration, overlap checks).
+1. Validates + enriches it into `clip_plan_validated.json` (clip ids, source/output times, total duration, overlap checks). Boundaries are then snapped to natural pauses (`SNAP_CLIP_LINE_END`) and nudged clear of the original footage's hard cuts (`SCENE_CUT_SNAP`, see below).
 2. Concatenates those source ranges into a single `edited_source.mp4`.
 3. **(Orchestrated path — default)** Stops here; the agent writes `narration.json` against the output timeline (0 .. total seconds). Invoked by `recap.py` with `--no-narration-map`.
 4. **(Legacy single-pass path)** When invoked directly **without** `--no-narration-map`: maps narration written in original-video time onto the cut output timeline → `narration_mapped.json`.
@@ -55,6 +55,7 @@ In the orchestrated flow, downstream (voiceover + assemble) treat `edited_source
 - In the legacy single-pass path, timestamps in `clip_plan.json` and `narration.json` are **original-video time**; this tool does the source→output remap. In the orchestrated path, `narration.json` is written by the agent directly in **output-timeline time** — no remap is performed.
 - Overlapping/duplicate source ranges raise an error unless `--allow-overlap` is set; with overlap, narration should set `source_clip_id`.
 - Segments that fall outside every kept clip are dropped (logged).
+- **Shot-change-aware boundaries (`SCENE_CUT_SNAP`, default on).** A clip boundary that lands a few tenths of a second from a hard cut in the *original* footage shows a brief sliver of the adjacent shot that then cuts again — a visible 闪烁/flicker at the edit point. After the natural-pause snap, each `source_start` is moved forward onto, and each `source_end` back onto, any original shot-change within `SCENE_CUT_SNAP_MARGIN` (default `0.5`s; detected with ffmpeg's scene metric at `SCENE_CUT_DETECT_THRESHOLD`, default `0.4`). Boundaries already on a cut, or with no nearby cut, are untouched; snaps that would shrink a clip below ~0.5s are skipped. Set `SCENE_CUT_SNAP=0` to disable.
 
 ## What this skill does NOT do
 - Does NOT re-transcribe or re-analyze the video.

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import re
+import subprocess
 from pathlib import Path
 
 from lib import CONFIG, get_video_duration, log, run_cmd
@@ -309,6 +310,92 @@ def snap_clip_ends_to_lines(plan, silence_periods, video_duration, max_extend):
     return result
 
 
+def _detect_shot_changes(video, win_start, win_end, threshold, lead=0.25):
+    """Absolute source-time hard cuts inside [win_start, win_end] via ffmpeg's scene metric.
+
+    Input-seek to a little before the window: the rebased output PTS restarts at ~0 at the seek
+    target, so `seek + pts_time` recovers absolute source time. The `lead` keeps the seek/keyframe
+    settling artifact frame outside [win_start, win_end] so it is filtered out, not mistaken for a
+    cut. Returns [] on any ffmpeg trouble (advisory pass must never block the cut).
+    """
+    win_start = max(0.0, float(win_start))
+    win_end = max(win_start, float(win_end))
+    if win_end - win_start < 1e-3:
+        return []
+    seek = max(0.0, win_start - lead)
+    dur = (win_end - seek) + 0.1
+    cmd = ["ffmpeg", "-hide_banner", "-nostats", "-ss", f"{seek:.3f}", "-i", str(video),
+           "-t", f"{dur:.3f}", "-an", "-sn",
+           "-filter:v", f"select='gt(scene,{threshold})',showinfo", "-f", "null", "-"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except (OSError, ValueError):
+        return []
+    changes = []
+    for m in re.finditer(r"pts_time:([0-9.]+)", proc.stderr or ""):
+        t = seek + float(m.group(1))
+        if win_start <= t <= win_end:
+            changes.append(round(t, 3))
+    return sorted(set(changes))
+
+
+def snap_clips_off_shot_changes(plan, video, video_duration, margin, threshold, min_keep=0.5):
+    """Nudge each clip's boundaries clear of the ORIGINAL footage's hard cuts to avoid 闪烁.
+
+    A clip whose source_start sits just before a shot-change opens on a brief sliver of the old
+    shot that then hard-cuts again; one whose source_end sits just after a shot-change closes on a
+    sliver of the next shot. Both flash at the edit point. So:
+      - move source_start FORWARD onto a shot-change in (start, start+margin]  → clean open
+      - move source_end   BACK   onto a shot-change in [end-margin, end)       → clean close
+    Boundaries already on a cut, or with no nearby cut, are left untouched. Snaps that would shrink
+    a clip below `min_keep` are skipped. Recomputes the output timeline cursor-based. Advisory: any
+    detection failure leaves that boundary as-is.
+    """
+    margin = float(margin)
+    if margin <= 0 or not plan.get("clips"):
+        return plan
+    clips = [dict(c) for c in plan["clips"]]
+    n_start = n_end = 0
+    for clip in clips:
+        s = float(clip["source_start"])
+        e = float(clip["source_end"])
+        new_s, new_e = s, e
+        # Opening: a shot-change just AFTER source_start leaves an old-shot sliver before it.
+        start_changes = [c for c in _detect_shot_changes(video, s, min(e, s + margin), threshold)
+                         if c > s + 1e-3]
+        if start_changes:
+            cand = max(start_changes)          # open after the last rapid cut in the window
+            if cand < e - min_keep:
+                new_s = round(cand, 3)
+        # Closing: a shot-change just BEFORE source_end leaves a next-shot sliver after it.
+        end_changes = [c for c in _detect_shot_changes(video, max(new_s, e - margin), e, threshold)
+                       if c < e - 1e-3]
+        if end_changes:
+            cand = min(end_changes)            # close before the first rapid cut in the window
+            if cand > new_s + min_keep:
+                new_e = round(cand, 3)
+        n_start += new_s != s
+        n_end += new_e != e
+        clip["source_start"] = new_s
+        clip["source_end"] = new_e
+
+    # Recompute output timeline cursor-based (same cursor logic as snap_clip_ends_to_lines).
+    cursor = 0.0
+    for clip in clips:
+        duration = round(clip["source_end"] - clip["source_start"], 3)
+        clip["duration"] = duration
+        clip["output_start"] = round(cursor, 3)
+        clip["output_end"] = round(cursor + duration, 3)
+        cursor += duration
+
+    if n_start or n_end:
+        log(f"避让原片切镜头: {n_start} 个起点前移、{n_end} 个终点回收 (margin={margin}s, 阈值={threshold})")
+    result = dict(plan)
+    result["clips"] = clips
+    result["total_duration"] = round(sum(c["duration"] for c in clips), 3)
+    return result
+
+
 def source_time_to_output_time(source_time, clips):
     """Map a source timestamp into the post-concat output timeline."""
     ts = float(source_time)
@@ -567,6 +654,18 @@ def main():
             silence_periods,
             video_duration,
             CONFIG.get("clip_snap_max_extend", 2.0),
+        )
+
+    # Keep boundaries off the original footage's hard cuts (avoids 闪烁 at the edit point).
+    # Runs after the line-snap so it refines the final source ranges; video-clean wins on the rare
+    # boundary that is both in a quiet window and beside a shot-change.
+    if CONFIG.get("scene_cut_snap", True):
+        validated_plan = snap_clips_off_shot_changes(
+            validated_plan,
+            args.video,
+            video_duration,
+            CONFIG.get("scene_cut_snap_margin", 0.5),
+            CONFIG.get("scene_cut_detect_threshold", 0.4),
         )
 
     if isinstance(validated_plan, dict):

--- a/skills/video-cut/scripts/lib.py
+++ b/skills/video-cut/scripts/lib.py
@@ -32,6 +32,13 @@ def env_float(name, default, min_val=None):
 CONFIG = {
     "snap_clip_line_end": env_bool("SNAP_CLIP_LINE_END", True),
     "clip_snap_max_extend": env_float("CLIP_SNAP_MAX_EXTEND", 2.0, min_val=0.0),
+    # Keep clip boundaries off the ORIGINAL footage's hard cuts: a clip that opens/closes a few
+    # tenths of a second from a source shot-change shows a brief sliver of the adjacent shot that
+    # then hard-cuts again — a visible 闪烁/flicker at the edit point. Snap source_start forward
+    # past (and source_end back before) any shot-change within the margin.
+    "scene_cut_snap": env_bool("SCENE_CUT_SNAP", True),
+    "scene_cut_snap_margin": env_float("SCENE_CUT_SNAP_MARGIN", 0.5, min_val=0.0),    # 边界±此秒内有切镜头才避让
+    "scene_cut_detect_threshold": env_float("SCENE_CUT_DETECT_THRESHOLD", 0.4, min_val=0.0),  # ffmpeg scene 分数阈值(硬切)
 }
 
 

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -28,6 +28,7 @@ Defaults below are bundle-level defaults unless a note scopes them to a specific
 | Edit mode | `EDIT_MODE` / `--edit-mode` | `full` | `full` or `cut` |
 | Cut target | `TARGET_DURATION` / `--target-duration` | — | e.g. `10m` (cut mode) |
 | Scene threshold | `--scene-threshold` | `0.1` | scene-cut sensitivity |
+| Shot-change-aware cut | `SCENE_CUT_SNAP` / `SCENE_CUT_SNAP_MARGIN` / `SCENE_CUT_DETECT_THRESHOLD` | on / `0.5` / `0.4` | cut mode: nudge each clip boundary off the original footage's hard cuts so the edit point doesn't flash a sliver of the adjacent shot (闪烁). source_start moves forward onto / source_end back onto any shot-change within the margin; boundaries already on a cut, or that would shrink a clip below ~0.5s, are left as-is. Set `SCENE_CUT_SNAP=0` to disable |
 | VLM workers | `VLM_WORKERS` | `8` | lower to 1 if a proxy/WAF rate-limits |
 | Subtitle size | `SUBTITLE_FONT_SIZE` / `SUBTITLE_MARGIN_V` | `42` / `48` | look & placement |
 | 整理 / index | `--no-consolidate` / `--consolidate-asr` | on | build the understanding index (and optionally clean ASR); use `--no-consolidate` to skip |

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -1,9 +1,11 @@
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-cut' / 'scripts'))
+import types
 import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
-from cut import build_edited_source_video, lint_mapped_narration, map_narration_to_clips, normalize_clip_plan, parse_duration_seconds, snap_clip_ends_to_lines, source_time_to_output_time
+import cut
+from cut import build_edited_source_video, lint_mapped_narration, map_narration_to_clips, normalize_clip_plan, parse_duration_seconds, snap_clip_ends_to_lines, snap_clips_off_shot_changes, source_time_to_output_time
 
 
 def test_lint_mapped_narration_flags_dropped_and_sparse():
@@ -473,3 +475,74 @@ def test_snap_skips_malformed_silence_rows():
     plan = _make_plan([(0.0, 10.0)])
     snapped = snap_clip_ends_to_lines(plan, silence, video_duration=100.0, max_extend=5.0)
     assert snapped["clips"][0]["source_end"] == 12.0  # the well-formed row still snaps
+
+
+# ---------------------------------------------------------------------------
+# snap_clips_off_shot_changes tests (avoid 闪烁 at edit points)
+# ---------------------------------------------------------------------------
+
+def _fake_detector(changes):
+    """Stand in for _detect_shot_changes: return the seeded cuts that fall in the asked window."""
+    def detect(video, win_start, win_end, threshold, lead=0.25):
+        return sorted(c for c in changes if win_start <= c <= win_end)
+    return detect
+
+
+def test_scene_cut_snap_moves_start_forward_past_early_change(monkeypatch):
+    """A shot-change just after source_start (old-shot sliver) pushes source_start onto the cut."""
+    monkeypatch.setattr(cut, "_detect_shot_changes", _fake_detector([10.3]))
+    plan = _make_plan([(10.0, 30.0)])
+    snapped = snap_clips_off_shot_changes(plan, "v.mp4", video_duration=100.0, margin=0.5, threshold=0.4)
+    c = snapped["clips"][0]
+    assert c["source_start"] == 10.3 and c["source_end"] == 30.0
+    assert c["duration"] == 19.7
+    assert c["output_start"] == 0.0 and c["output_end"] == 19.7
+
+
+def test_scene_cut_snap_pulls_end_back_before_late_change(monkeypatch):
+    """A shot-change just before source_end (next-shot sliver) pulls source_end onto the cut."""
+    monkeypatch.setattr(cut, "_detect_shot_changes", _fake_detector([29.7]))
+    plan = _make_plan([(10.0, 30.0)])
+    snapped = snap_clips_off_shot_changes(plan, "v.mp4", video_duration=100.0, margin=0.5, threshold=0.4)
+    c = snapped["clips"][0]
+    assert c["source_start"] == 10.0 and c["source_end"] == 29.7
+
+
+def test_scene_cut_snap_leaves_clean_boundaries_untouched(monkeypatch):
+    """A cut in the middle of the clip (far from both boundaries) triggers no snap."""
+    monkeypatch.setattr(cut, "_detect_shot_changes", _fake_detector([20.0]))
+    plan = _make_plan([(10.0, 30.0)])
+    snapped = snap_clips_off_shot_changes(plan, "v.mp4", video_duration=100.0, margin=0.5, threshold=0.4)
+    c = snapped["clips"][0]
+    assert c["source_start"] == 10.0 and c["source_end"] == 30.0
+
+
+def test_scene_cut_snap_skips_when_snap_would_collapse_clip(monkeypatch):
+    """On a clip too short to keep min_keep after snapping, the boundary is left as-is (no collapse)."""
+    monkeypatch.setattr(cut, "_detect_shot_changes", _fake_detector([10.4]))
+    plan = _make_plan([(10.0, 10.6)])  # 0.6s clip, change at 10.4 inside both windows
+    snapped = snap_clips_off_shot_changes(plan, "v.mp4", video_duration=100.0, margin=0.5, threshold=0.4)
+    c = snapped["clips"][0]
+    assert c["source_start"] == 10.0 and c["source_end"] == 10.6  # unchanged, still a valid clip
+    assert c["duration"] == 0.6
+
+
+def test_scene_cut_snap_recomputes_output_across_multiple_clips(monkeypatch):
+    """Output timeline is repacked cursor-based after the source ranges shrink."""
+    monkeypatch.setattr(cut, "_detect_shot_changes", _fake_detector([10.3, 49.6]))
+    plan = _make_plan([(10.0, 20.0), (40.0, 50.0)])
+    snapped = snap_clips_off_shot_changes(plan, "v.mp4", video_duration=100.0, margin=0.5, threshold=0.4)
+    a, b = snapped["clips"]
+    assert a["source_start"] == 10.3 and a["output_start"] == 0.0 and a["output_end"] == 9.7
+    assert b["source_end"] == 49.6 and b["output_start"] == 9.7
+    assert snapped["total_duration"] == round(9.7 + 9.6, 3)
+
+
+def test_detect_shot_changes_offsets_by_seek_and_filters_window(monkeypatch):
+    """pts_time is rebased to the seek target, so seek+pts recovers absolute time; cuts outside
+    [win_start, win_end] (e.g. the seek/keyframe artifact) are dropped."""
+    stderr = "frame showinfo pts_time:1.762\n frame pts_time:5.866 \n frame pts_time:0.05\n"
+    monkeypatch.setattr(cut, "subprocess",
+                        types.SimpleNamespace(run=lambda *a, **k: CompletedProcess(a, 0, "", stderr)))
+    out = cut._detect_shot_changes("v.mkv", 55.0, 68.0, 0.4)  # seek=54.75
+    assert out == [56.512, 60.616]  # 54.8 (54.75+0.05) is < win_start → filtered


### PR DESCRIPTION
## Why
A clip boundary that lands a few tenths of a second from a hard cut in the **original** footage shows a brief sliver of the adjacent shot that then cuts again — a visible 闪烁/flicker at the edit point.

## What
New `snap_clips_off_shot_changes` pass (after the natural-pause snap) detects original hard cuts near each boundary with ffmpeg's scene metric in a narrow window, moves `source_start` forward onto / `source_end` back onto them, then repacks the output timeline cursor-based.

Self-contained in video-cut (per-boundary targeted detection, ~2 quick ffmpeg probes per clip — works with existing caches, no understanding re-run). Boundaries already on a cut or with no nearby cut are untouched; snaps that would collapse a clip below ~0.5s are skipped; any ffmpeg trouble leaves the boundary as-is.

Config: `SCENE_CUT_SNAP` (on) / `SCENE_CUT_SNAP_MARGIN` (0.5) / `SCENE_CUT_DETECT_THRESHOLD` (0.4). 6 tests; exercised live (`避让原片切镜头: 1 起点前移、1 终点回收`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)