### PR TITLE
Show gap subtitles for BYO user_subtitles even with mask off

### DIFF
--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -278,16 +278,21 @@ def _subtitle_style_config():
     }
 
 
+def _has_user_subtitles(work_dir):
+    """True when the user dropped a bring-your-own original-subtitle file into work_dir."""
+    return work_dir is not None and any(
+        (Path(work_dir) / name).exists()
+        for name in ("user_subtitles.json", "user_subtitles.srt", "user_subtitles.ass")
+    )
+
+
 def assembly_settings_fingerprint(work_dir=None):
     """Settings that affect the rendered video, used by pipeline resume cache. When work_dir is
     given, a user_subtitles presence flag is included so dropping in a user-subtitle file rebuilds
     the cached subtitles."""
     burn_subtitles = bool(CONFIG.get("burn_subtitles", False))
     mask_source_subtitles = burn_subtitles and bool(CONFIG.get("mask_source_subtitles", False))
-    user_subtitles = work_dir is not None and any(
-        (Path(work_dir) / name).exists()
-        for name in ("user_subtitles.json", "user_subtitles.srt", "user_subtitles.ass")
-    )
+    user_subtitles = _has_user_subtitles(work_dir)
     fingerprint = {
         "version": SUBTITLE_RENDER_VERSION,
         "subtitle_text_normalize": SUBTITLE_TEXT_NORMALIZE_VERSION,
@@ -796,11 +801,14 @@ def _original_gap_subtitle_entries(tts_segments, work_dir, video_duration):
     """Subtitle entries for the ORIGINAL dialogue during the original-audio blocks (narration
     gaps), so the band is not blank while the original speaks. Off unless we are burning and
     subtitle_original_in_gaps is set; no-op when there is no ASR. Cut mode remaps ASR to output."""
-    # Only fill the gaps when we are masking the source's own subs (else they already show there
-    # and ours would double). subtitle_original_in_gaps is the explicit override.
+    # Fill the gaps when either (a) we are masking the source's own burned-in subs (so the band is
+    # blank without us), or (b) the user supplied their own subtitle file — a clear signal they want
+    # the original dialogue shown, e.g. a clean/foreign source with mask OFF (no burned subs to
+    # double). Without a user file we keep the mask requirement so we don't double the source's own
+    # visible subs. subtitle_original_in_gaps is the explicit override either way.
     if not (CONFIG.get("burn_subtitles", False)
-            and CONFIG.get("mask_source_subtitles", False)
-            and CONFIG.get("subtitle_original_in_gaps", True)):
+            and CONFIG.get("subtitle_original_in_gaps", True)
+            and (CONFIG.get("mask_source_subtitles", False) or _has_user_subtitles(work_dir))):
         return []
     gaps = _narration_gap_windows(tts_segments, video_duration)
     if not gaps:

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -9,7 +9,7 @@ from lib import CONFIG
 from lib import log, run_cmd, get_video_duration
 from timeline import build_timeline, save_timeline
 
-SUBTITLE_RENDER_VERSION = 3
+SUBTITLE_RENDER_VERSION = 4  # bumped: BYO user_subtitles now fill gaps even with mask off
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
 _SUBTITLE_TERMINAL_PUNCTUATION = "。！？!?…."
 _SUBTITLE_CLOSING_QUOTES = "」』”’）)]】》〉\"'"

--- a/tests/assemble/test_original_gap_subtitles.py
+++ b/tests/assemble/test_original_gap_subtitles.py
@@ -93,6 +93,25 @@ def test_original_gap_entries_gated_off(monkeypatch, tmp_path):
     assert assemble._original_gap_subtitle_entries([], tmp_path, 10.0) == []
 
 
+def test_original_gap_entries_use_user_subs_even_without_mask(monkeypatch, tmp_path):
+    """A bring-your-own user_subtitles file populates the gaps even with mask OFF — the clean/foreign
+    source case (no burned subs to double). Without a user file, mask OFF still yields nothing."""
+    monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
+    monkeypatch.setitem(assemble.CONFIG, "mask_source_subtitles", False)   # nothing to mask
+    monkeypatch.setitem(assemble.CONFIG, "subtitle_original_in_gaps", True)
+    segs = [{"actual_place_start": 5.0, "actual_place_end": 8.0, "narration": "解说"}]
+
+    # no user file → mask OFF keeps the gate closed (don't double the source's own visible subs)
+    assert assemble._original_gap_subtitle_entries(segs, tmp_path, 10.0) == []
+
+    # drop in user_subtitles.srt → gaps fill from it despite mask OFF
+    (tmp_path / "user_subtitles.srt").write_text(
+        "1\n00:00:01,000 --> 00:00:04,000\n原声台词\n\n", encoding="utf-8")
+    entries = assemble._original_gap_subtitle_entries(segs, tmp_path, 10.0)
+    assert entries and all(e["text"] for e in entries)
+    assert all(1.0 <= e["start"] and e["end"] <= 4.0 + 1e-6 for e in entries)
+
+
 def test_original_gap_entries_full_mode(monkeypatch, tmp_path):
     _burn_on(monkeypatch)
     (tmp_path / "asr_result.json").write_text(


### PR DESCRIPTION
## Why
The original-dialogue gap subtitles were gated on `mask_source_subtitles` being **on**, so a clean/foreign source (no burned-in subs) rendered with mask **off** — the correct choice when there's nothing to mask — silently dropped the gap subtitles, even when the user supplied `user_subtitles.*`.

## What
Decouple: gaps fill when burning + the explicit `subtitle_original_in_gaps` **and** (masking **or** a user subtitle file is present). A user file is a clear intent signal and carries no doubling risk on a clean source. Bumps `SUBTITLE_RENDER_VERSION` so the resume cache rebuilds subtitles after the change.

Pairs with `FOREIGN_SOURCE_AUDIO` (foreign drama + BYO Chinese subs). 1 new test; exercised live (15 bracketed 「」 original-dialogue cues in the Long Vacation demo gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)