### PR TITLE
语速基准校准 3.5→3.9 + 截断可见 + doctor 预检能力清单

### DIFF
--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -192,10 +192,10 @@ CONFIG = {
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
     "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
     "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒），由校准得出。MiMo TTS 中文约 3.5 字/秒
+    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": 3.5,
-    "speech_safety_margin": 0.85,  # 保守系数：TTS 实际语速有 ±20% 波动
+    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
+    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # aim ~70% narrated:original (7:3)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated

--- a/skills/video-recap/scripts/doctor.py
+++ b/skills/video-recap/scripts/doctor.py
@@ -18,6 +18,7 @@ from lib import CONFIG
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+DEGRADED_GROUP = "warnings/degraded"
 
 
 def _command_path(name: str) -> str | None:
@@ -73,6 +74,186 @@ def _asr_status() -> dict[str, object]:
         "mimo_asr_api_key_source": CONFIG.get("mimo_asr_api_key_source", "MIMO_API_KEY"),
         "note": "ASR uses MiMo (mimo-v2.5-asr); set MIMO_API_KEY, or run with --skip-asr.",
     }
+
+
+def _capability(name: str, summary: str, *, detail: str = "", action: str = "") -> dict[str, str]:
+    item = {"name": name, "summary": summary}
+    if detail:
+        item["detail"] = detail
+    if action:
+        item["action"] = action
+    return item
+
+
+def _build_capability_menu(checks: dict[str, object]) -> dict[str, list[dict[str, str]]]:
+    """Human-ready preflight summary grouped by what can run, what blocks, and what degrades.
+
+    This is intentionally a small rollup over the existing `checks` tree. It does not replace
+    the raw machine checks, install anything, or introduce provider ranking.
+    """
+    system = cast(dict[str, Any], checks["system_tools"])
+    api = cast(dict[str, Any], checks["api_config"])
+    asr = cast(dict[str, Any], checks["asr"])
+    tts = cast(dict[str, Any], checks["tts"])
+
+    menu: dict[str, list[dict[str, str]]] = {
+        "ready": [],
+        "blocked": [],
+        DEGRADED_GROUP: [],
+        "optional_upgrades": [],
+    }
+
+    ffmpeg_ready = bool(system.get("ffmpeg"))
+    ffprobe_ready = bool(system.get("ffprobe"))
+    subtitles_ready = bool(system.get("burn_subtitles_ready"))
+    api_key_set = bool(api.get("api_key_set"))
+    asr_ready = bool(asr.get("available"))
+    tts_ready = bool(tts.get("available"))
+    vlm_ready = bool(api.get("mimo_video_configured"))
+    normal_core_ready = ffmpeg_ready and ffprobe_ready and api_key_set and vlm_ready and tts_ready
+
+    if ffmpeg_ready and ffprobe_ready:
+        menu["ready"].append(
+            _capability(
+                "core_media_tools",
+                "ffmpeg and ffprobe are available",
+                detail="Local probing, cutting, rendering, and duration checks can run.",
+            )
+        )
+    else:
+        if not ffmpeg_ready:
+            menu["blocked"].append(
+                _capability("ffmpeg", "Missing ffmpeg", action="Install ffmpeg before running the recap pipeline.")
+            )
+        if not ffprobe_ready:
+            menu["blocked"].append(
+                _capability("ffprobe", "Missing ffprobe", action="Install ffprobe before running media probing/export.")
+            )
+
+    if api_key_set:
+        menu["ready"].append(
+            _capability(
+                "mimo_credentials",
+                "MiMo API key is configured",
+                detail=f"Source: {api.get('api_key_source')}",
+            )
+        )
+    else:
+        menu["blocked"].append(
+            _capability(
+                "mimo_credentials",
+                "Missing MIMO_API_KEY",
+                action="Set MIMO_API_KEY; the default ASR / VLM / TTS path depends on it.",
+            )
+        )
+
+    if vlm_ready:
+        menu["ready"].append(
+            _capability(
+                "mimo_vlm",
+                "MiMo VLM/video understanding is configured",
+                detail=f"Model: {api.get('vlm_model')}",
+            )
+        )
+    elif api_key_set:
+        menu["blocked"].append(
+            _capability(
+                "mimo_vlm",
+                "MiMo VLM/video understanding is not configured",
+                action="Set MIMO_VIDEO_API_KEY or the shared MIMO_API_KEY before video understanding.",
+            )
+        )
+
+    if tts_ready:
+        menu["ready"].append(
+            _capability(
+                "mimo_tts",
+                "MiMo TTS is configured",
+                detail=f"Voice: {tts.get('mimo_tts_voice')}; model: {tts.get('mimo_tts_model')}",
+            )
+        )
+    elif api_key_set:
+        menu["blocked"].append(
+            _capability(
+                "mimo_tts",
+                "MiMo TTS is not configured",
+                action="Set MIMO_TTS_API_KEY or the shared MIMO_API_KEY before voiceover.",
+            )
+        )
+
+    if asr_ready:
+        menu["ready"].append(
+            _capability(
+                "mimo_asr",
+                "MiMo ASR is configured",
+                detail=f"Language: {asr.get('mimo_asr_language')}; model: {asr.get('mimo_asr_model')}",
+            )
+        )
+    else:
+        menu[DEGRADED_GROUP].append(
+            _capability(
+                "mimo_asr",
+                "ASR is unavailable; run only with --skip-asr",
+                action=str(asr.get("note") or "Set MIMO_ASR_API_KEY or MIMO_API_KEY to enable ASR."),
+            )
+        )
+
+    if subtitles_ready:
+        menu["ready"].append(
+            _capability("subtitle_burn", "Subtitle burn-in is available", detail="ffmpeg has the subtitles/libass filter.")
+        )
+    elif ffmpeg_ready:
+        menu[DEGRADED_GROUP].append(
+            _capability(
+                "subtitle_burn",
+                "Subtitle burn-in is unavailable",
+                action="Use --no-burn-subtitles or install an ffmpeg build with the subtitles/libass filter.",
+            )
+        )
+
+    if not normal_core_ready:
+        menu["blocked"].append(
+            _capability(
+                "default_recap_pipeline",
+                "Default recap run is blocked",
+                detail="Resolve the blocking items above before a normal run.",
+            )
+        )
+    elif asr_ready and subtitles_ready:
+        menu["ready"].append(
+            _capability("default_recap_pipeline", "Default recap run is ready", detail="ASR, VLM, TTS, and media tools are configured.")
+        )
+    else:
+        actions = []
+        if not asr_ready:
+            actions.append("run with --skip-asr")
+        if not subtitles_ready:
+            actions.append("run with --no-burn-subtitles")
+        menu[DEGRADED_GROUP].append(
+            _capability(
+                "recap_degraded_mode",
+                "Recap can run only in an explicit degraded mode",
+                detail="; ".join(actions),
+            )
+        )
+
+    menu["optional_upgrades"].append(
+        _capability(
+            "jianying_export",
+            "Editable JianYing draft export can be requested with --export-jianying",
+            detail="No JianYing install is required to write the draft; ffprobe improves media metadata.",
+        )
+    )
+    if subtitles_ready:
+        menu["optional_upgrades"].append(
+            _capability(
+                "burned_subtitles",
+                "Burned subtitles are available and enabled by default",
+                action="Use --no-burn-subtitles if you prefer external subtitle files.",
+            )
+        )
+
+    return menu
 
 
 def build_report() -> dict[str, object]:
