### PR TITLE
fix(assemble): 出片强制 yuv420p + faststart（微信/手机可播 + 边下边播）

### DIFF
--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1401,8 +1401,13 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     if max_h > 0:
         vf_chain.append(_output_downscale_filter(max_h))
     # yuv420p: 10-bit/4:2:2 sources re-encoded as-is play on desktop but fail on WeChat/
-    # mobile/Safari; force 8-bit 4:2:0 so every recap is universally decodable.
+    # mobile/Safari; force 8-bit 4:2:0 so every recap is universally decodable. yuv420p also
+    # needs EVEN width AND height, so normalize odd dims (4:2:2/4:4:4 permit them) before the
+    # encode — otherwise libx264 aborts to a 0-byte file. The downscale helper already evens out.
+    even = "scale=trunc(iw/2)*2:trunc(ih/2)*2"
     if vf_chain:
+        if max_h <= 0:  # no downscale in the chain to force even dims
+            vf_chain.append(even)
         cmd += ["-vf", ",".join(vf_chain), "-c:v", "libx264", "-preset", preset, "-crf", crf,
                 "-pix_fmt", "yuv420p"]
         notes = ((["遮挡原字幕"] if mask_filter else [])
@@ -1410,7 +1415,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
                  + ([f"缩放≤{max_h}p"] if max_h > 0 else []))
         log(f"视频重编码: {' + '.join(notes)} (crf={crf}, preset={preset})")
     elif CONFIG.get("force_video_reencode", False):
-        cmd += ["-c:v", "libx264", "-preset", preset, "-crf", crf, "-pix_fmt", "yuv420p"]
+        cmd += ["-vf", even, "-c:v", "libx264", "-preset", preset, "-crf", crf, "-pix_fmt", "yuv420p"]
     else:
         cmd += ["-c:v", "copy"]
 

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1400,18 +1400,24 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     # OUTPUT_MAX_HEIGHT can't crash libx264; 'min(ih,H)' only ever shrinks the source.
     if max_h > 0:
         vf_chain.append(_output_downscale_filter(max_h))
+    # yuv420p: 10-bit/4:2:2 sources re-encoded as-is play on desktop but fail on WeChat/
+    # mobile/Safari; force 8-bit 4:2:0 so every recap is universally decodable.
     if vf_chain:
-        cmd += ["-vf", ",".join(vf_chain), "-c:v", "libx264", "-preset", preset, "-crf", crf]
+        cmd += ["-vf", ",".join(vf_chain), "-c:v", "libx264", "-preset", preset, "-crf", crf,
+                "-pix_fmt", "yuv420p"]
         notes = ((["遮挡原字幕"] if mask_filter else [])
                  + (["压制解说字幕"] if CONFIG.get("burn_subtitles", False) else [])
                  + ([f"缩放≤{max_h}p"] if max_h > 0 else []))
         log(f"视频重编码: {' + '.join(notes)} (crf={crf}, preset={preset})")
     elif CONFIG.get("force_video_reencode", False):
-        cmd += ["-c:v", "libx264", "-preset", preset, "-crf", crf]
+        cmd += ["-c:v", "libx264", "-preset", preset, "-crf", crf, "-pix_fmt", "yuv420p"]
     else:
         cmd += ["-c:v", "copy"]
 
-    cmd += ["-c:a", "aac", "-b:a", "192k", "-t", str(video_duration), str(output_path)]
+    # +faststart relocates the moov atom to the front so web/social players can start
+    # before the full file downloads; valid (and beneficial) on the copy path too.
+    cmd += ["-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart",
+            "-t", str(video_duration), str(output_path)]
     try:
         result = run_cmd(cmd)
         if result.returncode != 0:

