### PR TITLE
Cross-harness support: cwd-robust skills + Claude Code marketplace + Codex/OpenClaw/opencode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "video-recap-skills",
+  "name": "video-recap",
   "owner": {
-    "name": "worldwonderer"
+    "name": "PiteChen"
   },
   "description": "Turn any video into a Chinese-narration recap on ffmpeg + one Xiaomi MiMo API key.",
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "video-recap-skills",
+  "owner": {
+    "name": "worldwonderer"
+  },
+  "description": "Turn any video into a Chinese-narration recap on ffmpeg + one Xiaomi MiMo API key.",
+  "plugins": [
+    {
+      "name": "video-recap-skills",
+      "source": "./",
+      "description": "Turn any video into a Chinese-narration recap (understanding -> narration -> cut -> voiceover -> assemble) on ffmpeg + one Xiaomi MiMo API key. A bundle of independent skills + a thin orchestrator. macOS / Linux / Windows.",
+      "homepage": "https://github.com/worldwonderer/video-recap-skills",
+      "license": "MIT"
+    }
+  ]
+}

--- a/README.en.md
+++ b/README.en.md
@@ -46,7 +46,7 @@ flowchart LR
 
 ```text
 /plugin marketplace add worldwonderer/video-recap-skills
-/plugin install video-recap-skills@video-recap-skills
+/plugin install video-recap-skills@video-recap
 ```
 
 (Or just tell Claude Code: "Install this plugin: https://github.com/worldwonderer/video-recap-skills".)
@@ -80,15 +80,15 @@ The engine is plain Python + ffmpeg + one MiMo key — harness-agnostic — so i
 
   ```bash
   codex plugin marketplace add worldwonderer/video-recap-skills
-  codex plugin add video-recap-skills@video-recap-skills
+  codex plugin add video-recap-skills@video-recap
   ```
 
   (The `owner/repo` form works once the repo is published; locally use `codex plugin marketplace add ./video-recap-skills`.)
 
-- **OpenClaw** (verified) — it imports the Claude plugin bundle directly:
+- **OpenClaw** (verified) — it imports the Claude plugin bundle directly. After cloning, point the argument at the cloned directory:
 
   ```bash
-  openclaw plugins install ./video-recap-skills   # or clone, then point at the dir
+  openclaw plugins install ./video-recap-skills
   ```
 
   All 6 skills become native, auto-triggering skills (`openclaw skills list`).
@@ -96,8 +96,8 @@ The engine is plain Python + ffmpeg + one MiMo key — harness-agnostic — so i
 - **opencode** (per its docs; not run-verified here) — opencode auto-discovers skills under `.claude/skills` / `.agents/skills` / `.opencode/skills`. After cloning, expose `skills/` under one of them:
 
   ```bash
-  ln -s ../skills .claude/skills      # macOS / Linux
-  # Windows: copy skills\* into .claude\skills\
+  mkdir -p .claude && ln -s ../skills .claude/skills   # macOS / Linux
+  # Windows: create .claude\skills first, then copy skills\* into it
   ```
 
 > Harnesses don't always run commands from the skill's directory; the "Running the scripts" note at the top of each `SKILL.md` shows how to invoke them by absolute path (the scripts self-locate via `__file__`).

--- a/README.en.md
+++ b/README.en.md
@@ -42,11 +42,14 @@ flowchart LR
 
 ## Installation
 
-**① Install the plugin** — ask Claude Code:
+**① Install the plugin** — add this repo as a marketplace and install, inside Claude Code:
 
 ```text
-Install this plugin: https://github.com/worldwonderer/video-recap-skills
+/plugin marketplace add worldwonderer/video-recap-skills
+/plugin install video-recap-skills@video-recap-skills
 ```
+
+(Or just tell Claude Code: "Install this plugin: https://github.com/worldwonderer/video-recap-skills".)
 
 **② Install ffmpeg** (no `pip install`: pure standard library + `ffmpeg` on `PATH`, Python 3.10+):
 