@@ -138,10 +319,12 @@ def build_report() -> dict[str, object]:
         failures.append("MIMO_API_KEY is not set; ASR / VLM / TTS all require a MiMo key")
     if not asr_check.get("available"):
         warnings.append("ASR not configured (MIMO_API_KEY); pipeline can run with --skip-asr")
+    capability_menu = _build_capability_menu(checks)
     return {
         "ok": not failures,
         "repo_root": str(SCRIPT_DIR.parents[2]),
         "checks": checks,
+        "capability_menu": capability_menu,
         "failures": failures,
         "warnings": warnings,
     }
@@ -201,6 +384,22 @@ def _print_human(report: dict[str, object]) -> None:
     print(f"✓ TTS model: {tts.get('mimo_tts_model')} (source: {tts.get('mimo_tts_model_source')})")
     print(f"✓ TTS voice: {tts.get('mimo_tts_voice')} (source: {tts.get('mimo_tts_voice_source')})")
     print(f"✓ TTS API URL: {tts.get('mimo_tts_api_url')} (source: {tts.get('mimo_tts_api_url_source')})")
+
+    menu = cast(dict[str, list[dict[str, str]]], report.get("capability_menu") or {})
+    print("\n[capability menu]")
+    for group in ("ready", "blocked", DEGRADED_GROUP, "optional_upgrades"):
+        print(f"{group}:")
+        items = menu.get(group) or []
+        if not items:
+            print("  - none")
+            continue
+        for item in items:
+            line = f"  - {item.get('name')}: {item.get('summary')}"
+            if item.get("detail"):
+                line += f" ({item['detail']})"
+            print(line)
+            if item.get("action"):
+                print(f"    action: {item['action']}")
 
     warnings = cast(list[str], report.get("warnings") or [])
     failures = cast(list[str], report.get("failures") or [])

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -183,10 +183,10 @@ CONFIG = {
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
     "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
     "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒），由校准得出。MiMo TTS 中文约 3.5 字/秒
+    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": 3.5,
-    "speech_safety_margin": 0.85,  # 保守系数：TTS 实际语速有 ±20% 波动
+    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
+    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # aim ~70% narrated:original (7:3)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -193,10 +193,10 @@ CONFIG = {
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
     "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
     "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒），由校准得出。MiMo TTS 中文约 3.5 字/秒
+    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": 3.5,
-    "speech_safety_margin": 0.85,  # 保守系数：TTS 实际语速有 ±20% 波动
+    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
+    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # aim ~70% narrated:original (7:3)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -199,10 +199,10 @@ CONFIG = {
     "storyboard": env_bool("STORYBOARD", True),  # generate source/edited storyboard contact sheets
     "storyboard_max_tiles": env_int("STORYBOARD_MAX_TILES", 30, minimum=1),  # cap tiles per sheet for legibility
     "storyboard_columns": env_int("STORYBOARD_COLUMNS", 6, minimum=1),  # tile grid columns
-    # TTS 语速（字符/秒），由校准得出。MiMo TTS 中文约 3.5 字/秒
+    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": 3.5,
-    "speech_safety_margin": 0.85,  # 保守系数：TTS 实际语速有 ±20% 波动
+    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
+    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # aim ~70% narrated:original (7:3)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -193,10 +193,10 @@ CONFIG = {
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
     "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
     "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒），由校准得出。MiMo TTS 中文约 3.5 字/秒
+    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": 3.5,
-    "speech_safety_margin": 0.85,  # 保守系数：TTS 实际语速有 ±20% 波动
+    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
+    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # aim ~70% narrated:original (7:3)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated

--- a/skills/video-voiceover/scripts/voiceover.py
+++ b/skills/video-voiceover/scripts/voiceover.py
@@ -104,6 +104,7 @@ def _synthesize_segment(i, seg, narration, tts_dir, engine):
         target_chars = max(5, int(raw_budget * chars_per_sec) - 1)
         truncated = _truncate_at_sentence(text, target_chars)
         if truncated and len(truncated) >= 5 and truncated != text:
+            log(f"  段 {i+1}: 解说超出片段时长，自动截断 {len(text)}→{len(truncated)} 字以适配（建议在解说里改写得更短）")
             text = truncated
             _run_tts_engine(engine, text, output_wav, rate=rate, pitch=pitch, emotion=seg.get("emotion"))
             dur = _get_audio_duration(output_wav)

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -33,6 +33,10 @@ def _tools_present(monkeypatch):
     )
 
 
