### PR TITLE
docs: pixel width for demo video so GitHub actually shrinks it

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 ## Demo
 
-<video src="https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff" width="70%" controls></video>
+<video src="https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff" width="640" controls></video>
 
 Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand — original clips, narration, BGM, and subtitles each on their own track:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 演示
 
-<video src="https://github.com/user-attachments/assets/aa96bd1d-ce4b-42bd-a7df-439aeb63dd18" width="70%" controls></video>
+<video src="https://github.com/user-attachments/assets/aa96bd1d-ce4b-42bd-a7df-439aeb63dd18" width="640" controls></video>
 
 成片之外，还能一键导出**剪映草稿**手动精修——原片、解说、BGM、字幕各一轨：
 


### PR DESCRIPTION
Follow-up to #41. `width="70%"` survives GitHub's sanitizer but browsers ignore a **percentage** on a `<video>` element (the width attribute is pixels-only per the HTML spec — that's why it didn't shrink). Switched to `width="640"` (~70% of GitHub's ~896px content column), which is honored; `max-width:100%` keeps it responsive on narrow screens. Applies to both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)