--- a/README.en.md
+++ b/README.en.md
@@ -72,6 +72,37 @@ export MIMO_TOKEN_PLAN_CLUSTER=cn
 Pay-as-you-go `sk-*` keys default to `https://api.xiaomimimo.com/v1`. Everything else has a default; to change the model, voice, loudness, or subtitles, or set a key/URL per capability, see the
 [config playbook](skills/video-recap/references/config-playbook.md).
 
+## Use it in other agent harnesses (opencode / Codex / OpenClaw)
+
+The engine is plain Python + ffmpeg + one MiMo key — harness-agnostic — so it also runs under other agent CLIs. Get the shared prerequisites first: **ffmpeg** on `PATH`, **`MIMO_API_KEY`** set, **Python 3.10+** (as above).
+
+- **Codex CLI** (verified) — it reads this repo's `.claude-plugin/marketplace.json` directly:
+
+  ```bash
+  codex plugin marketplace add worldwonderer/video-recap-skills
+  codex plugin add video-recap-skills@video-recap-skills
+  ```
+
+  (The `owner/repo` form works once the repo is published; locally use `codex plugin marketplace add ./video-recap-skills`.)
+
+- **OpenClaw** (verified) — it imports the Claude plugin bundle directly:
+
+  ```bash
+  openclaw plugins install ./video-recap-skills   # or clone, then point at the dir
+  ```
+
+  All 6 skills become native, auto-triggering skills (`openclaw skills list`).
+
+- **opencode** (per its docs; not run-verified here) — opencode auto-discovers skills under `.claude/skills` / `.agents/skills` / `.opencode/skills`. After cloning, expose `skills/` under one of them:
+
+  ```bash
+  ln -s ../skills .claude/skills      # macOS / Linux
+  # Windows: copy skills\* into .claude\skills\
+  ```
+
+> Harnesses don't always run commands from the skill's directory; the "Running the scripts" note at the top of each `SKILL.md` shows how to invoke them by absolute path (the scripts self-locate via `__file__`).
+> **Don't double-register**: registering the same skills through more than one discovery path (the repo's `skills/`, a copy under `~/.agents/skills`, a harness install cache) can cause name clashes or double auto-triggering — enable just one.
+
 ## Usage
 
 Point it at a video and give it whatever story context you have:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ export MIMO_TOKEN_PLAN_CLUSTER=cn
 按量付费的 `sk-*` key 默认走 `https://api.xiaomimimo.com/v1`。其它都有默认值；想分别配 key/URL 或改模型、音色、响度、字幕等，可见
 [配置手册](skills/video-recap/references/config-playbook.md)。
 
+## 在其他 Agent 工具里用（opencode / Codex / OpenClaw）
+
+引擎是纯 Python + ffmpeg + 一个 MiMo key，与具体 Agent 无关，所以也能在别的 Agent CLI 里跑。先备齐共同前置：`PATH` 上有 **ffmpeg**、设好 **`MIMO_API_KEY`**、**Python 3.10+**（同上）。
+
+- **Codex CLI**（已验证）——直接读本仓库的 `.claude-plugin/marketplace.json`：
+
+  ```bash
+  codex plugin marketplace add worldwonderer/video-recap-skills
+  codex plugin add video-recap-skills@video-recap-skills
+  ```
+
+  （仓库 push 后可用 `owner/repo` 形式；本地可用 `codex plugin marketplace add ./video-recap-skills`。）
+
+- **OpenClaw**（已验证）——直接导入 Claude 插件包：
+
+  ```bash
+  openclaw plugins install ./video-recap-skills   # 或克隆后指向该目录
+  ```
+
+  6 个 skill 会成为原生、可自动触发的技能（`openclaw skills list` 可见）。
+
+- **opencode**（按其文档，未在本机实测）——opencode 自动发现 `.claude/skills` / `.agents/skills` / `.opencode/skills` 下的 skill。克隆本仓库后，把 `skills/` 暴露到其中之一即可：
+
+  ```bash
+  ln -s ../skills .claude/skills      # macOS / Linux
+  # Windows：把 skills\* 复制到 .claude\skills\
+  ```
+
+> 各 Agent 跑脚本的工作目录不一定是 skill 目录；每个 `SKILL.md` 顶部的「Running the scripts」说明了如何用绝对路径调起（脚本用 `__file__` 自定位）。
+> **别重复注册**：同一套 skill 经多条发现路径（仓库 `skills/`、`~/.agents/skills` 拷贝、各 Agent 的安装缓存）同时注册，会命名冲突或重复自动触发——只启用一条。
+
 ## 怎么用
 
 把视频丢给它，顺手给点视频背景：

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ flowchart LR
 
 ## 安装
 