+def _capability_names(report, group):
+    return {item["name"] for item in report["capability_menu"][group]}
+
+
 def test_doctor_ok_when_tools_and_mimo_key_present(monkeypatch):
     _tools_present(monkeypatch)
     for k in ("api_key", "mimo_asr_api_key", "mimo_tts_api_key", "mimo_video_api_key"):
@@ -42,17 +46,27 @@ def test_doctor_ok_when_tools_and_mimo_key_present(monkeypatch):
 
     assert report["ok"] is True
     assert report["failures"] == []
+    assert {"ok", "repo_root", "checks", "failures", "warnings"} <= set(report)
+    assert set(report["capability_menu"]) == {"ready", "blocked", "warnings/degraded", "optional_upgrades"}
+    assert "default_recap_pipeline" in _capability_names(report, "ready")
+    assert "mimo_asr" in _capability_names(report, "ready")
+    assert "subtitle_burn" in _capability_names(report, "ready")
+    assert report["capability_menu"]["blocked"] == []
 
 
 def test_doctor_fails_without_mimo_key(monkeypatch):
     _tools_present(monkeypatch)
     monkeypatch.setitem(doctor.CONFIG, "api_key", "")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_video_api_key", "")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_tts_api_key", "")
     monkeypatch.setitem(doctor.CONFIG, "mimo_asr_api_key", "")
 
     report = doctor.build_report()
 
     assert report["ok"] is False
     assert any("MIMO_API_KEY" in f for f in report["failures"])
