### PR TITLE
fix: 整段解说跨镜头不再被截断 + 指纹去重/文档打磨

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,13 +10,13 @@
 
 ## Demo
 
-<video src="https://github.com/user-attachments/assets/92698ec6-0d23-4f9f-8825-c3684ef57aff" width="640" controls></video>
+<video src="https://github.com/user-attachments/assets/aa96bd1d-ce4b-42bd-a7df-439aeb63dd18" width="640" controls></video>
 
-Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand — original clips, narration, BGM, and subtitles each on their own track:
+Beyond the rendered MP4, you can export a **剪映/JianYing draft** to keep editing by hand, with original clips, narration, BGM, and subtitles each on their own track:
 
 <img alt="Exported 剪映 draft: original clips, narration, BGM, and subtitles each on their own track" src="docs/jianying-export.png" width="70%">
 
-## What is it?
+## What it is
 
 ```mermaid
 flowchart LR
@@ -29,11 +29,11 @@ flowchart LR
     class research,cut opt;
 ```
 
-## Why use it?
+## Why use it
 
 - **One key, runs anywhere.** ASR, VLM, and TTS all go through [Xiaomi MiMo](https://platform.xiaomimimo.com); `ffmpeg` is the only local dependency.
-- **Research when it matters.** When the title/story context is known or the brief says the substrate is thin, put character relationships and plot background in `background_research.json` so the VLM knows who's who; skip it when network/context is unavailable.
-- **Narration in blocks, original in blocks.** Narration plays in connected blocks, each voiced in one pass; in the gaps between, the original audio plays at full volume — roughly 7:3.
+- **Research when it matters.** When the title/story context is known or the brief notes the material is thin, put character relationships and plot background in `background_research.json` so the VLM knows who's who; skip it when network/context is unavailable.
+- **Narration in blocks, original in blocks.** Narration plays in connected blocks, each voiced in one pass; in the gaps, the original audio returns at full volume — roughly 7:3.
 - **Cut first, no drift.** `--edit-mode cut` renders the cut first, then you narrate against that timeline, so picture and voice stay in sync; an LLM pass reviews the draft before TTS.
 - **Keep editing in 剪映.** Optionally export a multi-track 剪映 draft — original, narration, BGM, and subtitles each on a track; the core render needs only `ffmpeg`.
 
@@ -45,7 +45,7 @@ flowchart LR
 Install this plugin: https://github.com/worldwonderer/video-recap-skills
 ```
 
-**② Install ffmpeg** (the pipeline needs no `pip install` — just the standard library and `ffmpeg` on `PATH`, Python 3.10+):
+**② Install ffmpeg** (no `pip install`: pure standard library + `ffmpeg` on `PATH`, Python 3.10+):
 
 ```bash
 brew install ffmpeg                        # macOS
@@ -53,9 +53,9 @@ sudo apt install ffmpeg                     # Debian/Ubuntu
 choco install ffmpeg                        # Windows (or scoop / winget install ffmpeg)
 ```
 
-Subtitles are burned into the picture by default, which needs an ffmpeg built with **libass (the `subtitles` filter)** — the packages above include it in almost all cases. If yours lacks libass, the run fails fast at the start with a clear message (or pass `--no-burn-subtitles` to keep the MP4 unmasked and subtitles as a sidecar `.srt`). Run `python3 scripts/recap.py --doctor` to self-check.
+Subtitles are burned into the picture by default, which needs an ffmpeg built with **libass (the `subtitles` filter)** — the packages above include it in almost all cases. If yours lacks libass, the run fails fast at the start with a clear message (or pass `--no-burn-subtitles` to keep the MP4 unmasked and subtitles as a sidecar `.srt`). Run `python3 skills/video-recap/scripts/recap.py --doctor` to self-check.
 
-**③ Set your MiMo API key** (one key powers ASR / VLM / TTS — keep it in an env var, never in the repo):
+**③ Set your MiMo API key** (one key powers ASR / VLM / TTS — register at [platform.xiaomimimo.com](https://platform.xiaomimimo.com), then keep it in an env var, never in the repo):
 
 ```bash
 export MIMO_API_KEY=your-mimo-key
@@ -63,7 +63,7 @@ export MIMO_API_KEY=your-mimo-key
 export MIMO_TOKEN_PLAN_CLUSTER=cn
 ```
 
-Pay-as-you-go `sk-*` keys default to `https://api.xiaomimimo.com/v1`. Everything else has a default; to change a model, the voice, loudness, subtitles, or set a key/URL per capability, see the
+Pay-as-you-go `sk-*` keys default to `https://api.xiaomimimo.com/v1`. Everything else has a default; to change the model, voice, loudness, or subtitles, or set a key/URL per capability, see the
 [config playbook](skills/video-recap/references/config-playbook.md).
 
 ## Usage
@@ -99,7 +99,7 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 ## Output
 
-- `recap_<video>.mp4`: the final recap; a stable output alias overwritten in place on every run, so iterating on the narration refreshes the same file. `subtitles.srt` (plus `subtitles.ass`; subtitle burn-in is on by default, `--no-burn-subtitles` to disable)
+- `recap_<name>.mp4`: the final recap; a stable alias overwritten in place on every run. `subtitles.srt` (plus `subtitles.ass`; subtitle burn-in is on by default, `--no-burn-subtitles` to disable)
 - `work_dir/narration.json`: the narration script (`narration_lint.json` timing diagnostics, `narration_review.md` review notes)
 - `work_dir/agent_narration_brief.md`: timing and scene brief for the agent
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`: understanding artifacts

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ flowchart LR
 安装这个插件：https://github.com/worldwonderer/video-recap-skills
 ```
 
-**② 装 ffmpeg**（流水线本身不用 `pip install`，脚本都是标准库 + `PATH` 上的 `ffmpeg`，Python 3.10+）：
+**② 装 ffmpeg**（不用 `pip install`：纯标准库 + `PATH` 上的 `ffmpeg`，Python 3.10+）：
 
 ```bash
 brew install ffmpeg                        # macOS
@@ -53,9 +53,9 @@ sudo apt install ffmpeg                     # Debian/Ubuntu
 choco install ffmpeg                        # Windows（或 scoop / winget install ffmpeg）
 ```
 
-字幕默认烧进画面，需要带 **libass（`subtitles` 滤镜）** 的 ffmpeg——上面这些包基本都自带。如果你的 ffmpeg 没编 libass，开跑前会立刻报错并提示（也可以加 `--no-burn-subtitles` 输出未遮黑条的 MP4 + `.srt` 外挂字幕）。用 `python3 scripts/recap.py --doctor` 自检。
+字幕默认烧进画面，需要带 **libass（`subtitles` 滤镜）** 的 ffmpeg——上面这些包基本都自带。如果你的 ffmpeg 没编 libass，开跑前会立刻报错并提示（也可以加 `--no-burn-subtitles` 输出未遮黑条的 MP4 + `.srt` 外挂字幕）。用 `python3 skills/video-recap/scripts/recap.py --doctor` 自检。
 
-**③ 配 MiMo API Key**（一个 key 同时驱动 ASR / VLM / TTS）：
+**③ 配 MiMo API Key**（一个 key 同时驱动 ASR / VLM / TTS；先在 [platform.xiaomimimo.com](https://platform.xiaomimimo.com) 注册获取）：
 
 ```bash
 export MIMO_API_KEY=your-mimo-key
@@ -99,7 +99,7 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 ## 输出
 
-- `recap_<video>.mp4`：成片（固定输出名，每次运行原地覆盖，迭代解说时刷新同一文件）。`subtitles.srt`（默认烧录字幕，同时产出 `subtitles.ass`；`--no-burn-subtitles` 关闭）
+- `recap_<名>.mp4`：成片（固定输出名，每次运行原地覆盖）。`subtitles.srt`（默认烧录字幕，同时产出 `subtitles.ass`；`--no-burn-subtitles` 关闭）
 - `work_dir/narration.json`：解说脚本（`narration_lint.json` 时间诊断、`narration_review.md` 评审意见）
 - `work_dir/agent_narration_brief.md`：给 Agent 的时间和场景 brief
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`：理解产物

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -237,27 +237,3 @@ CLI 校验 `clip_plan.json` 后写出，额外包含输出时间轴：
 ```
 
 > `character_details`、`plot_arcs`、`cultural_notes` 为（可选，新增）字段。仅含 `synopsis`、`characters`、`worldbuilding`、`episode_context` 四个原始字段的旧 JSON 仍然有效。
-
-## workflow_state.json
-
-统一步骤状态文件。`.step_*.done` 仍保留用于兼容旧工作目录和手动清理习惯，但新的续跑逻辑会同时写入 `workflow_state.json`，记录视频内容指纹、每步状态、耗时和参数指纹。
-
-```json
-{
-  "schema_version": 1,
-  "input_video": "/path/to/video.mp4",
-  "video_fingerprint": "md5...",
-  "started_at": "2026-06-06T12:00:00Z",
-  "steps": {
-    "extract": {
-      "status": "done",
-      "progress": 100,
-      "started_at": "2026-06-06T12:00:01Z",
-      "completed_at": "2026-06-06T12:00:05Z",
-      "elapsed_s": 4.0,
-      "params": {"fps": 1},
-      "params_fingerprint": "md5..."
-    }
-  }
-}
-```

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -319,10 +319,19 @@ def _normalise_narration_segment(seg, scenes_analysis=None):
     if scenes_analysis:
         parent = _find_scene_for_midpoint(scenes_analysis, item["start"], item["end"])
         if parent:
-            item["start"] = round(max(parent["start"], item["start"]), 2)
-            item["end"] = round(min(parent["end"], item["end"]), 2)
-            if item["end"] <= item["start"]:
-                return None
+            clamped_start = round(max(parent["start"], item["start"]), 2)
+            clamped_end = round(min(parent["end"], item["end"]), 2)
+            # Only tighten the window to the midpoint scene when the authored text
+            # still fits the clamped span. A multi-sentence BLOCK is meant to span
+            # the cut and play across scenes; shrinking it here would make
+            # _validate_narration_budget/_truncate_at_sentence drop trailing
+            # sentences the author wrote — keep the author's timing in that case.
+            if clamped_end > clamped_start and (
+                _text_char_count(item["narration"])
+                <= _recommended_char_budget(clamped_start, clamped_end, item.get("pause_after_ms")) * 1.25
+            ):
+                item["start"] = clamped_start
+                item["end"] = clamped_end
     return item
 
 

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -11,13 +11,12 @@ Output: narration_review.json (structured) + narration_review.md (readable). Adv
 verdict REVISE means "fix and re-review"; it never blocks (validate.py is the hard gate).
 """
 import argparse
-import hashlib
 import json
 import math
 import re
 from pathlib import Path
 
-from lib import CONFIG, log, api_call
+from lib import CONFIG, log, api_call, stable_hash
 
 CATEGORIES = [
     "hallucination", "weak_hook", "no_throughline", "narrating_picture",
@@ -41,10 +40,6 @@ RUBRIC = """你是中文视频解说稿的严格评审。依据以下规则审�
 {"verdict":"REVISE|OK","summary":"一两句总体判断","findings":[{"segment":<草稿段号(从0起)或null表示整体>,"severity":"error|warning|suggestion","category":"<上面类别之一>","issue":"问题","fix":"具体改法"}]}"""
 
 
-
-def _value_fingerprint(value):
-    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.md5(payload.encode("utf-8")).hexdigest()
 
 def _load(work_dir, name):
     path = Path(work_dir) / name
@@ -71,7 +66,7 @@ def _load_cut_clip_spans(work_dir):
     if not isinstance(plan, dict):
         return None
     raw_plan = _load(work_dir, "clip_plan.json")
-    if raw_plan is not None and plan.get("raw_plan_fingerprint") != _value_fingerprint(raw_plan):
+    if raw_plan is not None and plan.get("raw_plan_fingerprint") != stable_hash(raw_plan):
         return None
     clips = plan.get("clips")
     if not isinstance(clips, list):

--- a/skills/video-script/scripts/validate.py
+++ b/skills/video-script/scripts/validate.py
@@ -6,12 +6,11 @@ understanding index produced by video-understanding. Writes narration_lint.json 
 in full mode, rewrites narration.json with quiet-window alignment applied.
 """
 import argparse
-import hashlib
 import json
 import math
 from pathlib import Path
 
-from lib import CONFIG, log
+from lib import CONFIG, log, stable_hash
 from narration import (
     validate_narration_or_raise,
     _validate_narration_budget,
@@ -22,11 +21,6 @@ from narration import (
 def _load(path):
     path = Path(path)
     return json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
-
-
-def _value_fingerprint(value):
-    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.md5(payload.encode("utf-8")).hexdigest()
 
 
 def _load_cut_clip_plan(work_dir):
@@ -41,7 +35,7 @@ def _load_cut_clip_plan(work_dir):
     validated = _load(validated_plan)
     if (
         isinstance(validated, dict)
-        and validated.get("raw_plan_fingerprint") == _value_fingerprint(raw)
+        and validated.get("raw_plan_fingerprint") == stable_hash(raw)
     ):
         return validated
     # The orchestrator validates before video-cut refreshes clip_plan_validated.json.

--- a/skills/video-understanding/references/data-schema.md
+++ b/skills/video-understanding/references/data-schema.md
@@ -220,27 +220,3 @@ CLI 校验 `clip_plan.json` 后写出，额外包含输出时间轴：
 ```
 
 > `character_details`、`plot_arcs`、`cultural_notes` 为（可选，新增）字段。仅含 `synopsis`、`characters`、`worldbuilding`、`episode_context` 四个原始字段的旧 JSON 仍然有效。
-
-## workflow_state.json
-
-统一步骤状态文件。`.step_*.done` 仍保留用于兼容旧工作目录和手动清理习惯，但新的续跑逻辑会同时写入 `workflow_state.json`，记录视频内容指纹、每步状态、耗时和参数指纹。
-
-```json
-{
-  "schema_version": 1,
-  "input_video": "/path/to/video.mp4",
-  "video_fingerprint": "md5...",
-  "started_at": "2026-06-06T12:00:00Z",
-  "steps": {
-    "extract": {
-      "status": "done",
-      "progress": 100,
-      "started_at": "2026-06-06T12:00:01Z",
-      "completed_at": "2026-06-06T12:00:05Z",
-      "elapsed_s": 4.0,
-      "params": {"fps": 1},
-      "params_fingerprint": "md5..."
-    }
-  }
-}
-```

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -319,10 +319,19 @@ def _normalise_narration_segment(seg, scenes_analysis=None):
     if scenes_analysis:
         parent = _find_scene_for_midpoint(scenes_analysis, item["start"], item["end"])
         if parent:
-            item["start"] = round(max(parent["start"], item["start"]), 2)
-            item["end"] = round(min(parent["end"], item["end"]), 2)
-            if item["end"] <= item["start"]:
-                return None
+            clamped_start = round(max(parent["start"], item["start"]), 2)
+            clamped_end = round(min(parent["end"], item["end"]), 2)
+            # Only tighten the window to the midpoint scene when the authored text
+            # still fits the clamped span. A multi-sentence BLOCK is meant to span
+            # the cut and play across scenes; shrinking it here would make
+            # _validate_narration_budget/_truncate_at_sentence drop trailing
+            # sentences the author wrote — keep the author's timing in that case.
+            if clamped_end > clamped_start and (
+                _text_char_count(item["narration"])
+                <= _recommended_char_budget(clamped_start, clamped_end, item.get("pause_after_ms")) * 1.25
+            ):
+                item["start"] = clamped_start
+                item["end"] = clamped_end
     return item
 
 

--- a/tests/script/test_narration_fixes.py
+++ b/tests/script/test_narration_fixes.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 
-from narration import _truncate_at_sentence, _validate_narration_budget
+from narration import _truncate_at_sentence, _validate_narration_budget, _text_char_count
 
 
 # ── BUG 9: trailing pause punctuation must be replaced, not appended ──
@@ -72,3 +72,41 @@ def test_truncate_falls_back_to_last_pause_boundary():
 def test_truncate_noop_when_within_budget():
     text = "他走进了那扇门。"
     assert _truncate_at_sentence(text, 100) == text
+
+
+# ── BLOCK-TRUNCATION BUG: full-mode scene clamp must not chop a block that spans a cut ──
+
+_TWO_SCENES = [
+    {"scene_id": 0, "start": 0.0, "end": 10.0},
+    {"scene_id": 1, "start": 10.0, "end": 30.0},
+]
+
+
+def test_multi_sentence_block_spanning_scene_cut_keeps_full_text():
+    # An authored 3-sentence BLOCK spans the cut at 10s (midpoint 10.0 is on the boundary,
+    # _find_scene_for_midpoint resolves it to a single scene). Before the fix the window was
+    # clamped to that one scene and _truncate_at_sentence dropped trailing sentences.
+    # ~50 chars: overflows the clamped single-scene window [2,10] (budget ~30) but fits the
+    # authored window [2,18] (budget ~61). Old code clamped to 10s and truncated the tail.
+    block = "他猛地推开那扇沉重的木门冲进房间，屋里却空无一人。桌上的台灯还亮着，茶杯里的水汽未散。窗帘在夜风里轻轻晃动着。"
+    out = _validate_narration_budget(
+        [{"start": 2.0, "end": 18.0, "narration": block}], _TWO_SCENES
+    )
+    assert len(out) == 1
+    # Full authored text survives (no trailing-sentence truncation).
+    assert _text_char_count(out[0]["narration"]) == _text_char_count(block)
+    assert "窗帘在夜风里轻轻晃动着" in out[0]["narration"]
+    # Author timing is preserved because clamping would have forced truncation.
+    assert out[0]["end"] == 18.0
+
+
+def test_single_sentence_beat_still_clamped_to_midpoint_scene():
+    # A short single-sentence beat whose midpoint (6.0) is in scene 0 but nominal end (12)
+    # spills into scene 1. The clamped window (2-10) still fits the tiny text, so the clamp
+    # still applies — single-sentence quiet-window alignment is unchanged by the fix.
+    out = _validate_narration_budget(
+        [{"start": 2.0, "end": 12.0, "narration": "他点了点头。"}], _TWO_SCENES
+    )
+    assert len(out) == 1
+    assert out[0]["end"] == 10.0  # tightened to the scene boundary
+    assert out[0]["narration"].startswith("他点了点头")

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -518,7 +518,7 @@ def test_cut_validate_uses_validated_plan_when_raw_fingerprint_matches(tmp_path)
     validated = tmp_path / "clip_plan_validated.json"
     raw.write_text(json.dumps(raw_payload), encoding="utf-8")
     validated.write_text(json.dumps({
-        "raw_plan_fingerprint": validate._value_fingerprint(raw_payload),
+        "raw_plan_fingerprint": validate.stable_hash(raw_payload),
         "clips": [{"clip_id": 0, "source_start": 40.0, "source_end": 50.0}],
     }), encoding="utf-8")
 

--- a/tests/script/test_review.py
+++ b/tests/script/test_review.py
@@ -205,7 +205,7 @@ def test_review_narration_cut_output_uses_remapped_grounding(monkeypatch, tmp_pa
     raw_plan = [{"start": 10, "end": 20}]
     (tmp_path / "clip_plan.json").write_text(json.dumps(raw_plan), encoding="utf-8")
     (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
-        "raw_plan_fingerprint": review._value_fingerprint(raw_plan),
+        "raw_plan_fingerprint": review.stable_hash(raw_plan),
         "clips": [{"source_start": 10, "source_end": 20, "output_start": 0, "output_end": 10}],
     }), encoding="utf-8")
     payloads = []


### PR DESCRIPTION
## 修复（真 bug）

**full 模式下整段解说跨镜头被静默截断。** `validate` 把每段解说裁到「中点所在的那一个镜头」，再按裁短后的窗口重算预算并截断 —— 跨剪辑点的多句整段因此被砍掉尾句，违背 block-delivery 模型（盘龙 demo 上 4 段被砍、手动补回）。

改为**按预算裁**：仅当裁短后的窗口仍放得下原文时才贴合镜头边界，否则保留作者写的时间，不裁不截。单句解说仍按原规则贴齐镜头；`cut_output` 路径本就传 `None`、不受影响。字节孪生 `brief.py` 同步修改（md5 一致），新增 2 个回归测试。

## 清理 + 文档

- `validate.py` / `review.py` 重复的 `_value_fingerprint` 改用现成的 `lib.stable_hash`（输出字节一致，跨 skill `raw_plan_fingerprint` 握手不变），删掉无用的 `hashlib` 导入。
- 删除两个 `data-schema.md` 里无任何代码读写的 `workflow_state.json` / `.step_*.done` 文档段。
- README（中英）：修正 `--doctor` 路径、补 MiMo key 注册引导、统一占位符 `recap_<name>`、去英文问号标题、对齐中英 demo 链接、收冗余措辞。

## 验证

- 466 测试全绿（7 个隔离 skill 组），`ruff check skills tests scripts` 干净。
- `brief.py` ≡ `narration.py` md5 parity 测试通过（孪生同步）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)