-**① 装插件**——复制到 claude code：
+**① 装插件**——在 claude code 里添加本仓库为插件市场并安装：
 
 ```text
-安装这个插件：https://github.com/worldwonderer/video-recap-skills
+/plugin marketplace add worldwonderer/video-recap-skills
+/plugin install video-recap-skills@video-recap-skills
 ```
+
+（也可以直接对 claude code 说「安装这个插件：https://github.com/worldwonderer/video-recap-skills」。）
 
 **② 装 ffmpeg**（不用 `pip install`：纯标准库 + `PATH` 上的 `ffmpeg`，Python 3.10+）：
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flowchart LR
 
 ```text
 /plugin marketplace add worldwonderer/video-recap-skills
-/plugin install video-recap-skills@video-recap-skills
+/plugin install video-recap-skills@video-recap
 ```
 
 （也可以直接对 claude code 说「安装这个插件：https://github.com/worldwonderer/video-recap-skills」。）
@@ -80,15 +80,15 @@ export MIMO_TOKEN_PLAN_CLUSTER=cn
 
   ```bash
   codex plugin marketplace add worldwonderer/video-recap-skills
-  codex plugin add video-recap-skills@video-recap-skills
+  codex plugin add video-recap-skills@video-recap
   ```
 
   （仓库 push 后可用 `owner/repo` 形式；本地可用 `codex plugin marketplace add ./video-recap-skills`。）
 
-- **OpenClaw**（已验证）——直接导入 Claude 插件包：
+- **OpenClaw**（已验证）——直接导入 Claude 插件包。克隆本仓库后，把参数指向克隆出的目录运行：
 
   ```bash
-  openclaw plugins install ./video-recap-skills   # 或克隆后指向该目录
+  openclaw plugins install ./video-recap-skills
   ```
 
   6 个 skill 会成为原生、可自动触发的技能（`openclaw skills list` 可见）。
@@ -96,8 +96,8 @@ export MIMO_TOKEN_PLAN_CLUSTER=cn
 - **opencode**（按其文档，未在本机实测）——opencode 自动发现 `.claude/skills` / `.agents/skills` / `.opencode/skills` 下的 skill。克隆本仓库后，把 `skills/` 暴露到其中之一即可：
 
   ```bash
-  ln -s ../skills .claude/skills      # macOS / Linux
-  # Windows：把 skills\* 复制到 .claude\skills\
+  mkdir -p .claude && ln -s ../skills .claude/skills   # macOS / Linux
+  # Windows：先建 .claude\skills 目录，再把 skills\* 复制进去
   ```
 
 > 各 Agent 跑脚本的工作目录不一定是 skill 目录；每个 `SKILL.md` 顶部的「Running the scripts」说明了如何用绝对路径调起（脚本用 `__file__` 自定位）。

--- a/skills/video-assemble/SKILL.md
+++ b/skills/video-assemble/SKILL.md
@@ -23,7 +23,7 @@ description: >
 - `work_dir/tts_meta.json` — `{segments: [...]}` from **video-voiceover** (each segment carries
   `audio_path`, timing, `pause_after_ms`, and `overlaps_speech`/placement used for ducking + subtitles).
 
-> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate from their own path, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
 
 ## Run
 

