### PR TITLE
Release v0.3.2: newer JianYing draft schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,8 @@
 {
   "name": "video-recap-skills",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Turn any video into a Chinese-narration recap on ffmpeg + one Xiaomi MiMo API key: understanding (ASR + VLM) -> narration -> cut -> voiceover -> assemble. A bundle of independent skills + a thin orchestrator. Runs on macOS, Linux, and Windows.",
-  "author": { "name": "PiteChen" }
+  "author": {
+    "name": "PiteChen"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+
+## [0.3.2] - 2026-06-22
+
+让剪映草稿导出跟上新版工程结构，方便在剪映专业版里继续精修。
+
+### 新增
+
+- **新版剪映 schema-driven 草稿导出。** 剪映导出从单文件 JSON 拼装拆成 schema / model / builder / track / writer 分层，草稿基线升级到 `version: 360000`、`new_version: 111.0.0`、`app_version: 5.9.5-beta1`，并补齐包含 `common_mask` 在内的新版 `materials` skeleton。
+- **素材类型注册表与能力清单。** 明确区分已支持的 `video` / `audio` / `text` / `subtitle` / `speed`，以及预留但暂不写出的 image/sticker/effect/mask 等类别；未知或暂不支持类别会输出 note 并跳过，避免生成畸形草稿。
+
+### 改进
+
+- **剪映导出仍保持可选、懒加载、stdlib-only。** `export_jianying.py` 现在只是薄 facade，核心 ffmpeg 渲染路径不会导入任何 `jianying_*` 模块；`timeline.json` 仍是后端无关的 canonical input，ffmpeg 仍是最终成片判定标准。
+- **草稿写入更安全。** 写入器继续保留非空目录避让、媒体打包、路径重写、临时目录原子替换；并新增 `draft_name` 校验，拒绝空名、绝对路径、`..`、以及路径分隔符，防止错误名称逃逸草稿父目录。
+- **BGM 循环与音量自动化覆盖更完整。** 循环 BGM 会拆成多段铺满时间线，并把窗口内 `KFTypeVolume` 音量关键帧放到对应片段。
+
+### 验证
+
+- `ruff` / `py_compile` / `mypy --ignore-missing-imports` 覆盖剪映导出模块；相关 assemble/timeline 测试 84 passed，全项目 `scripts/test.py` 全部 skill groups passed。
+- 本机剪映专业版 `10.8.7` 实测：生成并打开 schema E2E 草稿；又把历史 `longvacation_2min_work/timeline.json` 转成 `recap_tmp_convert_longvacation_2min_20260623_003900`，剪映已登记并可打开。
+
 ## [0.3.0] - 2026-06-20
 
 长视频更稳、跨语言更干净、剪辑更顺眼，并新增解说导航与成片压缩工具。

--- a/README.en.md
+++ b/README.en.md
@@ -38,7 +38,7 @@ flowchart LR
 - **Research when it matters.** When the title/story context is known or the brief notes the material is thin, put character relationships and plot background in `background_research.json` so the VLM knows who's who.
 - **Narration in blocks, original in blocks.** Narration plays in connected blocks, each voiced in one pass; in the gaps, the original audio returns at full volume — roughly 7:3.
 - **Cut first, frames aligned.** `--edit-mode cut` renders the cut first, then you narrate against that timeline, so picture and voice stay in sync.
-- **Keep editing in 剪映.** Optionally export a multi-track 剪映 draft — original, narration, BGM, and subtitles each on a track.
+- **Keep editing in 剪映.** Optionally export a schema-driven multi-track 剪映 draft — original, narration, BGM, and subtitles each on a track; ffmpeg remains the canonical render.
 
 ## Installation
 
@@ -138,6 +138,7 @@ Priority: **your file › the agent-proofread `original_subtitles.json` › ASR 
 
 - [linux.do](https://linux.do)
 - The 剪映 draft export follows the schema of [pyJianYingDraft](https://github.com/GuanYixuan/pyJianYingDraft) and [capcut-mate](https://github.com/Hommy-master/capcut-mate) (both Apache-2.0).
+- The schema / builder / writer split for 剪映 export is inspired by [duoec/duo-video](https://github.com/duoec/duo-video).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ flowchart LR
 - **该查资料时先查。** 片名/剧情明确或 brief 提示素材偏薄时，把人物关系、剧情背景存进 `background_research.json`，VLM 才更容易认出谁是谁。
 - **解说成块，原声也成块。** 解说一段段连着讲、整块一次配音，段间留白把精彩原声整段放回满音量——大致七三开。
 - **先剪后配，画面对齐。** `--edit-mode cut` 先把长视频剪成成片，再对着成片写解说，时间轴天然对齐。
-- **能接着在剪映里改。** 可选导出多轨剪映草稿，原片、解说、BGM、字幕各占一轨。
+- **能接着在剪映里改。** 可选导出 schema-driven 的多轨剪映草稿，原片、解说、BGM、字幕各占一轨；ffmpeg 仍是最终成片的判定标准。
 
 ## 安装
 
@@ -138,6 +138,7 @@ python3 skills/video-recap/scripts/recap.py --doctor
 
 - [linux.do](https://linux.do)
 - 剪映草稿导出参考了 [pyJianYingDraft](https://github.com/GuanYixuan/pyJianYingDraft)、[capcut-mate](https://github.com/Hommy-master/capcut-mate)（均 Apache-2.0）的草稿结构。
+- 剪映导出的 schema / builder / writer 分层参考了 [duoec/duo-video](https://github.com/duoec/duo-video) 的设计思路。
 
 ## 许可
 

--- a/skills/video-assemble/scripts/export_jianying.py
+++ b/skills/video-assemble/scripts/export_jianying.py
@@ -6,10 +6,12 @@ desktop app can open and the user can keep editing: video clips on the main trac
 the narration and BGM as their own audio tracks, the recap lines as a subtitle
 track, and the gap-fill ducking carried as native volume keyframes.
 
-This module is **optional and self-contained**. The core ffmpeg render never
-imports it; it is only loaded when an export is explicitly requested. Nothing in
-the rest of the bundle depends on it, and 剪映 does not need to be installed to
-produce (or test) a draft.
+The public entrypoints stay small (`build_draft`, `export_timeline_to_jianying`,
+`_us`, CLI). Internally the exporter is split into schema/templates, a thin
+normalized build context, material/segment builders, track layout metadata, and
+a safe writer/bundler. This mirrors the useful schema boundaries from duo-video
+while ffmpeg remains the canonical renderer and JianYing export remains an
+optional sidecar.
 
 Schema and the draft skeleton are reimplemented from the open-source
 pyJianYingDraft (© GuanYixuan, Apache-2.0) and capcut-mate (© Hommy, Apache-2.0);
@@ -18,26 +20,17 @@ draft JSON is built directly here so the bundle stays stdlib-only.
 """
 
 import json
-import os
-import shutil
 import subprocess
-import tempfile
 import uuid
 
-DRAFT_VERSION = 360000
-NEW_VERSION = "110.0.0"
-APP = {"app_id": 3704, "app_source": "lv", "app_version": "5.9.0", "os": "mac"}
+from jianying_builders import build_timeline_track as _build_timeline_track
+from jianying_model import DraftBuildContext as _DraftBuildContext
+from jianying_schema import draft_content_skeleton as _draft_content_skeleton
+from jianying_schema import meta_info as _meta_info
+from jianying_schema import us as _us
+from jianying_writer import write_draft as _write_draft
 
-# render_index layering: main video at 0, audio tracks above it, subtitles on top.
-RI_VIDEO = 0
-RI_NARRATION = 1
-RI_BGM = 2
-RI_TEXT = 15000  # 剪映's text-track render_index band; keeps subtitles above all media
-
-
-def _us(seconds):
-    """Seconds (float) -> integer microseconds. The single seconds->µs boundary."""
-    return int(round(float(seconds) * 1_000_000))
+__all__ = ["_us", "build_draft", "export_timeline_to_jianying", "main"]
 
 
 def _default_id():
@@ -48,412 +41,47 @@ def _probe_media(path):
     """Return (duration_us, width, height) via ffprobe; zeros on any failure."""
     try:
         r = subprocess.run(
-            ["ffprobe", "-v", "error", "-of", "json",
-             "-show_entries", "format=duration:stream=width,height,codec_type", str(path)],
-            capture_output=True, text=True, timeout=30)
+            [
+                "ffprobe", "-v", "error", "-of", "json",
+                "-show_entries", "format=duration:stream=width,height,codec_type", str(path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
         data = json.loads(r.stdout or "{}")
         dur_us = _us(float(data.get("format", {}).get("duration") or 0))
-        w = h = 0
-        for s in data.get("streams", []):
-            if s.get("codec_type") == "video":
-                w, h = int(s.get("width") or 0), int(s.get("height") or 0)
+        width = height = 0
+        for stream in data.get("streams", []):
+            if stream.get("codec_type") == "video":
+                width, height = int(stream.get("width") or 0), int(stream.get("height") or 0)
                 break
-        return dur_us, w, h
+        return dur_us, width, height
     except (OSError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired):
         return 0, 0, 0
 
 
-def _timerange(start_us, dur_us):
-    return {"start": int(start_us), "duration": int(dur_us)}
-
-
-def _speed_material(new_id):
-    return {"id": new_id(), "speed": 1.0, "type": "speed", "mode": 0, "curve_speed": None}
-
-
-def _volume_keyframes(keyframes, seg_start_s, new_id):
-    """One KFTypeVolume keyframe list from timeline-absolute [{t,gain}] points,
-    re-based to microseconds relative to the segment start. Empty list -> no entry."""
-    if not keyframes:
-        return []
-    kfs = []
-    for kf in keyframes:
-        kfs.append({
-            "curveType": "Line", "graphID": "",
-            "left_control": {"x": 0.0, "y": 0.0},
-            "right_control": {"x": 0.0, "y": 0.0},
-            "id": new_id(),
-            "time_offset": max(0, _us(kf["t"] - seg_start_s)),
-            "values": [round(float(kf["gain"]), 4)],
-        })
-    return [{"id": new_id(), "keyframe_list": kfs, "material_id": "",
-             "property_type": "KFTypeVolume"}]
-
-
-def _windowed_volume_keyframes(keyframes, seg_start_s, seg_end_s, default_gain, new_id):
-    """Keyframes that affect one split segment, without leaking earlier beats.
-
-    The timeline stores absolute keyframes. When a looped BGM bed is split into
-    several JianYing segments, each piece must receive only the automation for
-    its target window. If a duck spans a piece boundary, seed the piece with the
-    gain active at its start; otherwise leave flat/default pieces keyframe-free.
-    """
-    if not keyframes:
-        return []
-    start = float(seg_start_s)
-    end = float(seg_end_s)
-    default_gain = float(default_gain)
-    ordered = sorted((
-        {"t": float(kf["t"]), "gain": float(kf["gain"])}
-        for kf in keyframes
-        if "t" in kf and "gain" in kf
-    ), key=lambda kf: kf["t"])
-    if not ordered or end <= start:
-        return []
-
-    start_gain = default_gain
-    for kf in ordered:
-        if kf["t"] <= start:
-            start_gain = kf["gain"]
-        else:
-            break
-    inner = [kf for kf in ordered if start <= kf["t"] <= end]
-    if not inner and abs(start_gain - default_gain) < 1e-4:
-        return []
-
-    selected = [{"t": start, "gain": start_gain}]
-    for kf in inner:
-        if abs(kf["t"] - start) < 1e-4:
-            selected[-1] = {"t": start, "gain": kf["gain"]}
-        else:
-            selected.append(kf)
-    if all(abs(kf["gain"] - default_gain) < 1e-4 for kf in selected):
-        return []
-    return _volume_keyframes(selected, start, new_id)
-
-
-def _base_segment(material_id, target_start_us, target_dur_us, render_index,
-                  volume, keyframes, new_id):
-    return {
-        "enable_adjust": True, "enable_color_correct_adjust": False,
-        "enable_color_curves": True, "enable_color_match_adjust": False,
-        "enable_color_wheels": True, "enable_lut": True,
-        "enable_smart_color_adjust": False,
-        "last_nonzero_volume": 1.0, "reverse": False,
-        "track_attribute": 0, "track_render_index": 0, "visible": True,
-        "id": new_id(), "material_id": material_id,
-        "target_timerange": _timerange(target_start_us, target_dur_us),
-        "common_keyframes": keyframes, "keyframe_refs": [],
-        "speed": 1.0, "volume": round(float(volume), 4),
-        "is_tone_modify": False, "render_index": render_index,
-    }
-
-
-def _audio_segment_piece(material_id, target_start_us, target_dur_us, source_start_us,
-                         source_dur_us, render_index, volume, keyframes, new_id):
-    seg = _base_segment(material_id, target_start_us, target_dur_us, render_index,
-                        volume, keyframes, new_id)
-    seg["source_timerange"] = _timerange(source_start_us, source_dur_us)
-    seg["extra_material_refs"] = []
-    seg["clip"] = None
-    seg["hdr_settings"] = None
-    return seg
-
-
-def _clip_default():
-    return {"alpha": 1.0, "flip": {"horizontal": False, "vertical": False},
-            "rotation": 0.0, "scale": {"x": 1.0, "y": 1.0},
-            "transform": {"x": 0.0, "y": 0.0}}
-
-
 def build_draft(timeline, new_id=None, probe=None):
-    """Build the 剪映 draft_content dict (and its companion meta) from a timeline."""
+    """Build the 剪映 draft_content dict and companion meta from a timeline."""
     new_id = new_id or _default_id
     probe = probe or _probe_media
+    ctx = _DraftBuildContext.from_timeline(timeline, new_id, probe)
 
-    canvas = timeline.get("canvas", {})
-    width = int(canvas.get("width", 1920))
-    height = int(canvas.get("height", 1080))
-    fps = float(canvas.get("fps", 30))
-    total_us = _us(timeline.get("duration", 0))
-
-    materials = {"videos": [], "audios": [], "texts": [], "speeds": []}
-    tracks = []
-    notes = []
-
-    def media_dur(path, fallback_us):
-        if path and os.path.exists(path):
-            d, w, h = probe(path)
-            return d or fallback_us, w, h
-        return fallback_us, 0, 0
-
-    for track in timeline.get("tracks", []):
-        kind = track.get("kind")
-        # skip empty audio/text tracks — some 剪映 versions dislike zero-segment tracks
-        if kind in ("audio", "text") and not track.get("segments"):
-            continue
-
-        if kind == "video":
-            segs = []
-            for clip in track.get("clips", []):
-                ts, te = float(clip["timeline_start"]), float(clip["timeline_end"])
-                ss, se = float(clip["source_start"]), float(clip["source_end"])
-                path = clip["source_path"]
-                src_dur_us, w, h = media_dur(path, _us(se))
-                mat_id = new_id()
-                materials["videos"].append({
-                    "audio_fade": None, "category_id": "", "category_name": "local",
-                    "check_flag": 63487, "crop": {
-                        "upper_left_x": 0.0, "upper_left_y": 0.0,
-                        "upper_right_x": 1.0, "upper_right_y": 0.0,
-                        "lower_left_x": 0.0, "lower_left_y": 1.0,
-                        "lower_right_x": 1.0, "lower_right_y": 1.0},
-                    "crop_ratio": "free", "crop_scale": 1.0,
-                    "duration": int(src_dur_us), "height": h or height,
-                    "id": mat_id, "local_material_id": mat_id, "material_id": mat_id,
-                    "material_name": os.path.basename(path), "media_path": "",
-                    "path": path, "type": "video", "width": w or width})
-                speed = _speed_material(new_id)
-                materials["speeds"].append(speed)
-                audio = clip.get("audio", {})
-                vol = audio.get("base_gain", 1.0) if not audio.get("volume_keyframes") else 1.0
-                seg = _base_segment(mat_id, _us(ts), _us(te - ts), RI_VIDEO, vol,
-                                    _volume_keyframes(audio.get("volume_keyframes"), ts, new_id),
-                                    new_id)
-                seg["source_timerange"] = _timerange(_us(ss), _us(se - ss))
-                seg["extra_material_refs"] = [speed["id"]]
-                seg["clip"] = _clip_default()
-                seg["uniform_scale"] = {"on": True, "value": 1.0}
-                seg["hdr_settings"] = {"intensity": 1.0, "mode": 1, "nits": 1000}
-                segs.append(seg)
-            tracks.append({"attribute": 0, "flag": 0, "id": new_id(),
-                           "is_default_name": False, "name": "video",
-                           "segments": segs, "type": "video"})
-
-        elif kind == "audio":
-            role = track.get("role", track.get("name", "audio"))
-            ri = RI_BGM if role == "bgm" else RI_NARRATION
-            segs = []
-            for s in track.get("segments", []):
-                ts, te = float(s["timeline_start"]), float(s["timeline_end"])
-                path = s["source_path"]
-                mat_dur_us, _w, _h = media_dur(path, _us(te - ts))
-                # a single audio segment cannot exceed its material; clamp (loop is left to the editor)
-                want_us = _us(te - ts)
-                place_us = want_us
-                if mat_dur_us and want_us > mat_dur_us:
-                    if role == "bgm" and track.get("loop"):
-                        place_us = want_us
-                    else:
-                        place_us = mat_dur_us
-                    if role == "bgm" and not track.get("loop"):  # looping a bed matters; a beat clamp is sub-frame rounding
-                        notes.append(f"BGM 素材({mat_dur_us/1e6:.1f}s) 短于时间线({(te - ts):.1f}s)，剪映中未循环铺满（可在剪映里手动复制延长）")
-                mat_id = new_id()
-                materials["audios"].append({
-                    "app_id": 0, "category_id": "", "category_name": "local",
-                    "check_flag": 3, "copyright_limit_type": "none",
-                    "duration": int(mat_dur_us or want_us), "effect_id": "",
-                    "formula_id": "", "id": mat_id, "local_material_id": mat_id,
-                    "music_id": mat_id, "name": os.path.basename(path), "path": path,
-                    "source_platform": 0, "type": "extract_music", "wave_points": []})
-                kfs = _volume_keyframes(s.get("volume_keyframes"), ts, new_id)
-                vol = s.get("gain", 1.0) if not kfs else 1.0
-                if role == "bgm" and track.get("loop") and mat_dur_us and want_us > mat_dur_us:
-                    cursor = 0
-                    while cursor < want_us:
-                        piece = min(mat_dur_us, want_us - cursor)
-                        if piece <= 0:
-                            break
-                        piece_start_s = ts + (cursor / 1_000_000)
-                        piece_end_s = ts + ((cursor + piece) / 1_000_000)
-                        speed = _speed_material(new_id)
-                        materials["speeds"].append(speed)
-                        piece_kfs = _windowed_volume_keyframes(
-                            s.get("volume_keyframes"), piece_start_s, piece_end_s,
-                            s.get("gain", 1.0), new_id)
-                        piece_vol = s.get("gain", 1.0) if not piece_kfs else 1.0
-                        seg = _audio_segment_piece(
-                            mat_id, _us(ts) + cursor, piece, 0, piece, ri, piece_vol, piece_kfs, new_id)
-                        seg["extra_material_refs"] = [speed["id"]]
-                        segs.append(seg)
-                        cursor += piece
-                else:
-                    speed = _speed_material(new_id)
-                    materials["speeds"].append(speed)
-                    seg = _audio_segment_piece(
-                        mat_id, _us(ts), place_us, 0, place_us, ri, vol, kfs, new_id)
-                    seg["extra_material_refs"] = [speed["id"]]
-                    segs.append(seg)
-            tracks.append({"attribute": 0, "flag": 0, "id": new_id(),
-                           "is_default_name": False, "name": role,
-                           "segments": segs, "type": "audio"})
-
-        elif kind == "text":
-            segs = []
-            for s in track.get("segments", []):
-                ts, te = float(s["timeline_start"]), float(s["timeline_end"])
-                text = s.get("text", "")
-                mat_id = new_id()
-                content = {"text": text, "styles": [{
-                    "fill": {"alpha": 1.0, "content": {"render_type": "solid",
-                             "solid": {"alpha": 1.0, "color": [1.0, 1.0, 1.0]}}},
-                    "range": [0, len(text.encode("utf-16-le")) // 2],
-                    "size": 8.0, "bold": False, "italic": False,
-                    "underline": False, "strokes": []}]}
-                materials["texts"].append({
-                    "id": mat_id, "content": json.dumps(content, ensure_ascii=False),
-                    "type": "text", "typesetting": 0,
-                    "alignment": 1, "letter_spacing": 0.0, "line_spacing": 0.02,
-                    "font_size": 8.0, "text_color": "#FFFFFF", "add_type": 0,
-                    "check_flag": 7})
-                seg = _base_segment(mat_id, _us(ts), _us(te - ts), RI_TEXT, 1.0, [], new_id)
-                seg["source_timerange"] = None
-                seg["extra_material_refs"] = []
-                seg["clip"] = _clip_default()
-                seg["uniform_scale"] = {"on": True, "value": 1.0}
-                seg["type"] = "text_effect"
-                seg["source_platform"] = 1
-                # nudge subtitles to the lower third
-                seg["clip"]["transform"]["y"] = -0.72
-                segs.append(seg)
-            tracks.append({"attribute": 0, "flag": 0, "id": new_id(),
-                           "is_default_name": False, "name": "subtitle",
-                           "segments": segs, "type": "text"})
+    for timeline_track in timeline.get("tracks", []):
+        _build_timeline_track(ctx, timeline_track)
 
     draft_id = new_id()
-    content = {
-        "canvas_config": {"width": width, "height": height, "ratio": "original"},
-        "color_space": 0,
-        "config": {"adjust_max_index": 1, "attachment_info": [], "combination_max_index": 1,
-                   "export_range": None, "extract_audio_last_index": 1,
-                   "lyrics_recognition_id": "", "lyrics_sync": True, "lyrics_taskinfo": [],
-                   "maintrack_adsorb": True, "material_save_mode": 0,
-                   "multi_language_current": "none", "multi_language_list": [],
-                   "multi_language_main": "none", "multi_language_mode": "none",
-                   "original_sound_last_index": 1, "record_audio_last_index": 1,
-                   "sticker_max_index": 1, "subtitle_keywords_config": None,
-                   "subtitle_recognition_id": "", "subtitle_sync": True,
-                   "subtitle_taskinfo": [], "system_font_list": [], "video_mute": False,
-                   "zoom_info_params": None},
-        "cover": None, "create_time": 0, "duration": int(total_us), "extra_info": None,
-        "fps": fps, "free_render_index_mode_on": False, "group_container": None,
-        "id": draft_id, "keyframe_graph_list": [],
-        "keyframes": {"adjusts": [], "audios": [], "effects": [], "filters": [],
-                      "handwrites": [], "stickers": [], "texts": [], "videos": []},
-        "last_modified_platform": dict(APP), "platform": dict(APP),
-        "materials": _full_materials(materials),
-        "mutable_config": None, "name": "", "new_version": NEW_VERSION,
-        "relationships": [], "render_index_track_mode_on": False, "retouch_cover": None,
-        "source": "default", "static_cover_image_path": "", "time_marks": None,
-        "tracks": tracks, "update_time": 0, "version": DRAFT_VERSION,
-    }
-    meta = _meta_info(draft_id, total_us)
-    return content, meta, notes
-
-
-# the full 剪映 materials object: ~45 parallel arrays, only four of which we fill
-_MATERIAL_KEYS = (
-    "ai_translates audio_balances audio_effects audio_fades audio_track_indexes audios "
-    "beats canvases chromas color_curves digital_humans drafts effects flowers green_screens "
-    "handwrites hsl images log_color_wheels loudnesses manual_deformations masks "
-    "material_animations material_colors multi_language_refs placeholders plugin_effects "
-    "primary_color_wheels realtime_denoises shapes smart_crops smart_relights "
-    "sound_channel_mappings speeds stickers tail_leaders text_templates texts time_marks "
-    "transitions video_effects video_trackings videos vocal_beautifys vocal_separations"
-).split()
-
-
-def _full_materials(filled):
-    out = {k: [] for k in _MATERIAL_KEYS}
-    out.update(filled)
-    return out
-
-
-def _meta_info(draft_id, total_us):
-    return {
-        "cloud_package_completed_time": "", "draft_cloud_capcut_purchase_info": "",
-        "draft_cloud_last_action_download": False, "draft_cloud_materials": [],
-        "draft_cloud_purchase_info": "", "draft_cloud_template_id": "",
-        "draft_cloud_tutorial_info": "", "draft_cloud_videocut_purchase_info": "",
-        "draft_cover": "", "draft_deeplink_url": "",
-        "draft_enterprise_info": {"draft_enterprise_extra": "", "draft_enterprise_id": "",
-                                  "draft_enterprise_name": "", "enterprise_material": []},
-        "draft_fold_path": "", "draft_id": draft_id, "draft_is_ai_packaging_used": False,
-        "draft_is_ai_shorts": False, "draft_is_ai_translate": False,
-        "draft_is_article_video_draft": False, "draft_is_from_deeplink": "false",
-        "draft_is_invisible": False,
-        "draft_materials": [{"type": t, "value": []} for t in (0, 1, 2, 3, 6, 7, 8)],
-        "draft_materials_copied_info": [], "draft_name": "", "draft_new_version": "",
-        "draft_removable_storage_device": "", "draft_root_path": "",
-        "draft_segment_extra_info": [], "draft_type": "", "tm_draft_cloud_completed": "",
-        "tm_draft_cloud_modified": 0, "tm_draft_removed": 0, "tm_duration": int(total_us),
-    }
-
-
-def _bundle_media(content, draft_dir):
-    """Copy every referenced media file into <draft_dir>/materials/ and rewrite the
-    material paths to the copies, so the draft folder is self-contained and portable
-    (move/zip it to any 剪映 machine; media sits right next to the JSON for relink)."""
-    mats_dir = os.path.join(draft_dir, "materials")
-    os.makedirs(mats_dir, exist_ok=True)
-    copied, used, notes = {}, set(), []
-    for arr in (content["materials"]["videos"], content["materials"]["audios"]):
-        for m in arr:
-            src = m.get("path")
-            if not src:
-                continue
-            if src in copied:
-                m["path"] = copied[src]
-                continue
-            if not os.path.exists(src):
-                notes.append(f"素材缺失，未打包: {src}")
-                continue
-            base = os.path.basename(src)
-            name, stem_ext = base, os.path.splitext(base)
-            i = 1
-            while name in used:
-                name = f"{stem_ext[0]}_{i}{stem_ext[1]}"
-                i += 1
-            used.add(name)
-            dest = os.path.join(mats_dir, name)
-            shutil.copy2(src, dest)
-            copied[src] = dest
-            m["path"] = dest
-    return notes
-
-
-def _draft_dir_has_user_content(draft_dir):
-    """Return True when writing here could overwrite an existing draft/material."""
-    if not os.path.exists(draft_dir):
-        return False
-    try:
-        return any(os.scandir(draft_dir))
-    except OSError:
-        return True
-
-
-def _collision_safe_draft_dir(out_dir, draft_name):
-    """Pick a fresh draft folder instead of overwriting an existing non-empty one."""
-    base = os.path.join(out_dir, draft_name)
-    if not _draft_dir_has_user_content(base):
-        return base, draft_name
-    idx = 2
-    while True:
-        candidate_name = f"{draft_name}_{idx}"
-        candidate = os.path.join(out_dir, candidate_name)
-        if not _draft_dir_has_user_content(candidate):
-            return candidate, candidate_name
-        idx += 1
-
-
-def _rewrite_material_prefix(content, old_prefix, new_prefix):
-    old_prefix = os.path.abspath(old_prefix)
-    new_prefix = os.path.abspath(new_prefix)
-    for arr in (content["materials"]["videos"], content["materials"]["audios"]):
-        for material in arr:
-            path = material.get("path")
-            if path and os.path.abspath(path).startswith(old_prefix + os.sep):
-                material["path"] = new_prefix + os.path.abspath(path)[len(old_prefix):]
+    content = _draft_content_skeleton(
+        draft_id,
+        ctx.width,
+        ctx.height,
+        ctx.fps,
+        ctx.total_us,
+        ctx.materials,
+        ctx.tracks,
+    )
+    meta = _meta_info(draft_id, ctx.total_us)
+    return content, meta, ctx.notes
 
 
 def export_timeline_to_jianying(timeline, out_dir, draft_name="recap", new_id=None,
@@ -461,40 +89,10 @@ def export_timeline_to_jianying(timeline, out_dir, draft_name="recap", new_id=No
     """Write a 剪映 draft folder under out_dir/draft_name. Returns (folder, notes).
 
     bundle_media=True copies the referenced media into the draft folder so it is
-    self-contained and portable to another machine."""
+    self-contained and portable to another machine.
+    """
     content, meta, notes = build_draft(timeline, new_id=new_id, probe=probe)
-    out_dir = os.path.abspath(out_dir)
-    os.makedirs(out_dir, exist_ok=True)
-    draft_dir, actual_name = _collision_safe_draft_dir(out_dir, draft_name)
-    if actual_name != draft_name:
-        notes.append(f"草稿目录已存在，改写为 {actual_name} 以避免覆盖")
-
-    tmp_parent = tempfile.mkdtemp(prefix=f".{actual_name}.", dir=out_dir)
-    tmp_dir = os.path.join(tmp_parent, actual_name)
-    try:
-        os.makedirs(tmp_dir, exist_ok=False)
-        if bundle_media:
-            notes = notes + _bundle_media(content, tmp_dir)
-            _rewrite_material_prefix(content, tmp_dir, draft_dir)
-        meta["draft_name"] = actual_name
-        meta["draft_fold_path"] = draft_dir
-        content["name"] = actual_name
-        # write both filenames for cross-version compatibility (5.9 reads draft_info.json)
-        for fname in ("draft_content.json", "draft_info.json"):
-            with open(os.path.join(tmp_dir, fname), "w", encoding="utf-8") as f:
-                json.dump(content, f, ensure_ascii=False, indent=2)
-        with open(os.path.join(tmp_dir, "draft_meta_info.json"), "w", encoding="utf-8") as f:
-            json.dump(meta, f, ensure_ascii=False, indent=2)
-        if os.path.isdir(draft_dir) and not _draft_dir_has_user_content(draft_dir):
-            os.rmdir(draft_dir)
-        os.replace(tmp_dir, draft_dir)
-    except Exception:
-        shutil.rmtree(tmp_parent, ignore_errors=True)
-        raise
-    finally:
-        if os.path.exists(tmp_parent):
-            shutil.rmtree(tmp_parent, ignore_errors=True)
-    return draft_dir, notes
+    return _write_draft(content, meta, notes, out_dir, draft_name, bundle_media_enabled=bundle_media)
 
 
 def main():
@@ -508,10 +106,14 @@ def main():
     args = ap.parse_args()
     with open(args.timeline, encoding="utf-8") as f:
         timeline = json.load(f)
-    draft_dir, notes = export_timeline_to_jianying(timeline, args.out_dir, args.name,
-                                                   bundle_media=args.bundle_media)
-    for n in notes:
-        print(f"  注意: {n}")
+    draft_dir, notes = export_timeline_to_jianying(
+        timeline,
+        args.out_dir,
+        args.name,
+        bundle_media=args.bundle_media,
+    )
+    for note in notes:
+        print(f"  注意: {note}")
     print(json.dumps({"status": "exported", "draft_dir": draft_dir}, ensure_ascii=False))
 
 

--- a/skills/video-assemble/scripts/jianying_builders.py
+++ b/skills/video-assemble/scripts/jianying_builders.py
@@ -1,0 +1,320 @@
+"""Material and segment builders for the milestone-1 JianYing exporter."""
+
+import json
+import os
+
+from jianying_schema import us, validate_material_category
+from jianying_tracks import RI_BGM, RI_NARRATION, RI_TEXT, RI_VIDEO
+
+
+def timerange(start_us, dur_us):
+    return {"start": int(start_us), "duration": int(dur_us)}
+
+
+def speed_material(new_id):
+    return {"id": new_id(), "speed": 1.0, "type": "speed", "mode": 0, "curve_speed": None}
+
+
+def volume_keyframes(keyframes, seg_start_s, new_id):
+    """Build one KFTypeVolume keyframe list from timeline-absolute points."""
+    if not keyframes:
+        return []
+    kfs = []
+    for kf in keyframes:
+        kfs.append({
+            "curveType": "Line",
+            "graphID": "",
+            "left_control": {"x": 0.0, "y": 0.0},
+            "right_control": {"x": 0.0, "y": 0.0},
+            "id": new_id(),
+            "time_offset": max(0, us(kf["t"] - seg_start_s)),
+            "values": [round(float(kf["gain"]), 4)],
+        })
+    return [{
+        "id": new_id(),
+        "keyframe_list": kfs,
+        "material_id": "",
+        "property_type": "KFTypeVolume",
+    }]
+
+
+def windowed_volume_keyframes(keyframes, seg_start_s, seg_end_s, default_gain, new_id):
+    """Window timeline-absolute keyframes for one split/looped segment."""
+    if not keyframes:
+        return []
+    start = float(seg_start_s)
+    end = float(seg_end_s)
+    default_gain = float(default_gain)
+    ordered = sorted((
+        {"t": float(kf["t"]), "gain": float(kf["gain"])}
+        for kf in keyframes
+        if "t" in kf and "gain" in kf
+    ), key=lambda kf: kf["t"])
+    if not ordered or end <= start:
+        return []
+
+    start_gain = default_gain
+    for kf in ordered:
+        if kf["t"] <= start:
+            start_gain = kf["gain"]
+        else:
+            break
+    inner = [kf for kf in ordered if start <= kf["t"] <= end]
+    if not inner and abs(start_gain - default_gain) < 1e-4:
+        return []
+
+    selected = [{"t": start, "gain": start_gain}]
+    for kf in inner:
+        if abs(kf["t"] - start) < 1e-4:
+            selected[-1] = {"t": start, "gain": kf["gain"]}
+        else:
+            selected.append(kf)
+    if all(abs(kf["gain"] - default_gain) < 1e-4 for kf in selected):
+        return []
+    return volume_keyframes(selected, start, new_id)
+
+
+def clip_default():
+    return {
+        "alpha": 1.0,
+        "flip": {"horizontal": False, "vertical": False},
+        "rotation": 0.0,
+        "scale": {"x": 1.0, "y": 1.0},
+        "transform": {"x": 0.0, "y": 0.0},
+    }
+
+
+def base_segment(material_id, target_start_us, target_dur_us, render_index, volume, keyframes, new_id):
+    return {
+        "enable_adjust": True,
+        "enable_color_correct_adjust": False,
+        "enable_color_curves": True,
+        "enable_color_match_adjust": False,
+        "enable_color_wheels": True,
+        "enable_lut": True,
+        "enable_smart_color_adjust": False,
+        "last_nonzero_volume": 1.0,
+        "reverse": False,
+        "track_attribute": 0,
+        "track_render_index": 0,
+        "visible": True,
+        "id": new_id(),
+        "material_id": material_id,
+        "target_timerange": timerange(target_start_us, target_dur_us),
+        "common_keyframes": keyframes,
+        "keyframe_refs": [],
+        "speed": 1.0,
+        "volume": round(float(volume), 4),
+        "is_tone_modify": False,
+        "render_index": render_index,
+    }
+
+
+def audio_segment_piece(material_id, target_start_us, target_dur_us, source_start_us,
+                        source_dur_us, render_index, volume, keyframes, new_id):
+    seg = base_segment(material_id, target_start_us, target_dur_us, render_index, volume, keyframes, new_id)
+    seg["source_timerange"] = timerange(source_start_us, source_dur_us)
+    seg["extra_material_refs"] = []
+    seg["clip"] = None
+    seg["hdr_settings"] = None
+    return seg
+
+
+def track(name, track_type, segments, new_id):
+    return {
+        "attribute": 0,
+        "flag": 0,
+        "id": new_id(),
+        "is_default_name": False,
+        "name": name,
+        "segments": segments,
+        "type": track_type,
+    }
+
+
+def unsupported_track_note(kind):
+    info = validate_material_category(kind)
+    if info["supported"]:
+        return None
+    return info.get("note")
+
+
+def build_video_track(ctx, timeline_track):
+    segs = []
+    for clip in timeline_track.get("clips", []):
+        ts, te = float(clip["timeline_start"]), float(clip["timeline_end"])
+        ss, se = float(clip["source_start"]), float(clip["source_end"])
+        path = clip["source_path"]
+        src_dur_us, width, height = ctx.media_duration(path, us(se))
+        mat_id = ctx.new_id()
+        ctx.materials["videos"].append({
+            "audio_fade": None,
+            "category_id": "",
+            "category_name": "local",
+            "check_flag": 63487,
+            "crop": {
+                "upper_left_x": 0.0,
+                "upper_left_y": 0.0,
+                "upper_right_x": 1.0,
+                "upper_right_y": 0.0,
+                "lower_left_x": 0.0,
+                "lower_left_y": 1.0,
+                "lower_right_x": 1.0,
+                "lower_right_y": 1.0,
+            },
+            "crop_ratio": "free",
+            "crop_scale": 1.0,
+            "duration": int(src_dur_us),
+            "height": height or ctx.height,
+            "id": mat_id,
+            "local_material_id": mat_id,
+            "material_id": mat_id,
+            "material_name": os.path.basename(path),
+            "media_path": "",
+            "path": path,
+            "type": "video",
+            "width": width or ctx.width,
+        })
+        speed = speed_material(ctx.new_id)
+        ctx.materials["speeds"].append(speed)
+        audio = clip.get("audio", {})
+        keyframes = volume_keyframes(audio.get("volume_keyframes"), ts, ctx.new_id)
+        volume = audio.get("base_gain", 1.0) if not keyframes else 1.0
+        seg = base_segment(mat_id, us(ts), us(te - ts), RI_VIDEO, volume, keyframes, ctx.new_id)
+        seg["source_timerange"] = timerange(us(ss), us(se - ss))
+        seg["extra_material_refs"] = [speed["id"]]
+        seg["clip"] = clip_default()
+        seg["uniform_scale"] = {"on": True, "value": 1.0}
+        seg["hdr_settings"] = {"intensity": 1.0, "mode": 1, "nits": 1000}
+        segs.append(seg)
+    ctx.tracks.append(track("video", "video", segs, ctx.new_id))
+
+
+def build_audio_track(ctx, timeline_track):
+    role = timeline_track.get("role", timeline_track.get("name", "audio"))
+    render_index = RI_BGM if role == "bgm" else RI_NARRATION
+    segs = []
+    for segment in timeline_track.get("segments", []):
+        ts, te = float(segment["timeline_start"]), float(segment["timeline_end"])
+        path = segment["source_path"]
+        mat_dur_us, _width, _height = ctx.media_duration(path, us(te - ts))
+        want_us = us(te - ts)
+        place_us = want_us
+        if mat_dur_us and want_us > mat_dur_us:
+            if role == "bgm" and timeline_track.get("loop"):
+                place_us = want_us
+            else:
+                place_us = mat_dur_us
+            if role == "bgm" and not timeline_track.get("loop"):
+                ctx.note(
+                    f"BGM 素材({mat_dur_us/1e6:.1f}s) 短于时间线({(te - ts):.1f}s)，"
+                    "剪映中未循环铺满（可在剪映里手动复制延长）"
+                )
+        mat_id = ctx.new_id()
+        ctx.materials["audios"].append({
+            "app_id": 0,
+            "category_id": "",
+            "category_name": "local",
+            "check_flag": 3,
+            "copyright_limit_type": "none",
+            "duration": int(mat_dur_us or want_us),
+            "effect_id": "",
+            "formula_id": "",
+            "id": mat_id,
+            "local_material_id": mat_id,
+            "music_id": mat_id,
+            "name": os.path.basename(path),
+            "path": path,
+            "source_platform": 0,
+            "type": "extract_music",
+            "wave_points": [],
+        })
+        keyframes = volume_keyframes(segment.get("volume_keyframes"), ts, ctx.new_id)
+        volume = segment.get("gain", 1.0) if not keyframes else 1.0
+        if role == "bgm" and timeline_track.get("loop") and mat_dur_us and want_us > mat_dur_us:
+            cursor = 0
+            while cursor < want_us:
+                piece = min(mat_dur_us, want_us - cursor)
+                if piece <= 0:
+                    break
+                piece_start_s = ts + (cursor / 1_000_000)
+                piece_end_s = ts + ((cursor + piece) / 1_000_000)
+                speed = speed_material(ctx.new_id)
+                ctx.materials["speeds"].append(speed)
+                piece_kfs = windowed_volume_keyframes(
+                    segment.get("volume_keyframes"), piece_start_s, piece_end_s,
+                    segment.get("gain", 1.0), ctx.new_id)
+                piece_volume = segment.get("gain", 1.0) if not piece_kfs else 1.0
+                piece_seg = audio_segment_piece(
+                    mat_id, us(ts) + cursor, piece, 0, piece, render_index,
+                    piece_volume, piece_kfs, ctx.new_id)
+                piece_seg["extra_material_refs"] = [speed["id"]]
+                segs.append(piece_seg)
+                cursor += piece
+        else:
+            speed = speed_material(ctx.new_id)
+            ctx.materials["speeds"].append(speed)
+            audio_seg = audio_segment_piece(
+                mat_id, us(ts), place_us, 0, place_us, render_index, volume, keyframes, ctx.new_id)
+            audio_seg["extra_material_refs"] = [speed["id"]]
+            segs.append(audio_seg)
+    ctx.tracks.append(track(role, "audio", segs, ctx.new_id))
+
+
+def build_text_track(ctx, timeline_track):
+    segs = []
+    for segment in timeline_track.get("segments", []):
+        ts, te = float(segment["timeline_start"]), float(segment["timeline_end"])
+        text = segment.get("text", "")
+        mat_id = ctx.new_id()
+        content = {"text": text, "styles": [{
+            "fill": {
+                "alpha": 1.0,
+                "content": {"render_type": "solid", "solid": {"alpha": 1.0, "color": [1.0, 1.0, 1.0]}},
+            },
+            "range": [0, len(text.encode("utf-16-le")) // 2],
+            "size": 8.0,
+            "bold": False,
+            "italic": False,
+            "underline": False,
+            "strokes": [],
+        }]}
+        ctx.materials["texts"].append({
+            "id": mat_id,
+            "content": json.dumps(content, ensure_ascii=False),
+            "type": "text",
+            "typesetting": 0,
+            "alignment": 1,
+            "letter_spacing": 0.0,
+            "line_spacing": 0.02,
+            "font_size": 8.0,
+            "text_color": "#FFFFFF",
+            "add_type": 0,
+            "check_flag": 7,
+        })
+        seg = base_segment(mat_id, us(ts), us(te - ts), RI_TEXT, 1.0, [], ctx.new_id)
+        seg["source_timerange"] = None
+        seg["extra_material_refs"] = []
+        seg["clip"] = clip_default()
+        seg["uniform_scale"] = {"on": True, "value": 1.0}
+        seg["type"] = "text_effect"
+        seg["source_platform"] = 1
+        seg["clip"]["transform"]["y"] = -0.72
+        segs.append(seg)
+    ctx.tracks.append(track("subtitle", "text", segs, ctx.new_id))
+
+
+def build_timeline_track(ctx, timeline_track):
+    kind = timeline_track.get("kind")
+    if kind in ("audio", "text") and not timeline_track.get("segments"):
+        return
+    if kind == "video":
+        build_video_track(ctx, timeline_track)
+    elif kind == "audio":
+        build_audio_track(ctx, timeline_track)
+    elif kind == "text":
+        build_text_track(ctx, timeline_track)
+    else:
+        note = unsupported_track_note(kind)
+        if note:
+            ctx.note(note)

--- a/skills/video-assemble/scripts/jianying_model.py
+++ b/skills/video-assemble/scripts/jianying_model.py
@@ -1,0 +1,54 @@
+"""Thin internal model used at the JianYing adapter boundary."""
+
+import os
+from dataclasses import dataclass, field
+from typing import Callable
+
+from jianying_schema import us
+
+
+ProbeFn = Callable[[str], tuple[int, int, int]]
+NewIdFn = Callable[[], str]
+
+
+@dataclass
+class DraftBuildContext:
+    """Normalized draft build state.
+
+    Public `timeline.json` stays backend-neutral (seconds/gains). This context is
+    the adapter-local place where canvas values and durations are normalized into
+    JianYing-friendly integers and material/track arrays are accumulated.
+    """
+
+    width: int
+    height: int
+    fps: float
+    total_us: int
+    new_id: NewIdFn
+    probe: ProbeFn
+    materials: dict[str, list] = field(
+        default_factory=lambda: {"videos": [], "audios": [], "texts": [], "speeds": []}
+    )
+    tracks: list[dict] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_timeline(cls, timeline, new_id, probe):
+        canvas = timeline.get("canvas", {})
+        return cls(
+            width=int(canvas.get("width", 1920)),
+            height=int(canvas.get("height", 1080)),
+            fps=float(canvas.get("fps", 30)),
+            total_us=us(timeline.get("duration", 0)),
+            new_id=new_id,
+            probe=probe,
+        )
+
+    def media_duration(self, path, fallback_us):
+        if path and os.path.exists(path):
+            duration_us, width, height = self.probe(path)
+            return duration_us or fallback_us, width, height
+        return fallback_us, 0, 0
+
+    def note(self, message):
+        self.notes.append(message)

--- a/skills/video-assemble/scripts/jianying_schema.py
+++ b/skills/video-assemble/scripts/jianying_schema.py
@@ -1,0 +1,213 @@
+"""Schema constants, skeleton factories, and capability registries for JianYing export.
+
+This module is intentionally data-oriented: it owns draft version metadata, the
+full `materials` parallel-array shape, and the duo-video-inspired distinction
+between material categories and cross-cutting exporter capabilities.
+"""
+
+DRAFT_VERSION = 360000
+NEW_VERSION = "111.0.0"
+APP = {"app_id": 3704, "app_source": "lv", "app_version": "5.9.5-beta1", "os": "mac"}
+
+# The full 剪映 materials object: ~45 parallel arrays, only a few are populated
+# by the milestone-1 exporter. Keeping every array preserves draft compatibility.
+MATERIAL_KEYS = (
+    "ai_translates audio_balances audio_effects audio_fades audio_track_indexes audios "
+    "beats canvases chromas color_curves digital_humans drafts effects flowers green_screens "
+    "handwrites hsl images log_color_wheels loudnesses manual_deformations masks common_mask "
+    "material_animations material_colors multi_language_refs placeholders plugin_effects "
+    "primary_color_wheels realtime_denoises shapes smart_crops smart_relights "
+    "sound_channel_mappings speeds stickers tail_leaders text_templates texts time_marks "
+    "transitions video_effects video_trackings videos vocal_beautifys vocal_separations"
+).split()
+
+
+def us(seconds):
+    """Seconds (float) -> integer microseconds. The single seconds->µs boundary."""
+    return int(round(float(seconds) * 1_000_000))
+
+
+def full_materials(filled):
+    """Return a complete JianYing `materials` object with all known arrays."""
+    out = {k: [] for k in MATERIAL_KEYS}
+    out.update(filled)
+    return out
+
+
+def draft_content_skeleton(draft_id, width, height, fps, total_us, materials, tracks):
+    """Build the root `draft_content.json` / `draft_info.json` skeleton."""
+    return {
+        "canvas_config": {"width": width, "height": height, "ratio": "original"},
+        "color_space": 0,
+        "config": {
+            "adjust_max_index": 1,
+            "attachment_info": [],
+            "combination_max_index": 1,
+            "export_range": None,
+            "extract_audio_last_index": 1,
+            "lyrics_recognition_id": "",
+            "lyrics_sync": True,
+            "lyrics_taskinfo": [],
+            "maintrack_adsorb": True,
+            "material_save_mode": 0,
+            "multi_language_current": "none",
+            "multi_language_list": [],
+            "multi_language_main": "none",
+            "multi_language_mode": "none",
+            "original_sound_last_index": 1,
+            "record_audio_last_index": 1,
+            "sticker_max_index": 1,
+            "subtitle_keywords_config": None,
+            "subtitle_recognition_id": "",
+            "subtitle_sync": True,
+            "subtitle_taskinfo": [],
+            "system_font_list": [],
+            "video_mute": False,
+            "zoom_info_params": None,
+        },
+        "cover": None,
+        "create_time": 0,
+        "duration": int(total_us),
+        "extra_info": None,
+        "fps": fps,
+        "free_render_index_mode_on": False,
+        "group_container": None,
+        "id": draft_id,
+        "keyframe_graph_list": [],
+        "keyframes": {
+            "adjusts": [],
+            "audios": [],
+            "effects": [],
+            "filters": [],
+            "handwrites": [],
+            "stickers": [],
+            "texts": [],
+            "videos": [],
+        },
+        "last_modified_platform": dict(APP),
+        "platform": dict(APP),
+        "materials": full_materials(materials),
+        "mutable_config": None,
+        "name": "",
+        "new_version": NEW_VERSION,
+        "relationships": [],
+        "render_index_track_mode_on": False,
+        "retouch_cover": None,
+        "source": "default",
+        "static_cover_image_path": "",
+        "time_marks": None,
+        "tracks": tracks,
+        "update_time": 0,
+        "version": DRAFT_VERSION,
+    }
+
+
+def meta_info(draft_id, total_us):
+    """Build the companion `draft_meta_info.json` skeleton."""
+    return {
+        "cloud_package_completed_time": "",
+        "draft_cloud_capcut_purchase_info": "",
+        "draft_cloud_last_action_download": False,
+        "draft_cloud_materials": [],
+        "draft_cloud_purchase_info": "",
+        "draft_cloud_template_id": "",
+        "draft_cloud_tutorial_info": "",
+        "draft_cloud_videocut_purchase_info": "",
+        "draft_cover": "",
+        "draft_deeplink_url": "",
+        "draft_enterprise_info": {
+            "draft_enterprise_extra": "",
+            "draft_enterprise_id": "",
+            "draft_enterprise_name": "",
+            "enterprise_material": [],
+        },
+        "draft_fold_path": "",
+        "draft_id": draft_id,
+        "draft_is_ai_packaging_used": False,
+        "draft_is_ai_shorts": False,
+        "draft_is_ai_translate": False,
+        "draft_is_article_video_draft": False,
+        "draft_is_from_deeplink": "false",
+        "draft_is_invisible": False,
+        "draft_materials": [{"type": t, "value": []} for t in (0, 1, 2, 3, 6, 7, 8)],
+        "draft_materials_copied_info": [],
+        "draft_name": "",
+        "draft_new_version": "",
+        "draft_removable_storage_device": "",
+        "draft_root_path": "",
+        "draft_segment_extra_info": [],
+        "draft_type": "",
+        "tm_draft_cloud_completed": "",
+        "tm_draft_cloud_modified": 0,
+        "tm_draft_removed": 0,
+        "tm_duration": int(total_us),
+    }
+
+
+def material_category_registry():
+    """Material category support table inspired by duo-video's MaterialTypeEnum.
+
+    Keep this separate from feature capabilities: keyframes, bundling, and path
+    rewrite are exporter capabilities, not material categories.
+    """
+    return {
+        "video": {"status": "supported", "materials_key": "videos", "track_type": "video"},
+        "audio": {"status": "supported", "materials_key": "audios", "track_type": "audio"},
+        "text": {"status": "supported", "materials_key": "texts", "track_type": "text"},
+        "subtitle": {"status": "supported", "materials_key": "texts", "track_type": "text"},
+        "speed": {"status": "supported_auxiliary", "materials_key": "speeds", "track_type": None},
+        "image": {"status": "reserved", "materials_key": "images", "track_type": "video"},
+        "sticker": {"status": "reserved", "materials_key": "stickers", "track_type": "sticker"},
+        "sound": {"status": "reserved", "materials_key": "audios", "track_type": "audio"},
+        "text_template": {"status": "reserved", "materials_key": "text_templates", "track_type": "text"},
+        "lut": {"status": "reserved", "materials_key": "effects", "track_type": "video"},
+        "transition": {"status": "reserved", "materials_key": "transitions", "track_type": "video"},
+        "video_effect": {"status": "reserved", "materials_key": "video_effects", "track_type": "video"},
+        "face_effect": {"status": "reserved", "materials_key": "effects", "track_type": "video"},
+        "mask": {"status": "reserved", "materials_key": "masks", "track_type": "video"},
+        "style": {"status": "reserved", "materials_key": "material_colors", "track_type": "video"},
+    }
+
+
+def feature_capabilities():
+    """Cross-cutting exporter capabilities, deliberately not material categories."""
+    return {
+        "volume_automation": {
+            "status": "supported",
+            "property_type": "KFTypeVolume",
+            "description": "timeline-absolute gain points become segment-relative JianYing keyframes",
+        },
+        "bgm_loop_splitting": {
+            "status": "supported",
+            "description": "looped BGM is split into repeated JianYing audio segments",
+        },
+        "media_bundling": {
+            "status": "supported",
+            "description": "referenced media can be copied into the draft materials folder",
+        },
+        "path_rewrite": {
+            "status": "supported",
+            "description": "bundled media paths are rewritten after atomic move",
+        },
+        "collision_safe_write": {
+            "status": "supported",
+            "description": "non-empty draft folders are never overwritten",
+        },
+        "lazy_export_isolation": {
+            "status": "supported",
+            "description": "assemble imports JianYing modules only when export is requested",
+        },
+    }
+
+
+def validate_material_category(category):
+    """Return deterministic support metadata for a public or future material kind."""
+    normalized = (category or "").strip().lower()
+    registry = material_category_registry()
+    info = dict(registry.get(normalized, {"status": "unsupported", "materials_key": None, "track_type": None}))
+    info["category"] = normalized
+    info["supported"] = info["status"] in {"supported", "supported_auxiliary"}
+    if not info["supported"]:
+        status = "保留但暂未实现" if info["status"] == "reserved" else "未知"
+        info["note"] = f"暂不支持的 JianYing material category: {normalized}（{status}），已跳过以避免生成无效草稿"
+    return info

--- a/skills/video-assemble/scripts/jianying_tracks.py
+++ b/skills/video-assemble/scripts/jianying_tracks.py
@@ -1,0 +1,68 @@
+"""Track layout bands and deterministic overlap-safe allocation for JianYing export."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TrackBand:
+    kind: str
+    track_type: str
+    render_index: int
+    description: str
+
+
+# Parity values for existing output are preserved: video at 0, narration/BGM at
+# 1/2 via explicit role handling, and subtitles in JianYing's high text band.
+RI_VIDEO = 0
+RI_NARRATION = 1
+RI_BGM = 2
+RI_TEXT = 15000
+
+
+TRACK_LAYOUT_BANDS = {
+    "audio": TrackBand("audio", "audio", RI_NARRATION, "narration and general audio below text"),
+    "sound": TrackBand("sound", "audio", RI_BGM, "sound/BGM bed lane"),
+    "video": TrackBand("video", "video", RI_VIDEO, "base video track"),
+    "image": TrackBand("image", "video", 1000, "future image/overlay lane"),
+    "overlay": TrackBand("overlay", "video", 1000, "future video/image overlay lane"),
+    "mask": TrackBand("mask", "video", 4000, "future mask/effect lane"),
+    "effect": TrackBand("effect", "video", 5000, "future effects lane"),
+    "video_effect": TrackBand("video_effect", "video", 5000, "future video effects lane"),
+    "sticker": TrackBand("sticker", "sticker", 10000, "future sticker lane"),
+    "subtitle": TrackBand("subtitle", "text", RI_TEXT, "subtitle text lane"),
+    "text": TrackBand("text", "text", RI_TEXT, "plain text lane"),
+    "text_template": TrackBand("text_template", "text", RI_TEXT + 100, "future text template lane"),
+}
+
+
+@dataclass(frozen=True)
+class AllocatedTrack:
+    kind: str
+    name: str
+    track_type: str
+    render_index: int
+
+
+class TrackAllocator:
+    """Allocate deterministic suffix tracks when same-name segments overlap."""
+
+    def __init__(self):
+        self._occupied = {}
+
+    @staticmethod
+    def _overlaps(start_us, duration_us, existing):
+        end_us = int(start_us) + int(duration_us)
+        return any(int(start_us) < old_end and end_us > old_start for old_start, old_end in existing)
+
+    def allocate(self, kind, base_name, start_us, duration_us):
+        band = TRACK_LAYOUT_BANDS.get(kind, TRACK_LAYOUT_BANDS["video"])
+        base_name = base_name or kind
+        suffix = 0
+        while True:
+            name = base_name if suffix == 0 else f"{base_name}-{suffix}"
+            key = (kind, name)
+            occupied = self._occupied.setdefault(key, [])
+            if not self._overlaps(start_us, duration_us, occupied):
+                occupied.append((int(start_us), int(start_us) + int(duration_us)))
+                return AllocatedTrack(kind, name, band.track_type, band.render_index + suffix)
+            suffix += 1

--- a/skills/video-assemble/scripts/jianying_writer.py
+++ b/skills/video-assemble/scripts/jianying_writer.py
@@ -1,0 +1,122 @@
+"""Safe writer and media bundler for JianYing draft folders."""
+
+import json
+import os
+import shutil
+import tempfile
+
+
+def validate_draft_name(draft_name):
+    """Reject draft names that could escape or alias the requested parent dir."""
+    if not isinstance(draft_name, str):
+        raise TypeError("draft_name must be a string")
+    if not draft_name or not draft_name.strip():
+        raise ValueError("draft_name must not be empty")
+    if os.path.isabs(draft_name):
+        raise ValueError("draft_name must be a plain folder name, not an absolute path")
+    if "/" in draft_name or "\\" in draft_name:
+        raise ValueError("draft_name must not contain path separators")
+    if draft_name in {".", ".."}:
+        raise ValueError("draft_name must not be '.' or '..'")
+
+
+def bundle_media(content, draft_dir):
+    """Copy referenced media into `<draft_dir>/materials/` and rewrite paths."""
+    mats_dir = os.path.join(draft_dir, "materials")
+    os.makedirs(mats_dir, exist_ok=True)
+    copied, used, notes = {}, set(), []
+    for arr in (content["materials"]["videos"], content["materials"]["audios"]):
+        for material in arr:
+            src = material.get("path")
+            if not src:
+                continue
+            if src in copied:
+                material["path"] = copied[src]
+                continue
+            if not os.path.exists(src):
+                notes.append(f"素材缺失，未打包: {src}")
+                continue
+            base = os.path.basename(src)
+            name, stem_ext = base, os.path.splitext(base)
+            i = 1
+            while name in used:
+                name = f"{stem_ext[0]}_{i}{stem_ext[1]}"
+                i += 1
+            used.add(name)
+            dest = os.path.join(mats_dir, name)
+            shutil.copy2(src, dest)
+            copied[src] = dest
+            material["path"] = dest
+    return notes
+
+
+def draft_dir_has_user_content(draft_dir):
+    """Return True when writing here could overwrite an existing draft/material."""
+    if not os.path.exists(draft_dir):
+        return False
+    try:
+        return any(os.scandir(draft_dir))
+    except OSError:
+        return True
+
+
+def collision_safe_draft_dir(out_dir, draft_name):
+    """Pick a fresh draft folder instead of overwriting an existing non-empty one."""
+    validate_draft_name(draft_name)
+    base = os.path.join(out_dir, draft_name)
+    if not draft_dir_has_user_content(base):
+        return base, draft_name
+    idx = 2
+    while True:
+        candidate_name = f"{draft_name}_{idx}"
+        candidate = os.path.join(out_dir, candidate_name)
+        if not draft_dir_has_user_content(candidate):
+            return candidate, candidate_name
+        idx += 1
+
+
+def rewrite_material_prefix(content, old_prefix, new_prefix):
+    old_prefix = os.path.abspath(old_prefix)
+    new_prefix = os.path.abspath(new_prefix)
+    for arr in (content["materials"]["videos"], content["materials"]["audios"]):
+        for material in arr:
+            path = material.get("path")
+            if path and os.path.abspath(path).startswith(old_prefix + os.sep):
+                material["path"] = new_prefix + os.path.abspath(path)[len(old_prefix):]
+
+
+def write_draft(content, meta, notes, out_dir, draft_name, bundle_media_enabled=False):
+    """Atomically write the three JianYing draft JSON files and optional bundle."""
+    validate_draft_name(draft_name)
+    out_dir = os.path.abspath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    draft_dir, actual_name = collision_safe_draft_dir(out_dir, draft_name)
+    notes = list(notes)
+    if actual_name != draft_name:
+        notes.append(f"草稿目录已存在，改写为 {actual_name} 以避免覆盖")
+
+    tmp_parent = tempfile.mkdtemp(prefix=f".{actual_name}.", dir=out_dir)
+    tmp_dir = os.path.join(tmp_parent, actual_name)
+    try:
+        os.makedirs(tmp_dir, exist_ok=False)
+        if bundle_media_enabled:
+            notes = notes + bundle_media(content, tmp_dir)
+            rewrite_material_prefix(content, tmp_dir, draft_dir)
+        meta["draft_name"] = actual_name
+        meta["draft_fold_path"] = draft_dir
+        content["name"] = actual_name
+        for fname in ("draft_content.json", "draft_info.json"):
+            with open(os.path.join(tmp_dir, fname), "w", encoding="utf-8") as f:
+                json.dump(content, f, ensure_ascii=False, indent=2)
+        with open(os.path.join(tmp_dir, "draft_meta_info.json"), "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+        if os.path.isdir(draft_dir) and not draft_dir_has_user_content(draft_dir):
+            os.rmdir(draft_dir)
+        os.replace(tmp_dir, draft_dir)
+    except Exception:
+        shutil.rmtree(tmp_parent, ignore_errors=True)
+        raise
+    finally:
+        if os.path.exists(tmp_parent):
+            shutil.rmtree(tmp_parent, ignore_errors=True)
+    return draft_dir, notes

--- a/skills/video-recap/references/timeline-and-jianying.md
+++ b/skills/video-recap/references/timeline-and-jianying.md
@@ -57,6 +57,27 @@ work_dir):
 - video on the main track, narration/BGM as their own audio tracks (higher
   `render_index`), subtitles on a text track.
 
+The exporter is now **schema-driven** rather than a single monolithic JSON
+builder. `export_jianying.py` remains the public facade, while the implementation
+is split into:
+
+- `jianying_schema.py` — draft version metadata, full `materials` skeleton,
+  root/meta skeleton factories, material-category registry, feature capabilities;
+- `jianying_model.py` — a thin internal build context where seconds/gains become
+  JianYing-local microseconds/gains;
+- `jianying_builders.py` — current video/audio/text/speed/KFTypeVolume builders;
+- `jianying_tracks.py` — render-index bands and deterministic overlap-safe
+  allocation for future overlay/text/image lanes;
+- `jianying_writer.py` — collision-safe folder choice, media bundling, path
+  rewrite, and atomic write of the three draft files.
+
+The schema metadata is aligned with the duoec/duo-video reference baseline
+(`version: 360000`, `new_version: 111.0.0`, `app_version: 5.9.5-beta1`) and the
+materials skeleton includes the newer `common_mask` array seen in that baseline.
+This makes the exporter newer-schema-friendly than the old minimal
+`app_version: 5.9.0` implementation, but it is not a promise that every future
+剪映/CapCut release will open drafts without a manual smoke test.
+
 **Media is bundled by default.** The referenced media is copied into the draft's
 `materials/` folder and the paths rewritten to those copies. This is **required on
 macOS**: 剪映 is sandboxed and cannot read files outside its own data dir, so an
@@ -68,15 +89,45 @@ paths (e.g. media already under the drafts root). If the requested draft folder 
 
 **Decoupling guarantees** (the core never depends on 剪映):
 - the exporter is **lazy-imported** only when an export is requested; importing the
-  render path does not import it (enforced by a test);
+  render path does not import it or any `jianying_*` helper module (enforced by a
+  clean-interpreter test);
 - it is **stdlib + ffprobe only** — no `pymediainfo`, no vendored library;
 - any failure is caught and logged; it never breaks the ffmpeg render.
+
+## Material registry and capabilities
+
+The registry deliberately separates **material categories** from **cross-cutting
+features**:
+
+- Supported material categories in milestone 1: `video`, `audio`, `text`,
+  `subtitle`, plus JianYing's auxiliary `speed` material.
+- Reserved categories, inspired by duo-video but not emitted yet:
+  `image`, `sticker`, `sound`, `text_template`, `lut`, `transition`,
+  `video_effect`, `face_effect`, `mask`, `style`.
+- Feature capabilities are tracked separately: `KFTypeVolume` automation, BGM
+  loop splitting, media bundling, bundled-path rewrite, collision-safe writes,
+  and lazy export isolation.
+
+Unsupported material categories produce explicit exporter notes and are skipped
+instead of silently writing malformed draft JSON.
 
 **Limitations** (documented, not bugs): the draft references the *un-burned* source,
 so the source's own hardcoded subtitles show in 剪映 (mask them there if needed);
 ffmpeg remains the canonical mix — the 剪映 mix is an editable approximation.
 
+## Manual smoke checklist
+
+When a desktop 剪映/CapCut install is available, generate a bundled draft and
+verify:
+
+1. the draft appears in the app's draft list;
+2. source clips, narration, BGM, and subtitles are online and editable;
+3. ducking is visible/audible as volume automation;
+4. no macOS permission/offline-media warnings appear for bundled media.
+
 ## Acknowledgements
 
 Draft schema follows [pyJianYingDraft](https://github.com/GuanYixuan/pyJianYingDraft)
-and [capcut-mate](https://github.com/Hommy-master/capcut-mate) (both Apache-2.0); no code vendored.
+and [capcut-mate](https://github.com/Hommy-master/capcut-mate) (both Apache-2.0),
+with schema/builder/writer boundaries inspired by duoec/duo-video; no code is
+vendored.

--- a/tests/assemble/test_export_jianying.py
+++ b/tests/assemble/test_export_jianying.py
@@ -2,7 +2,15 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
 import json  # noqa: E402
+import pytest  # noqa: E402
 from export_jianying import build_draft, export_timeline_to_jianying, _us  # noqa: E402
+from jianying_schema import (  # noqa: E402
+    MATERIAL_KEYS,
+    feature_capabilities,
+    material_category_registry,
+    validate_material_category,
+)
+from jianying_tracks import TRACK_LAYOUT_BANDS, TrackAllocator  # noqa: E402
 from timeline import build_timeline  # noqa: E402
 
 
@@ -79,6 +87,22 @@ def test_us_is_integer_microseconds():
     assert isinstance(_us(3.1), int)
 
 
+def test_draft_root_schema_material_keys_and_meta_shape():
+    content, meta, _notes = build_draft(_sample_timeline(), new_id=_counter_ids(), probe=_fake_probe)
+
+    required_root_keys = {
+        "canvas_config", "config", "duration", "fps", "keyframes", "materials",
+        "tracks", "version", "new_version", "platform", "last_modified_platform",
+    }
+    assert required_root_keys <= set(content)
+    assert set(MATERIAL_KEYS) <= set(content["materials"])
+    assert all(isinstance(content["materials"][key], list) for key in MATERIAL_KEYS)
+
+    assert {"draft_id", "draft_name", "draft_fold_path", "tm_duration", "draft_materials"} <= set(meta)
+    assert meta["tm_duration"] == content["duration"]
+    assert isinstance(meta["draft_materials"], list) and meta["draft_materials"]
+
+
 def test_build_draft_structure_and_tracks():
     content, meta, _notes = build_draft(_sample_timeline(), new_id=_counter_ids(), probe=_fake_probe)
     assert content["version"] == 360000
@@ -134,6 +158,85 @@ def test_export_writes_three_files(tmp_path):
     assert content == info                              # dual-file compatibility
     meta = json.loads((Path(draft_dir) / "draft_meta_info.json").read_text(encoding="utf-8"))
     assert meta["draft_name"] == "recap_demo" and meta["tm_duration"] == 15_000_000
+
+
+def test_export_rejects_draft_names_that_escape_output_parent(tmp_path):
+    out = tmp_path / "out"
+    unsafe_names = ["", "   ", ".", "..", "../escape", "nested/name", r"nested\name", str(tmp_path / "escape")]
+
+    for draft_name in unsafe_names:
+        with pytest.raises(ValueError):
+            export_timeline_to_jianying(
+                _sample_timeline(), str(out), draft_name=draft_name,
+                new_id=_counter_ids(), probe=_fake_probe)
+
+    assert not out.exists()
+
+
+def test_representative_parity_export_with_bundle_collision_loop_and_keyframes(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    vid = src / "orig.mp4"
+    narr = src / "n0.wav"
+    bgm = src / "bgm.mp3"
+    vid.write_bytes(b"video")
+    narr.write_bytes(b"narration")
+    bgm.write_bytes(b"bgm")
+
+    tl = _sample_timeline()
+    for track in tl["tracks"]:
+        if track.get("kind") == "video":
+            for clip in track["clips"]:
+                clip["source_path"] = str(vid)
+        elif track.get("role") == "narration":
+            track["segments"][0]["source_path"] = str(narr)
+        elif track.get("role") == "bgm":
+            track["segments"][0]["source_path"] = str(bgm)
+
+    out = tmp_path / "out"
+    existing = out / "recap_demo"
+    existing.mkdir(parents=True)
+    (existing / "draft_content.json").write_text("manual edit", encoding="utf-8")
+
+    def short_bgm_probe(path):
+        if str(path).endswith("bgm.mp3"):
+            return 5_000_000, 0, 0
+        return 600_000_000, 1920, 1080
+
+    draft_dir, notes = export_timeline_to_jianying(
+        tl, str(out), draft_name="recap_demo", new_id=_counter_ids(),
+        probe=short_bgm_probe, bundle_media=True)
+
+    assert Path(draft_dir).name == "recap_demo_2"
+    assert (existing / "draft_content.json").read_text(encoding="utf-8") == "manual edit"
+    assert any("避免覆盖" in note for note in notes)
+
+    draft_path = Path(draft_dir)
+    content = json.loads((draft_path / "draft_content.json").read_text(encoding="utf-8"))
+    info = json.loads((draft_path / "draft_info.json").read_text(encoding="utf-8"))
+    meta = json.loads((draft_path / "draft_meta_info.json").read_text(encoding="utf-8"))
+    assert content == info
+    assert meta["draft_name"] == "recap_demo_2"
+    assert meta["draft_fold_path"] == str(draft_path)
+
+    materials = content["materials"]
+    assert len(materials["videos"]) == 2
+    assert len(materials["audios"]) == 2
+    assert len(materials["texts"]) == 1
+    assert len(materials["speeds"]) == 6  # 2 video + narration + 3 looped BGM pieces
+
+    tracks = content["tracks"]
+    assert [(t["type"], t["name"]) for t in tracks] == [
+        ("video", "video"), ("audio", "narration"), ("audio", "bgm"), ("text", "subtitle")
+    ]
+    assert tracks[0]["segments"][0]["render_index"] == 0
+    assert tracks[-1]["segments"][0]["render_index"] == 15000
+    assert len(next(t for t in tracks if t["name"] == "bgm")["segments"]) == 3
+
+    assert tracks[0]["segments"][0]["common_keyframes"][0]["property_type"] == "KFTypeVolume"
+    assert next(t for t in tracks if t["name"] == "bgm")["segments"][0]["common_keyframes"][0]["property_type"] == "KFTypeVolume"
+    for material in materials["videos"] + materials["audios"]:
+        assert material["path"].startswith(str(draft_path / "materials"))
 
 
 def test_export_uses_collision_safe_draft_folder(tmp_path):
@@ -200,9 +303,65 @@ def test_core_assemble_does_not_import_exporter():
     import subprocess
     scripts = str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts')
     code = (f"import sys; sys.path.insert(0, {scripts!r}); import assemble; "
-            "assert 'export_jianying' not in sys.modules, 'core imported the 剪映 exporter'")
+            "assert 'export_jianying' not in sys.modules, 'core imported the 剪映 exporter'; "
+            "assert not any(name.startswith('jianying') for name in sys.modules), "
+            "'core imported JianYing helper modules'")
     r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert r.returncode == 0, r.stderr
+
+
+def test_material_category_registry_is_separate_from_feature_capabilities():
+    categories = material_category_registry()
+    assert categories["video"]["status"] == "supported"
+    assert categories["audio"]["status"] == "supported"
+    assert categories["text"]["status"] == "supported"
+    assert categories["subtitle"]["status"] == "supported"
+    assert categories["speed"]["status"] == "supported_auxiliary"
+    for reserved in (
+        "image", "sticker", "sound", "text_template", "lut", "transition",
+        "video_effect", "face_effect", "mask", "style",
+    ):
+        assert categories[reserved]["status"] == "reserved"
+
+    capabilities = feature_capabilities()
+    assert capabilities["volume_automation"]["property_type"] == "KFTypeVolume"
+    assert "media_bundling" in capabilities
+    assert "path_rewrite" in capabilities
+    assert "collision_safe_write" in capabilities
+    assert "lazy_export_isolation" in capabilities
+
+    assert "KFTypeVolume" not in categories
+    assert "media_bundling" not in categories
+    unsupported = validate_material_category("image")
+    assert unsupported["supported"] is False
+    assert unsupported["status"] == "reserved"
+
+
+def test_unsupported_material_category_produces_note_without_malformed_output():
+    tl = {"schema_version": 1, "canvas": {"width": 100, "height": 100, "fps": 30},
+          "duration": 2.0, "tracks": [
+              {"kind": "image", "name": "overlay", "segments": [
+                  {"source_path": "/overlay.png", "timeline_start": 0.0, "timeline_end": 2.0}
+              ]}]}
+
+    content, _meta, notes = build_draft(tl, new_id=_counter_ids(), probe=_fake_probe)
+
+    assert content["tracks"] == []
+    assert content["materials"]["images"] == []
+    assert any("暂不支持" in note and "image" in note for note in notes)
+
+
+def test_track_allocator_uses_layout_bands_and_suffixes_overlaps():
+    assert TRACK_LAYOUT_BANDS["video"].render_index == 0
+    assert TRACK_LAYOUT_BANDS["subtitle"].render_index == 15000
+    assert {"audio", "sound", "video", "image", "mask", "sticker", "subtitle", "text_template"} <= set(TRACK_LAYOUT_BANDS)
+
+    allocator = TrackAllocator()
+    assert allocator.allocate("subtitle", "subtitle", 0, 5_000_000).name == "subtitle"
+    assert allocator.allocate("subtitle", "subtitle", 5_000_000, 1_000_000).name == "subtitle"
+    assert allocator.allocate("subtitle", "subtitle", 4_500_000, 2_000_000).name == "subtitle-1"
+    assert allocator.allocate("subtitle", "subtitle", 4_500_000, 2_000_000).name == "subtitle-2"
+    assert allocator.allocate("image", "overlay", 4_500_000, 2_000_000).name == "overlay"
 
 
 


### PR DESCRIPTION
## Summary
- Refactor optional JianYing/剪映 export into schema/model/builders/tracks/writer modules behind a thin `export_jianying.py` facade.
- Align draft schema baseline with the newer reference shape: `version: 360000`, `new_version: 111.0.0`, `app_version: 5.9.5-beta1`, full materials skeleton including `common_mask`.
- Add material-category registry/capability separation, safer writer name validation, bundled media path rewrite, BGM loop splitting, and expanded docs/tests.
- Prepare release metadata for `v0.3.2` (`CHANGELOG.md`, `.claude-plugin/plugin.json`).

## Tests / Verification
- `python3 -m ruff check ...` on changed JianYing exporter/test files ✅
- `python3 -m py_compile ...` on changed exporter modules ✅
- `python3 -m mypy --ignore-missing-imports ...` on changed exporter modules ✅
- `python3 -m pytest tests/assemble/test_export_jianying.py tests/assemble/test_timeline.py tests/assemble/test_pure_assemble.py -q` ✅ — 84 passed
- `python3 scripts/test.py` ✅ — all skill groups passed
- `git diff --check` ✅

## Real JianYing E2E
- Local app: `/Applications/VideoFusion-macOS.app` / 剪映专业版 `10.8.7`.
- Generated schema E2E draft opened successfully in the app.
- Converted historical timeline `/Users/pite/makemoney/recap/longvacation_2min_work/timeline.json` to `recap_tmp_convert_longvacation_2min_20260623_003900`; app registered it in `root_meta_info.json` and user confirmed the draft opens.

## Review
- code-reviewer follow-up: APPROVE; previous draft-name path traversal finding resolved.
- architect lane: WATCH only — `TrackAllocator` is currently a future-facing seam and not consumed by the production builder path yet.

## Remaining risk
- No automated visual UI assertion; real app opening was manually verified.
- Newer-schema alignment is verified against the reference baseline and local JianYingPro 10.8.7, not guaranteed for every future JianYing/CapCut release without smoke testing.
