### PR TITLE
fix(assemble): 字幕样式按画布缩放，修复竖屏(9:16)字幕被拉伸

### DIFF
--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -9,8 +9,13 @@ from lib import CONFIG
 from lib import log, run_cmd, get_video_duration
 from timeline import build_timeline, save_timeline
 
-SUBTITLE_RENDER_VERSION = 4  # bumped: BYO user_subtitles now fill gaps even with mask off
+SUBTITLE_RENDER_VERSION = 5  # bumped: subtitle style now scales to the probed canvas (fixes 竖屏 distortion)
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
+# The default subtitle metrics (font/margins/PlayRes) were tuned in this reference space.
+# For any other canvas we scale them to it so glyphs are never stretched (PlayRes aspect ==
+# frame aspect) and stay proportional; a 16:9 source reproduces the legacy look exactly.
+SUBTITLE_STYLE_REF_W = 1280
+SUBTITLE_STYLE_REF_H = 720
 _SUBTITLE_TERMINAL_PUNCTUATION = "。！？!?…."
 _SUBTITLE_CLOSING_QUOTES = "」』”’）)]】》〉\"'"
 
@@ -259,9 +264,17 @@ def _seconds_to_ass_time(seconds):
     return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
 
 
-def _subtitle_style_config():
-    """Return the internal default burn-in subtitle style."""
-    return {
+def _subtitle_style_config(canvas=None):
+    """Return the internal default burn-in subtitle style.
+
+    When ``canvas`` ({"width","height"}) is given AND the user has not pinned PlayRes via
+    SUBTITLE_PLAY_RES_X/Y, the style is scaled to that canvas: PlayRes is set to the frame
+    dimensions (so libass never stretches glyphs — the old hardcoded 1280x720 squished
+    portrait text), horizontal metrics scale with width, vertical metrics with height, and
+    the font is additionally capped so a full ``max_chars`` line fits the usable width. A
+    16:9 source (or the 1280x720 default) reproduces the legacy values exactly.
+    """
+    style = {
         "font_name": CONFIG.get("subtitle_font_name", "Arial"),
         "font_size": CONFIG.get("subtitle_font_size", 42),
         "primary_color": CONFIG.get("subtitle_primary_color", "&H00FFFFFF"),
@@ -276,6 +289,35 @@ def _subtitle_style_config():
         "play_res_x": CONFIG.get("subtitle_play_res_x", 1280),
         "play_res_y": CONFIG.get("subtitle_play_res_y", 720),
     }
+    pinned = "SUBTITLE_PLAY_RES_X" in os.environ or "SUBTITLE_PLAY_RES_Y" in os.environ
+    cw = int((canvas or {}).get("width", 0) or 0)
+    ch = int((canvas or {}).get("height", 0) or 0)
+    if canvas is None or pinned or cw <= 0 or ch <= 0:
+        return style  # legacy / manually-pinned: unchanged
+
+    base_font = float(style["font_size"])
+    kx = cw / float(SUBTITLE_STYLE_REF_W)  # horizontal metrics ∝ width
+    ky = ch / float(SUBTITLE_STYLE_REF_H)  # vertical metrics ∝ height
+    margin_l = round(float(style["margin_l"]) * kx)
+    margin_r = round(float(style["margin_r"]) * kx)
+    margin_v = round(float(style["margin_v"]) * ky)
+    # height-proportional size, then cap so a full line of CJK glyphs (≈1em wide) fits the
+    # usable width — this is what keeps portrait text on-screen instead of overflowing.
+    usable_w = max(1.0, cw - margin_l - margin_r)
+    width_cap = usable_w / max(1, int(style["max_chars"]))
+    font_size = max(1, int(min(base_font * ky, width_cap)))  # floor so a full line never overflows
+    font_scale = font_size / base_font if base_font else 1.0
+    style.update({
+        "font_size": font_size,
+        "outline": max(0, round(float(style["outline"]) * font_scale)),
+        "shadow": max(0, round(float(style["shadow"]) * font_scale)),
+        "margin_l": margin_l,
+        "margin_r": margin_r,
+        "margin_v": margin_v,
+        "play_res_x": cw,
+        "play_res_y": ch,
+    })
+    return style
 
 
 def _has_user_subtitles(work_dir):
@@ -989,10 +1031,11 @@ def _escape_ass_text(text):
     )
 
 