--- a/skills/video-assemble/SKILL.md
+++ b/skills/video-assemble/SKILL.md
@@ -23,6 +23,8 @@ description: >
 - `work_dir/tts_meta.json` — `{segments: [...]}` from **video-voiceover** (each segment carries
   `audio_path`, timing, `pause_after_ms`, and `overlaps_speech`/placement used for ducking + subtitles).
 
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+
 ## Run
 
 ```bash

--- a/skills/video-cut/SKILL.md
+++ b/skills/video-cut/SKILL.md
@@ -35,6 +35,8 @@ Optionally `target_duration` at the object top level (e.g. `"10m"`).
 `work_dir/narration.json` (optional, legacy single-pass path only) — segments with original-video `start`/`end` + `narration` text, consumed only when `--no-narration-map` is NOT passed.
 Each segment may carry `source_clip_id` to disambiguate when overlapping clips are allowed.
 
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+
 ## Run
 
 ```bash

--- a/skills/video-cut/SKILL.md
+++ b/skills/video-cut/SKILL.md
@@ -35,7 +35,7 @@ Optionally `target_duration` at the object top level (e.g. `"10m"`).
 `work_dir/narration.json` (optional, legacy single-pass path only) — segments with original-video `start`/`end` + `narration` text, consumed only when `--no-narration-map` is NOT passed.
 Each segment may carry `source_clip_id` to disambiguate when overlapping clips are allowed.
 
-> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate from their own path, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
 
 ## Run
 

--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -35,7 +35,7 @@ Optional MiMo scene-chunk video understanding: `--mimo-video-overview`.
 
 Overridable defaults (zero-config otherwise): see `references/config-playbook.md`.
 
-> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate from their own path, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
 
 ## Use
 

--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -35,6 +35,8 @@ Optional MiMo scene-chunk video understanding: `--mimo-video-overview`.
 
 Overridable defaults (zero-config otherwise): see `references/config-playbook.md`.
 
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+
 ## Use
 
 ### 0. Research first (recommended)

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -228,7 +228,7 @@ def _preflight_burn_subtitles(args):
             "字幕烧录已开启，但当前 ffmpeg 不支持 subtitles/libass 滤镜，整条流程会跑到最后渲染才失败。\n"
             "  解决其一：(1) 安装带 libass 的 ffmpeg；(2) 加 --no-burn-subtitles 关闭烧录"
             "（仍输出 .srt 外挂字幕）。\n"
-            "  自检：python3 skills/video-recap/scripts/doctor.py")
+            f"  自检：python3 {_entry('video-recap', 'doctor.py')}")
 
 
 def _print_narration_review_pointer(work_dir, *, review_ran=True):

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -228,7 +228,7 @@ def _preflight_burn_subtitles(args):
             "字幕烧录已开启，但当前 ffmpeg 不支持 subtitles/libass 滤镜，整条流程会跑到最后渲染才失败。\n"
             "  解决其一：(1) 安装带 libass 的 ffmpeg；(2) 加 --no-burn-subtitles 关闭烧录"
             "（仍输出 .srt 外挂字幕）。\n"
-            f"  自检：python3 {_entry('video-recap', 'doctor.py')}")
+            f"  自检：python3 {shlex.quote(str(_entry('video-recap', 'doctor.py')))}")
 
 
 def _print_narration_review_pointer(work_dir, *, review_ran=True):

