### PR TITLE
docs: constrain demo video to 70% width in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 ## Demo
 
-https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff
+<video src="https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff" width="70%" controls></video>
 
 Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand — original clips, narration, BGM, and subtitles each on their own track:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 演示
 
-https://github.com/user-attachments/assets/aa96bd1d-ce4b-42bd-a7df-439aeb63dd18
+<video src="https://github.com/user-attachments/assets/aa96bd1d-ce4b-42bd-a7df-439aeb63dd18" width="70%" controls></video>
 
 成片之外，还能一键导出**剪映草稿**手动精修——原片、解说、BGM、字幕各一轨：
 


### PR DESCRIPTION
The demo was a bare `user-attachments` URL, which GitHub auto-embeds as a **full-width** video player — too large on the page. Wrapped it in a `<video src=... width="70%" controls>` tag so it matches the 剪映 screenshot directly below it. Applied to both `README.md` and `README.en.md`.

`width="70%"` is a one-number tweak — easy to bump to 60% / 50% if you want it smaller still.

🤖 Generated with [Claude Code](https://claude.com/claude-code)