-def _generate_ass(narration, work_dir, video_duration=None):
+def _generate_ass(narration, work_dir, video_duration=None, canvas=None):
     """Generate an ASS subtitle file for readable hard-sub rendering. video_duration given ⇒ also
-    burn the original dialogue (from ASR) during the original-audio gaps."""
-    style = _subtitle_style_config()
+    burn the original dialogue (from ASR) during the original-audio gaps. canvas ({"width","height"})
+    scales the style to the real frame so portrait/竖屏 subtitles are not stretched."""
+    style = _subtitle_style_config(canvas)
     ass_lines = [
         "[Script Info]",
         "ScriptType: v4.00+",
@@ -1106,12 +1149,13 @@ def _apply_narration_speed(tts_segments, work_dir):
     log(f"解说整体提速: atempo={factor:.2f} ({done} 段)")
 
 
-def _source_subtitle_mask_filter():
+def _source_subtitle_mask_filter(canvas=None):
     """ffmpeg drawbox that masks burned-in source subtitles along the bottom, or None.
 
     Many source videos (e.g. 庆余年) ship hardcoded subtitles; without this the recap
     shows the original subs AND our narration subs stacked. Covers the bottom band with
-    an opaque box; our subtitles render on top of it.
+    an opaque box; our subtitles render on top of it. canvas ({"width","height"}) makes the
+    single-line band sizing match the canvas-scaled subtitle style.
     """
     if not (CONFIG.get("burn_subtitles", False) and CONFIG.get("mask_source_subtitles", False)):
         return None
@@ -1122,10 +1166,11 @@ def _source_subtitle_mask_filter():
     # not compress the picture (a 2-line band ate ~23% of the height). Take the larger of the raw
     # ratio and this single-line need.
     if CONFIG.get("burn_subtitles", False):
-        style = _subtitle_style_config()
+        style = _subtitle_style_config(canvas)
         play_res_y = max(1.0, float(style["play_res_y"]))
         line_h = float(style["font_size"]) * 1.25
-        sub_band = (float(style["margin_v"]) + line_h + 10.0) / play_res_y
+        pad = 10.0 * play_res_y / SUBTITLE_STYLE_REF_H  # keep the band pad proportional to the canvas
+        sub_band = (float(style["margin_v"]) + line_h + pad) / play_res_y
         ratio = min(0.5, max(ratio, sub_band))
     if ratio <= 0:
         return None
@@ -1300,6 +1345,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
         raise RuntimeError("tts_meta.json 没有有效解说音频，已中止以避免生成无解说视频")
 
     video_duration = get_video_duration(input_video)
+    canvas = _probe_canvas(input_video)  # drives subtitle PlayRes/scale so 竖屏 text isn't stretched
 
     # 解说整体提速（可选）后，将所有 TTS 片段按时间位置合成到与视频等长的音轨上
     _apply_narration_speed(tts_segments, work_dir)
@@ -1311,7 +1357,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     log(f"字幕文件: {srt_path}")
     ass_path = None
     if CONFIG.get("burn_subtitles", False):
-        ass_path = _generate_ass(tts_segments, work_dir, video_duration)
+        ass_path = _generate_ass(tts_segments, work_dir, video_duration, canvas)
         log(f"压制字幕文件: {ass_path}")
 
     # 可选 BGM：作为一条独立音轨（input [2:a]）混入，旁白处自动压低
@@ -1390,7 +1436,7 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     preset = str(CONFIG.get("output_preset", "veryfast") or "veryfast")
     max_h = int(CONFIG.get("output_max_height", 0) or 0)
     vf_chain = []
-    mask_filter = _source_subtitle_mask_filter()
+    mask_filter = _source_subtitle_mask_filter(canvas)
     if mask_filter:
         vf_chain.append(mask_filter)
     if CONFIG.get("burn_subtitles", False):

--- a/tests/assemble/test_assemble_integration.py
+++ b/tests/assemble/test_assemble_integration.py
@@ -161,6 +161,36 @@ def _top_level_atoms(path):
     return atoms
 
 
+def _make_portrait_source_video(path, seconds=2):
+    """A 9:16 (270x480) source — exercises the canvas-matched subtitle PlayRes path."""
+    subprocess.run([
+        "ffmpeg", "-y",
+        "-f", "lavfi", "-i", f"color=c=navy:s=270x480:d={seconds}:r=25",
+        "-f", "lavfi", "-i", f"sine=frequency=220:duration={seconds}",
+        "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-shortest", str(path),
+    ], check=True, capture_output=True)
+
+
+def test_portrait_source_burns_canvas_matched_subtitles(tmp_path, monkeypatch):
+    """A 9:16 source must burn subtitles against a frame-matching PlayRes (not the old
+    hardcoded 1280x720 16:9 box that horizontally stretched portrait glyphs)."""
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setitem(CONFIG, "burn_subtitles", True)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    work = tmp_path / "w_portrait"
+    work.mkdir()
+    src = tmp_path / "src_portrait.mp4"
+    _make_portrait_source_video(src, seconds=2)
+    out = work / "recap_portrait.mp4"
+    segs = _segment(work, 0.3, 1.5, overlaps=True, dur=1.0)
+    assemble_video(src, segs, work, out)
+    assert out.exists() and out.stat().st_size > 0
+    assert "video" in _stream_types(out)
+    ass = (work / "subtitles.ass").read_text(encoding="utf-8")
+    assert "PlayResX: 270" in ass and "PlayResY: 480" in ass
+
+
 def test_output_is_yuv420p_and_faststart_on_reencode(tmp_path, monkeypatch):
     """Re-encoded recaps must be 8-bit 4:2:0 (universally decodable) with a front-loaded
     moov atom (progressive web/social playback). Regression guard for the output encode."""

--- a/tests/assemble/test_portrait_subtitles.py
+++ b/tests/assemble/test_portrait_subtitles.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
+"""Subtitle style must scale to the probed canvas so 竖屏 (9:16) text is not stretched.
+
+Regression guard for the hardcoded 1280x720 PlayRes bug: libass interprets all style
+metrics in the PlayRes coordinate space, so a 16:9 PlayRes on a 9:16 frame squished
+glyphs horizontally and mis-sized the source-subtitle mask band. Landscape output must
+stay byte-identical; portrait must use a frame-matching PlayRes that fits the width.
+"""
+from assemble import _subtitle_style_config, _generate_ass  # noqa: E402
+
+
+def test_canvas_none_is_legacy_default():
+    # the bug was THIS PlayRes being a hardcoded 16:9 box regardless of the frame
+    s = _subtitle_style_config()
+    assert (s["play_res_x"], s["play_res_y"]) == (1280, 720)
+
+
+def test_reference_canvas_equals_legacy_exactly():
+    # a 1280x720 source must reproduce the canvas-less defaults bit for bit
+    assert _subtitle_style_config({"width": 1280, "height": 720}) == _subtitle_style_config()
+
+
+def test_1080p_16x9_is_uniformly_scaled_without_distortion():
+    base = _subtitle_style_config()
+    s = _subtitle_style_config({"width": 1920, "height": 1080})
+    assert (s["play_res_x"], s["play_res_y"]) == (1920, 1080)
+    # PlayRes aspect == frame aspect => libass applies no horizontal stretch
+    assert abs(s["play_res_x"] / s["play_res_y"] - 1920 / 1080) < 1e-9
+    # 16:9 => width never binds, so the font is purely height-proportional (the legacy look)
+    assert s["font_size"] == int(base["font_size"] * 1080 / 720)
+    assert s["margin_v"] == round(base["margin_v"] * 1080 / 720)
+    assert s["margin_l"] == round(base["margin_l"] * 1920 / 1280)
+
+
+def test_portrait_matches_frame_aspect_and_fits_width():
+    cw, ch = 1080, 1920
+    s = _subtitle_style_config({"width": cw, "height": ch})
+    # the fix: PlayRes follows the frame instead of a hardcoded 16:9 box
+    assert (s["play_res_x"], s["play_res_y"]) == (cw, ch)
+    assert abs(s["play_res_x"] / s["play_res_y"] - cw / ch) < 1e-9
+    # a full max_chars line must fit the usable width -> no horizontal overflow off-frame
+    usable_w = cw - s["margin_l"] - s["margin_r"]
+    assert s["font_size"] * s["max_chars"] <= usable_w
+    # outline scales with the glyph, not the frame, so it stays proportionate
+    assert s["outline"] >= 1
+
+
+def test_env_pinned_playres_disables_canvas_scaling(monkeypatch):
+    # explicit SUBTITLE_PLAY_RES_* is the escape hatch: canvas must be ignored
+    monkeypatch.setenv("SUBTITLE_PLAY_RES_X", "1280")
+    monkeypatch.setenv("SUBTITLE_PLAY_RES_Y", "720")
+    s = _subtitle_style_config({"width": 1080, "height": 1920})
+    assert (s["play_res_x"], s["play_res_y"]) == (1280, 720)
+    assert s["font_size"] == 42  # unscaled
+
+
+def test_generate_ass_writes_canvas_driven_playres(tmp_path):
+    segs = [{"narration": "竖屏解说测试文本", "start": 1.0, "end": 4.0}]
+    _generate_ass(segs, tmp_path, None, {"width": 1080, "height": 1920})
+    ass = (tmp_path / "subtitles.ass").read_text(encoding="utf-8")
+    assert "PlayResX: 1080" in ass
+    assert "PlayResY: 1920" in ass
+    # and the canvas-less call still emits the legacy 16:9 PlayRes
+    _generate_ass(segs, tmp_path, None)
+    legacy = (tmp_path / "subtitles.ass").read_text(encoding="utf-8")
+    assert "PlayResX: 1280" in legacy and "PlayResY: 720" in legacy


### PR DESCRIPTION
> 取代被自动关闭的 #52（它的 base 分支随 #51 合并被删，GitHub 连带关闭了它）。本 PR 直接基于 main，仅含竖屏字幕这一处改动。

## 问题（已验证的真实 bug）

ASS `PlayResX/Y` 此前硬编码 **1280×720（16:9）**（`_subtitle_style_config` → `_generate_ass` / `_source_subtitle_mask_filter`），从不参考 `_probe_canvas` 的真实画面。libass 在 PlayRes 坐标系里解释字号/边距再缩放到帧：**竖屏(9:16)源** → 16:9 的 PlayRes 映射到 9:16 画面会把字形**横向压扁、边距错位**；`play_res_y` 还驱动原字幕遮挡带高度 → 竖屏下遮挡带也算错。16:9 源因宽高比一致只是等比放大，从未暴露。

## 改动

样式改由探测画布驱动：PlayRes 跟随帧尺寸（宽高比==帧 ⇒ libass 不拉伸字形）；水平边距∝宽、垂直∝高；字号 = min(按高度成比例, 整行 `max_chars` 容进可用宽度)（向下取整保证不溢出）；描边/阴影随字号缩放；显式 `SUBTITLE_PLAY_RES_X/Y` 仍可手动固定（逃生舱）。`assemble_video` 探测一次画布并传入 `_generate_ass` / `_source_subtitle_mask_filter`。`SUBTITLE_RENDER_VERSION` 4→5。

**零回归**：16:9 源（及 1280×720 默认 / canvas 为空）逐位复现旧效果。横屏→竖屏重构图（裁剪/智能取景）不在范围内。

## 验证

- 6 个样式单测 + 1 个真·ffmpeg 270×480 竖屏渲染冒烟；全量 `scripts/test.py` 通过，`ruff check .` 干净。
- **真·MiMo 端到端实测**（404×720 竖屏片段）：成片 `pix_fmt=yuv420p`、`moov` 前置、ASS `PlayRes 404×720`、烧录中文字幕**不拉伸且容进画面宽度**（抽帧目检确认）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)