--- a/skills/video-script/SKILL.md
+++ b/skills/video-script/SKILL.md
@@ -14,6 +14,8 @@ Authoring + validation of the narration script. The **agent writes `work_dir/nar
 following the rules below; then `validate.py` lints it against the understanding index, and in
 full mode time-aligns it to quiet windows.
 
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory. Some steps here call the sibling **video-recap** skill's `scripts/` (e.g. `recap_inspect.py`); resolve those the same way, via that skill's directory.
+
 ## Step 1 — read the brief
 
 Read `work_dir/agent_narration_brief.md` (scenes, durations, quiet windows, char budget) first.
@@ -21,7 +23,7 @@ Digest long dialogue via `asr_writing_chunks.json`; judge "is there speech/a sil
 via `timeline_fusion.json`. Check raw `vlm_analysis.json` / `asr_result.json` for details.
 In full mode, timestamps are **original-video time**. In orchestrated cut mode, pass 1 only writes `clip_plan.json`; after `edited_source.mp4` exists, pass 2 writes `narration.json` in **output timeline time**.
 
-写稿前先跑 `python3 skills/video-recap/scripts/recap_inspect.py --work-dir <work_dir> state` 看清楚当前模式、缺哪个产物、下一步该写什么。cut pass 2 写解说时用 `recap_inspect.py --work-dir <work_dir> clip-map --output-start <s> --output-end <e>`（或 `--source-start/--source-end`）核对输出↔原片时间轴，确认某段成片对应哪段原片、有没有跨剪辑边界或落进被剪掉的区间。
+写稿前先跑同捆 video-recap skill 的 `scripts/recap_inspect.py`（即 `recap_inspect.py --work-dir <work_dir> state`，用其绝对路径调起，见上方「Running the scripts」说明）看清楚当前模式、缺哪个产物、下一步该写什么。cut pass 2 写解说时用 `recap_inspect.py --work-dir <work_dir> clip-map --output-start <s> --output-end <e>`（或 `--source-start/--source-end`）核对输出↔原片时间轴，确认某段成片对应哪段原片、有没有跨剪辑边界或落进被剪掉的区间。
 
 ## Step 2 — write narration.json
 

--- a/skills/video-script/SKILL.md
+++ b/skills/video-script/SKILL.md
@@ -14,7 +14,7 @@ Authoring + validation of the narration script. The **agent writes `work_dir/nar
 following the rules below; then `validate.py` lints it against the understanding index, and in
 full mode time-aligns it to quiet windows.
 
-> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory. Some steps here call the sibling **video-recap** skill's `scripts/` (e.g. `recap_inspect.py`); resolve those the same way, via that skill's directory.
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate from their own path, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory. Some steps here call the sibling **video-recap** skill's `scripts/` (e.g. `recap_inspect.py`); resolve those the same way, via that skill's directory.
 
 ## Step 1 — read the brief
 

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import math
 import re
+import shlex
 from pathlib import Path
 
 from lib import CONFIG, file_fingerprint, stable_hash
@@ -1873,7 +1874,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "8. Give every block an `emotion` that fits its whole arc; keep it STEADY across the block (it is one utterance) and shift only at a real emotional turn between blocks. Use a calm base (平静/深沉/严肃) for most of a section and save 震惊/悲伤/紧张 for the actual turns.",
         "9. Between blocks, leave a gap of a few seconds with NO narration so the original audio plays alone — pick those spots at genuinely strong original moments, not arbitrarily. BRIDGE them: the block right BEFORE a gap must lead INTO that original moment (end on a line that makes the viewer want to hear what comes next), and the block right AFTER it must pick UP / react to what the original just said or showed — the narration and the original it brackets are ONE continuous beat, not 各说各的.",
         "10. 不要在解说文本里使用破折号（——、—）：破折号烧进字幕里很突兀，该停顿就用逗号，该断句就用句号；同理 `original_subtitles.json` 里也不要用破折号。",