--- a/tests/assemble/test_assemble_integration.py
+++ b/tests/assemble/test_assemble_integration.py
@@ -112,11 +112,12 @@ def test_assemble_video_runs_when_source_has_no_audio_stream(tmp_path, monkeypat
     assert "audio" in _stream_types(out)
 
 
-def _make_422_source_video(path, seconds=2):
-    """A 4:2:2 source: plays on desktop but fails on WeChat/mobile if passed through as-is."""
+def _make_422_source_video(path, seconds=2, w=320, h=240):
+    """A 4:2:2 source: plays on desktop but fails on WeChat/mobile if passed through as-is.
+    4:2:2 (unlike 4:2:0) permits ODD dimensions, which is how an odd-height source arises."""
     subprocess.run([
         "ffmpeg", "-y",
-        "-f", "lavfi", "-i", f"color=c=green:s=320x240:d={seconds}:r=25",
+        "-f", "lavfi", "-i", f"color=c=green:s={w}x{h}:d={seconds}:r=25",
         "-f", "lavfi", "-i", f"sine=frequency=220:duration={seconds}",
         "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv422p",
         "-c:a", "aac", "-shortest", str(path),
@@ -129,6 +130,15 @@ def _pix_fmt(path):
          "-show_entries", "stream=pix_fmt", "-of", "csv=p=0", str(path)],
         capture_output=True, text=True,
     ).stdout.strip()
+
+
+def _dims(path):
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", str(path)],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    return tuple(int(x) for x in out.split("x"))
 
 
 def _top_level_atoms(path):
@@ -171,3 +181,44 @@ def test_output_is_yuv420p_and_faststart_on_reencode(tmp_path, monkeypatch):
     atoms = _top_level_atoms(out)
     assert "moov" in atoms and "mdat" in atoms
     assert atoms.index("moov") < atoms.index("mdat"), f"moov not front-loaded: {atoms}"
+
+
+def test_odd_height_422_force_reencode_does_not_abort(tmp_path, monkeypatch):
+    """yuv420p needs even dims; an odd-height 4:2:2 source must still produce a valid file
+    (the bare force_video_reencode branch). Without the even-normalize, libx264 aborts to 0 bytes."""
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "force_video_reencode", True)
+    work = tmp_path / "w_odd_bare"
+    work.mkdir()
+    src = tmp_path / "src_odd.mp4"
+    _make_422_source_video(src, seconds=2, w=320, h=241)  # ODD height, 4:2:2
+    assert _dims(src)[1] % 2 == 1  # precondition: odd height
+    out = work / "recap_odd.mp4"
+    segs = _segment(work, 0.3, 1.5, overlaps=True, dur=1.0)
+    assemble_video(src, segs, work, out)
+    assert out.exists() and out.stat().st_size > 0
+    assert _pix_fmt(out) == "yuv420p"
+    w, h = _dims(out)
+    assert w % 2 == 0 and h % 2 == 0  # normalized to even
+
+
+def test_odd_height_422_with_burned_subs_does_not_abort(tmp_path, monkeypatch):
+    """Same hazard via the vf_chain branch (burned subtitles, no downscale): odd-height
+    4:2:2 source must render to even yuv420p rather than aborting."""
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "burn_subtitles", True)  # drives the vf_chain branch
+    monkeypatch.setitem(CONFIG, "force_video_reencode", False)
+    work = tmp_path / "w_odd_burn"
+    work.mkdir()
+    src = tmp_path / "src_odd_burn.mp4"
+    _make_422_source_video(src, seconds=2, w=320, h=241)
+    out = work / "recap_odd_burn.mp4"
+    segs = _segment(work, 0.3, 1.5, overlaps=True, dur=1.0)
+    assemble_video(src, segs, work, out)
+    assert out.exists() and out.stat().st_size > 0
+    assert _pix_fmt(out) == "yuv420p"
+    w, h = _dims(out)
+    assert w % 2 == 0 and h % 2 == 0