+    assert "mimo_credentials" in _capability_names(report, "blocked")
+    assert "default_recap_pipeline" in _capability_names(report, "blocked")
 
 
 def test_doctor_missing_ffmpeg_is_failure(monkeypatch):
@@ -64,18 +78,71 @@ def test_doctor_missing_ffmpeg_is_failure(monkeypatch):
 
     assert report["ok"] is False
     assert any("ffmpeg" in f for f in report["failures"])
+    assert {"ffmpeg", "ffprobe"} <= _capability_names(report, "blocked")
 
 
 def test_doctor_warns_when_asr_unconfigured_but_key_present(monkeypatch):
     """api_key powers VLM/TTS; an empty ASR key is only a warning (use --skip-asr)."""
     _tools_present(monkeypatch)
     monkeypatch.setitem(doctor.CONFIG, "api_key", "tp-x")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_video_api_key", "tp-x")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_tts_api_key", "tp-x")
     monkeypatch.setitem(doctor.CONFIG, "mimo_asr_api_key", "")
 
     report = doctor.build_report()
 
     assert report["ok"] is True
     assert any("ASR not configured" in w for w in report["warnings"])
+    assert "mimo_asr" in _capability_names(report, "warnings/degraded")
+    assert "recap_degraded_mode" in _capability_names(report, "warnings/degraded")
+    assert "default_recap_pipeline" not in _capability_names(report, "ready")
+
+
+def test_doctor_warns_when_subtitle_burn_degraded(monkeypatch):
+    monkeypatch.setattr("doctor._ffmpeg_filters", lambda: {"ass"})
+    monkeypatch.setattr(
+        "doctor._command_path",
+        lambda name: f"/usr/bin/{name}" if name in ("ffmpeg", "ffprobe") else None,
+    )
+    for k in ("api_key", "mimo_asr_api_key", "mimo_tts_api_key", "mimo_video_api_key"):
+        monkeypatch.setitem(doctor.CONFIG, k, "tp-test-key")
+
+    report = doctor.build_report()
+
+    assert report["ok"] is True
+    assert "subtitle_burn" in _capability_names(report, "warnings/degraded")
+    assert "recap_degraded_mode" in _capability_names(report, "warnings/degraded")
+    assert "default_recap_pipeline" not in _capability_names(report, "ready")
+
+
+def test_doctor_blocks_default_pipeline_when_vlm_or_tts_override_missing(monkeypatch):
+    _tools_present(monkeypatch)
+    monkeypatch.setitem(doctor.CONFIG, "api_key", "tp-x")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_asr_api_key", "tp-x")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_video_api_key", "")
+    monkeypatch.setitem(doctor.CONFIG, "mimo_tts_api_key", "")
+
+    report = doctor.build_report()
+
+    assert report["ok"] is True
+    assert {"mimo_vlm", "mimo_tts", "default_recap_pipeline"} <= _capability_names(report, "blocked")
+    assert "default_recap_pipeline" not in _capability_names(report, "ready")
+
+
+def test_doctor_human_output_prints_capability_menu(monkeypatch, capsys):
+    _tools_present(monkeypatch)
+    for k in ("api_key", "mimo_asr_api_key", "mimo_tts_api_key", "mimo_video_api_key"):
+        monkeypatch.setitem(doctor.CONFIG, k, "tp-test-key")
+
+    doctor._print_human(doctor.build_report())
+    out = capsys.readouterr().out
+
+    assert "[capability menu]" in out
+    assert "ready:" in out
+    assert "blocked:" in out
+    assert "warnings/degraded:" in out
+    assert "optional_upgrades:" in out
+    assert "default_recap_pipeline" in out
 
 
 def test_recap_full_mode_passes_explicit_narration_json(monkeypatch, tmp_path):

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -113,6 +113,7 @@ def test_doctor_warns_when_subtitle_burn_degraded(monkeypatch):
     assert "subtitle_burn" in _capability_names(report, "warnings/degraded")
     assert "recap_degraded_mode" in _capability_names(report, "warnings/degraded")
     assert "default_recap_pipeline" not in _capability_names(report, "ready")