-        f"11. After writing, run: `python3 {Path(__file__).resolve().parents[2] / 'video-recap' / 'scripts' / 'recap.py'} <video> --work-dir <work_dir>`.",
+        f"11. After writing, run: `python3 {shlex.quote(str(Path(__file__).resolve().parents[2] / 'video-recap' / 'scripts' / 'recap.py'))} <video> --work-dir <work_dir>`.",
         "",
         "## 原声留白字幕 `original_subtitles.json`（校对原声台词）",
         "",

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1873,7 +1873,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "8. Give every block an `emotion` that fits its whole arc; keep it STEADY across the block (it is one utterance) and shift only at a real emotional turn between blocks. Use a calm base (平静/深沉/严肃) for most of a section and save 震惊/悲伤/紧张 for the actual turns.",
         "9. Between blocks, leave a gap of a few seconds with NO narration so the original audio plays alone — pick those spots at genuinely strong original moments, not arbitrarily. BRIDGE them: the block right BEFORE a gap must lead INTO that original moment (end on a line that makes the viewer want to hear what comes next), and the block right AFTER it must pick UP / react to what the original just said or showed — the narration and the original it brackets are ONE continuous beat, not 各说各的.",
         "10. 不要在解说文本里使用破折号（——、—）：破折号烧进字幕里很突兀，该停顿就用逗号，该断句就用句号；同理 `original_subtitles.json` 里也不要用破折号。",