--- a/tests/assemble/test_assemble_integration.py
+++ b/tests/assemble/test_assemble_integration.py
@@ -110,3 +110,64 @@ def test_assemble_video_runs_when_source_has_no_audio_stream(tmp_path, monkeypat
 
     assert out.exists() and out.stat().st_size > 0
     assert "audio" in _stream_types(out)
+
+
+def _make_422_source_video(path, seconds=2):
+    """A 4:2:2 source: plays on desktop but fails on WeChat/mobile if passed through as-is."""
+    subprocess.run([
+        "ffmpeg", "-y",
+        "-f", "lavfi", "-i", f"color=c=green:s=320x240:d={seconds}:r=25",
+        "-f", "lavfi", "-i", f"sine=frequency=220:duration={seconds}",
+        "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv422p",
+        "-c:a", "aac", "-shortest", str(path),
+    ], check=True, capture_output=True)
+
+
+def _pix_fmt(path):
+    return subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=pix_fmt", "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _top_level_atoms(path):
+    """Ordered list of top-level mp4 box types — enough to verify moov precedes mdat."""
+    atoms = []
+    data = Path(path).read_bytes()
+    i, n = 0, len(data)
+    while i + 8 <= n:
+        size = int.from_bytes(data[i:i + 4], "big")
+        atoms.append(data[i + 4:i + 8].decode("latin-1", "replace"))
+        if size == 1:  # 64-bit largesize
+            if i + 16 > n:
+                break
+            size = int.from_bytes(data[i + 8:i + 16], "big")
+        if size == 0:  # box extends to EOF
+            break
+        if size < 8:
+            break
+        i += size
+    return atoms
+
+
+def test_output_is_yuv420p_and_faststart_on_reencode(tmp_path, monkeypatch):
+    """Re-encoded recaps must be 8-bit 4:2:0 (universally decodable) with a front-loaded
+    moov atom (progressive web/social playback). Regression guard for the output encode."""
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "force_video_reencode", True)  # drives the bare libx264 branch
+    work = tmp_path / "w_pf"
+    work.mkdir()
+    src = tmp_path / "src422.mp4"
+    _make_422_source_video(src, seconds=2)
+    assert _pix_fmt(src) == "yuv422p"  # precondition: a non-420 source
+    out = work / "recap.mp4"
+    segs = _segment(work, 0.3, 1.5, overlaps=True, dur=1.0)
+    assemble_video(src, segs, work, out)
+    assert out.exists() and out.stat().st_size > 0
+    assert _pix_fmt(out) == "yuv420p", "re-encode must force 8-bit 4:2:0"
+    atoms = _top_level_atoms(out)
+    assert "moov" in atoms and "mdat" in atoms
+    assert atoms.index("moov") < atoms.index("mdat"), f"moov not front-loaded: {atoms}"


### PR DESCRIPTION
## 问题（已验证的真实 bug）

`assemble.py` 的两处出片重编码分支（libx264，L1404 vf 链 / L1410 `force_video_reencode`）**既不设 `-pix_fmt yuv420p` 也不设 `-movflags +faststart`**，而同仓的 `video-understanding/vlm.py:356-357` 早已是正确写法。后果：

- **10-bit / 4:2:2 源**照原样重编码 → 桌面能播，但**微信 / 手机 / Safari 解不了码**（成片"打不开"）。
- `moov` 原子留在文件尾部 → **网页/社交平台播放需整段下载完才起播**。

影响所有走重编码的成片。

## 改动

- 两处 libx264 分支补 `-pix_fmt yuv420p`（强制 8-bit 4:2:0，全平台可解码）。
- 最终封装统一补 `-movflags +faststart`（前置 moov；对 `-c:v copy` 路径同样有益）。

两行级改动，参照仓内既有正确写法，不改其它行为。

## 验证

- `ruff` + `py_compile` 通过；`tests/assemble/` 全绿（136 项）。
- 新增集成回归测试 `test_output_is_yuv420p_and_faststart_on_reencode`：用 **4:2:2 源**走重编码，断言成片 `pix_fmt == yuv420p` 且 `moov` 在 `mdat` 之前。
- **反向验证**：stash 掉修复后该测试 FAIL（日志里 ffmpeg cmd 确无 yuv420p / faststart），恢复后 PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)