+    assert _capability_names(report, "optional_upgrades") == {"jianying_export"}
 
 
 def test_doctor_blocks_default_pipeline_when_vlm_or_tts_override_missing(monkeypatch):
@@ -127,6 +128,16 @@ def test_doctor_blocks_default_pipeline_when_vlm_or_tts_override_missing(monkeyp
     assert report["ok"] is True
     assert {"mimo_vlm", "mimo_tts", "default_recap_pipeline"} <= _capability_names(report, "blocked")
     assert "default_recap_pipeline" not in _capability_names(report, "ready")
+
+
+def test_doctor_optional_upgrades_include_burn_only_when_available(monkeypatch):
+    _tools_present(monkeypatch)
+    for k in ("api_key", "mimo_asr_api_key", "mimo_tts_api_key", "mimo_video_api_key"):
+        monkeypatch.setitem(doctor.CONFIG, k, "tp-test-key")
+
+    report = doctor.build_report()
+
+    assert _capability_names(report, "optional_upgrades") == {"jianying_export", "burned_subtitles"}
 
 
 def test_doctor_human_output_prints_capability_menu(monkeypatch, capsys):


### PR DESCRIPTION
## 概述
两个相互独立的改动，合并到一个 PR：

1. **语速基准校准 + 截断可见**（`fix(narration)`）
2. **doctor 预检能力清单**（`feat(doctor)`）

---

### 1. 语速基准 3.5 → 3.9 + 超时长截断不再静默

**背景**：`speech_rate` 硬编码 `3.5` 字/秒。实测 mimo-tts 冰糖音色 4 段真实渲染的中位语速为 `3.84 / 4.03 / 3.84 / 4.19`——`3.5` 系统性偏低 ~10-17%。后果：

- 给 agent 的字数预算过保守（写得比实际能容纳的更少）；
- 7:3 覆盖率指标用偏低的 rate 计算，误报 `under_narrated`。

**改动**：
- 默认值 `3.5 → 3.9`，并把 `speech_rate` / `speech_safety_margin` 由字面量提升为 `env_float`，支持 `SPEECH_RATE` / `SPEECH_SAFETY_MARGIN` 环境变量覆盖；5 个 `lib.py` 保持一致。
- `voiceover.py`：解说超出片段时长时触发的句末截断此前**完全静默**（毁掉作者写的结尾且无从察觉），现加 `log` 提示截断字数并建议改写。

**行为影响**：默认渲染的字数预算变宽、`under_narrated` 误报减少、over_budget 警告更贴近真实语速；渲染音频本身已有自愈逻辑，不受影响。可用 `SPEECH_RATE` 回退到任意旧值。

### 2. doctor 预检能力清单

在原始机器 `checks` 之上新增 `capability_menu` 汇总，把 ffmpeg/ffprobe、MiMo 凭证、VLM/TTS/ASR、字幕烧录按 **ready / blocked / degraded / optional_upgrades** 分组，并给出每项可执行建议。不安装任何东西、不做 provider 排序、不替换原始 checks；JSON 报告与 human 输出同步新增该字段。

---

## 测试
- `ruff check` 全绿。
- `python3 scripts/test.py` 全部 7 组通过（script / voiceover / understanding / orchestrator / assemble / cut / inspect，共 469 项），含新增 doctor 能力清单测试。
- env 覆盖端到端验证：默认 `speech_rate=3.9`；`SPEECH_RATE=4.2` → `4.2`，`SPEECH_SAFETY_MARGIN=0.9` → `0.9`。

## 范围说明
这是经评审后选定的**精简版**：直接把语速常量改对 + 让静默截断可见。更重的「自学习语速校准回路」（每次渲染产出 `speech_calibration.json` 并回喂）因评审发现其受生产/消费阶段倒置限制、仅对同一 work_dir 重渲生效，性价比低，已**主动延后**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