-        "11. After writing, run: `python3 skills/video-recap/scripts/recap.py <video> --work-dir <work_dir>`.",
+        f"11. After writing, run: `python3 {Path(__file__).resolve().parents[2] / 'video-recap' / 'scripts' / 'recap.py'} <video> --work-dir <work_dir>`.",
         "",
         "## 原声留白字幕 `original_subtitles.json`（校对原声台词）",
         "",

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -38,6 +38,8 @@ If `work_dir/background_research.json` exists (story research the agent did firs
 context, so scene descriptions can name people and read scenes with plot knowledge. Combine with
 `--context` for a quick inline hint.
 
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+
 ## Run
 
 ```bash

--- a/skills/video-understanding/SKILL.md
+++ b/skills/video-understanding/SKILL.md
@@ -38,7 +38,7 @@ If `work_dir/background_research.json` exists (story research the agent did firs
 context, so scene descriptions can name people and read scenes with plot knowledge. Combine with
 `--context` for a quick inline hint.
 
-> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate from their own path, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
 
 ## Run
 

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import math
 import re
+import shlex
 from pathlib import Path
 
 from lib import CONFIG, file_fingerprint, stable_hash
@@ -1873,7 +1874,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "8. Give every block an `emotion` that fits its whole arc; keep it STEADY across the block (it is one utterance) and shift only at a real emotional turn between blocks. Use a calm base (平静/深沉/严肃) for most of a section and save 震惊/悲伤/紧张 for the actual turns.",
         "9. Between blocks, leave a gap of a few seconds with NO narration so the original audio plays alone — pick those spots at genuinely strong original moments, not arbitrarily. BRIDGE them: the block right BEFORE a gap must lead INTO that original moment (end on a line that makes the viewer want to hear what comes next), and the block right AFTER it must pick UP / react to what the original just said or showed — the narration and the original it brackets are ONE continuous beat, not 各说各的.",
         "10. 不要在解说文本里使用破折号（——、—）：破折号烧进字幕里很突兀，该停顿就用逗号，该断句就用句号；同理 `original_subtitles.json` 里也不要用破折号。",
-        f"11. After writing, run: `python3 {Path(__file__).resolve().parents[2] / 'video-recap' / 'scripts' / 'recap.py'} <video> --work-dir <work_dir>`.",
+        f"11. After writing, run: `python3 {shlex.quote(str(Path(__file__).resolve().parents[2] / 'video-recap' / 'scripts' / 'recap.py'))} <video> --work-dir <work_dir>`.",
         "",
         "## 原声留白字幕 `original_subtitles.json`（校对原声台词）",
         "",

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1873,7 +1873,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "8. Give every block an `emotion` that fits its whole arc; keep it STEADY across the block (it is one utterance) and shift only at a real emotional turn between blocks. Use a calm base (平静/深沉/严肃) for most of a section and save 震惊/悲伤/紧张 for the actual turns.",
         "9. Between blocks, leave a gap of a few seconds with NO narration so the original audio plays alone — pick those spots at genuinely strong original moments, not arbitrarily. BRIDGE them: the block right BEFORE a gap must lead INTO that original moment (end on a line that makes the viewer want to hear what comes next), and the block right AFTER it must pick UP / react to what the original just said or showed — the narration and the original it brackets are ONE continuous beat, not 各说各的.",
         "10. 不要在解说文本里使用破折号（——、—）：破折号烧进字幕里很突兀，该停顿就用逗号，该断句就用句号；同理 `original_subtitles.json` 里也不要用破折号。",
-        "11. After writing, run: `python3 skills/video-recap/scripts/recap.py <video> --work-dir <work_dir>`.",
+        f"11. After writing, run: `python3 {Path(__file__).resolve().parents[2] / 'video-recap' / 'scripts' / 'recap.py'} <video> --work-dir <work_dir>`.",
         "",
         "## 原声留白字幕 `original_subtitles.json`（校对原声台词）",
         "",

--- a/skills/video-voiceover/SKILL.md
+++ b/skills/video-voiceover/SKILL.md
@@ -30,6 +30,8 @@ In the orchestrated cut-mode flow, the agent writes `narration.json` directly ag
 timeline, and the orchestrator passes it here. In the legacy direct-cut path,
 `narration_mapped.json` may be passed explicitly instead.
 
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+
 ## Run
 
 ```bash

--- a/skills/video-voiceover/SKILL.md
+++ b/skills/video-voiceover/SKILL.md
@@ -30,7 +30,7 @@ In the orchestrated cut-mode flow, the agent writes `narration.json` directly ag
 timeline, and the orchestrator passes it here. In the legacy direct-cut path,
 `narration_mapped.json` may be passed explicitly instead.
 
-> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate via `__file__`, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
+> **Running the scripts below** — the `scripts/…` paths are relative to this skill's own directory (the folder containing this `SKILL.md`). Claude Code runs commands from there, so they work as written. If your harness runs commands from the project root instead (opencode / Codex / OpenClaw commonly do), prefix this skill's absolute directory — e.g. `<skill-dir>/scripts/…`, using the directory your harness reports when it loads the skill. The scripts self-locate from their own path, so once started by the correct path they resolve their sibling skills and assets regardless of the working directory.
 
 ## Run
 

--- a/tests/orchestrator/test_plugin_manifest.py
+++ b/tests/orchestrator/test_plugin_manifest.py
@@ -1,7 +1,8 @@
 """Plugin packaging guards (no-move variant): plugin.json has exactly the 4 Anthropic keys,
 the 4 pure-tool stage skills are hidden (user-invocable: false) so video-recap is the router,
 and marketplace.json is the single Claude-compatible marketplace catalog (also imported by
-OpenClaw's `plugins install`); the plugin version stays single-sourced in plugin.json."""
+OpenClaw's `plugins install`); the plugin version stays single-sourced in plugin.json (bump it
+on each shipped change so installed users receive the update)."""
 import json
 from pathlib import Path
 
@@ -16,13 +17,17 @@ def test_plugin_manifest_has_exactly_four_keys():
 
 def test_marketplace_json_present_and_valid():
     mp = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
-    assert mp["name"] == "video-recap-skills"
+    plugin = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    assert mp["name"] == "video-recap"
     assert mp["owner"]["name"]
     plugins = mp["plugins"]
     assert len(plugins) == 1
     entry = plugins[0]
-    assert entry["name"] == "video-recap-skills"
+    # the marketplace entry name must match the plugin manifest name
+    assert entry["name"] == plugin["name"] == "video-recap-skills"
     assert entry["source"] == "./"
+    # source "./" must point at the dir that actually holds the plugin manifest
+    assert (ROOT / ".claude-plugin" / "plugin.json").exists()
     # version stays single-sourced in plugin.json; do not pin it in the marketplace entry
     assert "version" not in entry
 

--- a/tests/orchestrator/test_plugin_manifest.py
+++ b/tests/orchestrator/test_plugin_manifest.py
@@ -1,6 +1,7 @@
 """Plugin packaging guards (no-move variant): plugin.json has exactly the 4 Anthropic keys,
 the 4 pure-tool stage skills are hidden (user-invocable: false) so video-recap is the router,
-and marketplace.json stays deferred until product confirmation."""
+and marketplace.json is the single Claude-compatible marketplace catalog (also imported by
+OpenClaw's `plugins install`); the plugin version stays single-sourced in plugin.json."""
 import json
 from pathlib import Path
 
@@ -13,8 +14,17 @@ def test_plugin_manifest_has_exactly_four_keys():
     assert manifest["name"] == "video-recap-skills"
 
 
-def test_marketplace_json_is_deferred():
-    assert not (ROOT / ".claude-plugin" / "marketplace.json").exists()
+def test_marketplace_json_present_and_valid():
+    mp = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+    assert mp["name"] == "video-recap-skills"
+    assert mp["owner"]["name"]
+    plugins = mp["plugins"]
+    assert len(plugins) == 1
+    entry = plugins[0]
+    assert entry["name"] == "video-recap-skills"
+    assert entry["source"] == "./"
+    # version stays single-sourced in plugin.json; do not pin it in the marketplace entry
+    assert "version" not in entry
 
 
 def test_stage_skills_hidden_router_visible():


### PR DESCRIPTION
## What & why

Makes the skill bundle installable/usable beyond Claude Code — the cheapest in-comfort-zone reach play. The engine is already harness-agnostic (pure Python + ffmpeg + one MiMo key); this fixes the one place that wasn't (how the agent is *told* to invoke scripts) and documents per-harness install.

## Commits (independently reviewable)

1. **fix: make skill scripts cwd-robust for non-Claude harnesses** — `SKILL.md` commands like `python3 scripts/x.py` assumed the skill dir is the cwd (true in Claude Code; opencode/Codex/OpenClaw run from the project root). Adds a per-skill "Running the scripts" note and absolutizes the agent-facing resume/self-check paths (`narration.py`/`brief.py` brief step 11 → `__file__`-derived `recap.py`; `recap.py` libass hint → `_entry(...)`; `video-script/SKILL.md` `recap_inspect.py` ref). Pure correctness — scripts already self-locate via `__file__`; benefits any project-root invocation incl. Claude Code subagents. No pipeline behavior change.
2. **feat: ship Claude Code plugin marketplace (single-sourced version)** — adds `.claude-plugin/marketplace.json` so the repo installs via the standard `/plugin marketplace add owner/repo` + `/plugin install` flow (plugin.json alone doesn't satisfy that path). `source: "./"`; version stays only in `plugin.json` (no double-declare). Flips the prior `test_marketplace_json_is_deferred` guard to a presence/validity check now that shipping is confirmed. README install steps updated.
3. **docs: cross-harness install notes** — Codex and OpenClaw both consume the existing `.claude-plugin/marketplace.json` directly, so no per-harness files are needed; opencode discovers via `.claude/skills`.

## Verified

- **Codex 0.142.0** (local, isolated `CODEX_HOME`): `plugin marketplace add` + `plugin add` → all 6 skills installed, reading `.claude-plugin/marketplace.json`.
- **OpenClaw 2026.5.7** (separate box): `plugins install` imports the bundle; 6 skills `✓ ready`, visible-to-model + slash-command; folded `description: >` blocks parse fine.
- **Claude Code**: `claude plugin validate . --strict` ✓; local add/install/uninstall cycle ✓.
- `python3 scripts/test.py` all groups pass (incl. the updated packaging guard); `ruff check` clean; scripts run from a neutral cwd via absolute path.
- **opencode**: documented (`.claude/skills` discovery); *not* run-verified (the test box's opencode model config is broken) — README says so.

## Notes

- No symlinks (Windows-safe), no `.gitattributes`, no `sync_skills.py`, no per-harness manifests — the single `.claude-plugin/marketplace.json` serves Claude Code, Codex, and OpenClaw.
- The `owner/repo` install one-liners (Claude Code + Codex) go live once this is on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)