### PR TITLE
Support multi-video recaps and filesystem material reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .omx/
+.env
+.env.*
+!.env.example
 prd.json
 progress.txt
 

--- a/README.en.md
+++ b/README.en.md
@@ -49,7 +49,11 @@ flowchart LR
 /plugin install video-recap-skills@video-recap
 ```
 
-(Or just tell Claude Code: "Install this plugin: https://github.com/worldwonderer/video-recap-skills".)
+> Or skip the commands and tell Claude Code:
+>
+> ```text
+> Install this plugin: https://github.com/worldwonderer/video-recap-skills
+> ```
 
 **② Install ffmpeg** (no `pip install`: pure standard library + `ffmpeg` on `PATH`, Python 3.10+):
 
@@ -119,6 +123,28 @@ Turn /path/to/long.mp4 into a ~10-minute cut-down recap and burn the subtitles i
 
 Behind the scenes the orchestrator chains the stages, pausing so the agent can write the narration (cut mode pauses twice: first write `clip_plan.json` to pick the footage, then — once the cut is rendered — write `narration.json` against that output). Before the first run, check your setup:
 
+Multi-video recap is an MVP for cut mode only:
+
+```bash
+python3 skills/video-recap/scripts/recap.py ep1.mp4 ep2.mp4 --edit-mode cut --target-duration 10m --work-dir work_dir_multi_story
+```
+
+Each source is analyzed under `work_dir_multi_story/sources/<source_id>/`; the project-level `multi_source_manifest.json` records `source_id → source_path`, and each `clip_plan.json` clip must include `source_id`.
+
+The optional material library is filesystem-only and grep-friendly:
+
+```bash
+python3 skills/video-recap/scripts/recap.py ep1.mp4 --edit-mode cut \
+  --material-library-dir .video-materials --save-materials
+
+grep -R "hero" .video-materials
+
+python3 skills/video-recap/scripts/recap.py ep1.mp4 ep2.mp4 --edit-mode cut \
+  --material-library-dir .video-materials --use-materials
+```
+
+It stores small JSON/MD artifacts plus an append-only `materials_index.jsonl`; it does not copy raw media, create a DB, or use embeddings/semantic search.
+
 ```bash
 python3 skills/video-recap/scripts/recap.py --doctor
 ```
@@ -151,6 +177,8 @@ It runs English ASR, splits into complete sentences, pulls one reference clip, t
 - `work_dir/agent_narration_brief.md`: timing and scene brief for the agent
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`: understanding artifacts
 - `work_dir/clip_plan.json` · `edited_source.mp4` · `recap_phase.json`: cut-mode artifacts (narration is written on the output timeline; `recap_phase.json` records cut/narrate progress for deterministic resume)
+- `work_dir/multi_source_manifest.json` · `work_dir/sources/<source_id>/`: multi-video cut source manifest and per-source analysis artifacts
+- `<material-library-dir>/materials/<material_id>/material.json|material.md` · `materials_index.jsonl`: optional grep-friendly material library for reusing analyzed sources
 - `work_dir/timeline.json` · `work_dir/assembly_manifest.json` · `tts_segments/` · `tts_meta.json`: multi-track timeline, slim render record, and TTS audio
 
 ## Bring your own original-dialogue subtitles (optional, more accurate)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ flowchart LR
 /plugin install video-recap-skills@video-recap
 ```
 
-（也可以直接对 claude code 说「安装这个插件：https://github.com/worldwonderer/video-recap-skills」。）
+> 也可以跳过命令，直接对 Claude Code 说：
+>
+> ```text
+> 安装这个插件：https://github.com/worldwonderer/video-recap-skills
+> ```
 
 **② 装 ffmpeg**（不用 `pip install`：纯标准库 + `PATH` 上的 `ffmpeg`，Python 3.10+）：
 
@@ -119,6 +123,28 @@ export MIMO_TOKEN_PLAN_CLUSTER=cn
 
 背后是编排器把几个阶段串起来跑，中间停下来让 Agent 写解说（剪辑模式会停两次：先写 `clip_plan.json` 挑片段，剪成成片后再对着成片写 `narration.json`）。第一次跑前可先自检环境：
 
+多视频剪辑 MVP 只支持剪辑模式：
+
+```bash
+python3 skills/video-recap/scripts/recap.py ep1.mp4 ep2.mp4 --edit-mode cut --target-duration 10m --work-dir work_dir_multi_story
+```
+
+它会在 `work_dir_multi_story/sources/<source_id>/` 分别沉淀每个源视频的理解产物，在项目级 `multi_source_manifest.json` 里记录 `source_id → source_path`，并要求 `clip_plan.json` 的每个片段写明 `source_id`。
+
+可选素材库也是纯文件系统，方便以后 grep 复用已分析素材：
+
+```bash
+python3 skills/video-recap/scripts/recap.py ep1.mp4 --edit-mode cut \
+  --material-library-dir .video-materials --save-materials
+
+grep -R "范闲" .video-materials
+
+python3 skills/video-recap/scripts/recap.py ep1.mp4 ep2.mp4 --edit-mode cut \
+  --material-library-dir .video-materials --use-materials
+```
+
+素材库只保存 JSON/MD 小文件和追加式 `materials_index.jsonl`，不复制原始媒体、不建数据库、不做 embedding/语义搜索。
+
 ```bash
 python3 skills/video-recap/scripts/recap.py --doctor
 ```
@@ -151,6 +177,8 @@ python3 skills/video-recap/scripts/recap.py --doctor
 - `work_dir/agent_narration_brief.md`：给 Agent 的时间和场景 brief
 - `work_dir/vlm_analysis.json` · `asr_result.json` · `silence_periods.json` · `timeline_fusion.json`：理解产物
 - `work_dir/clip_plan.json` · `edited_source.mp4` · `recap_phase.json`：剪辑模式产物（解说在成片时间轴上写，`recap_phase.json` 记录剪/配进度供断点续跑）
+- `work_dir/multi_source_manifest.json` · `work_dir/sources/<source_id>/`：多视频 cut 的来源清单与每个源视频的理解产物
+- `<material-library-dir>/materials/<material_id>/material.json|material.md` · `materials_index.jsonl`：可选素材库，方便 `grep -R` 查找/复用已分析素材
 - `work_dir/timeline.json` · `work_dir/assembly_manifest.json` · `tts_segments/` · `tts_meta.json`：多轨时间线、渲染记录与 TTS 音频
 
 ## 自带原声字幕（可选，更准）

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -162,19 +162,15 @@ def _build_video_clips(input_video, work_dir, duration_s):
         plan = _load_cut_timeline_plan(work_dir)
         if plan is not None:
             entries = plan.get("clips", plan) if isinstance(plan, dict) else plan
+            # A plan is "multi-source" once any clip carries its own source_path; such
+            # clips must never be silently dropped — a missing one is degraded in place.
+            multi_source = any(
+                isinstance(c, dict) and str(c.get("source_path") or "").strip() for c in entries
+            )
             clips, cursor = [], 0.0
             for c in entries:
                 per_clip_source = str(c.get("source_path") or "").strip()
                 source_path = per_clip_source or explicit_source_video
-                if not source_path or not os.path.exists(source_path):
-                    if per_clip_source:
-                        log(f"  时间线: source_path 不存在，回退为剪后成片单片段: {source_path}")
-                        return [{"source_path": str(input_video), "source_start": 0.0,
-                                 "source_end": float(duration_s), "timeline_start": 0.0,
-                                 "timeline_end": float(duration_s),
-                                 "provenance_degraded": True,
-                                 "provenance_reason": f"missing_source_path:{source_path}"}]
-                    continue
                 ss = float(c.get("source_start", c.get("start")))
                 se = float(c.get("source_end", c.get("end")))
                 timeline_start = c.get("output_start")
@@ -190,7 +186,24 @@ def _build_video_clips(input_video, work_dir, duration_s):
                     timeline_start = float(timeline_start)
                     timeline_end = float(timeline_end)
                     cursor = max(cursor, timeline_end)
-                clips.append({"source_path": source_path, "source_start": ss,
+                if not source_path or not os.path.exists(source_path):
+                    if per_clip_source or multi_source:
+                        # Degrade ONLY this clip — point it at the rendered cut for its own
+                        # output window — and keep real provenance for every present source,
+                        # instead of collapsing the whole multi-source timeline.
+                        seg = max(0.0, float(timeline_end) - float(timeline_start))
+                        log(f"  时间线: source_path 不存在，该片段降级为剪后成片片段: {source_path or '(unset)'}")
+                        clips.append({"source_id": c.get("source_id"),
+                                      "source_path": str(input_video),
+                                      "source_start": float(timeline_start),
+                                      "source_end": float(timeline_start) + seg,
+                                      "timeline_start": float(timeline_start),
+                                      "timeline_end": float(timeline_end),
+                                      "provenance_degraded": True,
+                                      "provenance_reason": f"missing_source_path:{source_path or 'unset'}"})
+                    continue
+                clips.append({"source_id": c.get("source_id"),
+                              "source_path": source_path, "source_start": ss,
                               "source_end": se, "timeline_start": timeline_start,
                               "timeline_end": timeline_end})
             if clips:

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -56,6 +56,14 @@ def _source_video_identity():
     return str(path.resolve()), _artifact_fingerprint(path)
 
 
+def _timeline_provenance_status(work_dir):
+    data = _load_work_json(work_dir, "timeline.json")
+    if not isinstance(data, dict):
+        return None
+    provenance = data.get("provenance")
+    return provenance if isinstance(provenance, dict) else None
+
+
 def _assembly_manifest_payload(input_video, tts_segments, work_dir, output_path,
                                tts_meta_path=None, final_output=None):
     """Slim render record. The orchestrator reads `final_output` to report the result;
@@ -76,6 +84,9 @@ def _assembly_manifest_payload(input_video, tts_segments, work_dir, output_path,
     }
     if final_output is not None:
         payload["final_output"] = str(Path(final_output).resolve())
+    provenance = _timeline_provenance_status(work_dir)
+    if provenance:
+        payload["timeline_provenance"] = provenance
     return payload
 
 
@@ -142,19 +153,28 @@ def _has_audio_stream(video_path):
 def _build_video_clips(input_video, work_dir, duration_s):
     """Video-track clips for the timeline.
 
-    In cut mode (a clip_plan.json + a known original source) each plan entry
-    becomes a clip referencing the ORIGINAL source range, so an editor sees the
-    real cuts. Otherwise (or full mode) the rendered input is a single clip.
+    In cut mode each plan entry becomes a clip referencing the ORIGINAL source
+    range. Multi-source validated plans carry per-clip source_path and do not
+    require an explicit ambient --source-video.
     """
-    source_video = _explicit_source_video()
-    if source_video and os.path.exists(source_video):
-        try:
-            plan = _load_cut_timeline_plan(work_dir)
-            if plan is None:
-                raise ValueError("missing clip_plan.json")
+    explicit_source_video = _explicit_source_video()
+    try:
+        plan = _load_cut_timeline_plan(work_dir)
+        if plan is not None:
             entries = plan.get("clips", plan) if isinstance(plan, dict) else plan
             clips, cursor = [], 0.0
             for c in entries:
+                per_clip_source = str(c.get("source_path") or "").strip()
+                source_path = per_clip_source or explicit_source_video
+                if not source_path or not os.path.exists(source_path):
+                    if per_clip_source:
+                        log(f"  时间线: source_path 不存在，回退为剪后成片单片段: {source_path}")
+                        return [{"source_path": str(input_video), "source_start": 0.0,
+                                 "source_end": float(duration_s), "timeline_start": 0.0,
+                                 "timeline_end": float(duration_s),
+                                 "provenance_degraded": True,
+                                 "provenance_reason": f"missing_source_path:{source_path}"}]
+                    continue
                 ss = float(c.get("source_start", c.get("start")))
                 se = float(c.get("source_end", c.get("end")))
                 timeline_start = c.get("output_start")
@@ -170,13 +190,13 @@ def _build_video_clips(input_video, work_dir, duration_s):
                     timeline_start = float(timeline_start)
                     timeline_end = float(timeline_end)
                     cursor = max(cursor, timeline_end)
-                clips.append({"source_path": source_video, "source_start": ss,
+                clips.append({"source_path": source_path, "source_start": ss,
                               "source_end": se, "timeline_start": timeline_start,
                               "timeline_end": timeline_end})
             if clips:
                 return clips
-        except (TypeError, ValueError, KeyError, OSError) as exc:
-            log(f"  时间线: clip_plan 解析失败，回退单片 ({exc})")
+    except (TypeError, ValueError, KeyError, OSError) as exc:
+        log(f"  时间线: clip_plan 解析失败，回退单片 ({exc})")
     return [{"source_path": str(input_video), "source_start": 0.0,
              "source_end": float(duration_s), "timeline_start": 0.0,
              "timeline_end": float(duration_s)}]
@@ -237,6 +257,19 @@ def _emit_timeline(input_video, tts_segments, work_dir, duration_s, has_bgm):
     timeline = build_timeline(canvas, duration_s, video_clips,
                               narration_segments, bgm=bgm, ducking=ducking,
                               subtitle_segments=subtitle_segments)
+    degraded = [
+        {
+            "source_path": clip.get("source_path"),
+            "reason": clip.get("provenance_reason") or "unknown",
+        }
+        for clip in video_clips
+        if clip.get("provenance_degraded")
+    ]
+    if degraded:
+        timeline["provenance"] = {"degraded": True, "degraded_clips": degraded}
+        log(f"  ⚠️ 时间线 provenance 降级: {degraded[0]['reason']} ({len(degraded)} clip)")
+    else:
+        timeline["provenance"] = {"degraded": False}
     out = Path(work_dir) / "timeline.json"
     save_timeline(timeline, out)
     log(f"时间线模型: {out} ({len(timeline['tracks'])} 轨)")

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -125,31 +125,204 @@ def _load_edited_source_meta(output_path):
     return data if isinstance(data, dict) else None
 
 
-def _write_edited_source_meta(output_path, validated_plan, input_video):
+def _source_fingerprints_for_plan(validated_plan, input_video=None):
+    """Fingerprint every media file that can affect edited_source.mp4 bytes."""
+    paths = []
+    for clip in (validated_plan.get("clips", []) if isinstance(validated_plan, dict) else []):
+        if clip.get("source_path"):
+            paths.append(str(clip["source_path"]))
+    if not paths and input_video is not None:
+        paths.append(str(input_video))
+    fingerprints = {}
+    for path in sorted(set(paths)):
+        fingerprints[str(Path(path))] = file_fingerprint(path)
+    return fingerprints
+
+
+def _write_edited_source_meta(output_path, validated_plan, input_video=None):
     meta_path = _edited_source_meta_path(output_path)
-    meta_path.write_text(json.dumps({
-        "schema_version": 1,
+    source_fingerprints = _source_fingerprints_for_plan(validated_plan, input_video)
+    has_plan_sources = any(
+        clip.get("source_path")
+        for clip in (validated_plan.get("clips", []) if isinstance(validated_plan, dict) else [])
+    )
+    legacy_source_fp = (
+        file_fingerprint(input_video)
+        if input_video is not None and not has_plan_sources and len(source_fingerprints) == 1
+        else None
+    )
+    meta = {
+        "schema_version": 2,
         "clip_plan_fingerprint": cut_plan_fingerprint(validated_plan),
-        "source_video_fingerprint": file_fingerprint(input_video),
+        "source_fingerprints": source_fingerprints,
         "edited_source_fingerprint": file_fingerprint(output_path),
         "total_duration": validated_plan.get("total_duration"),
         "clip_count": len(validated_plan.get("clips", [])),
-    }, ensure_ascii=False, indent=2), encoding="utf-8")
+    }
+    # Preserve the legacy key for existing single-source callers/tests/metadata readers.
+    if legacy_source_fp is not None:
+        meta["source_video_fingerprint"] = legacy_source_fp
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-def should_reuse_edited_source(output_path, validated_plan, input_video):
+def should_reuse_edited_source(output_path, validated_plan, input_video=None):
     """Return True only when edited_source.mp4 matches source media and cut params."""
     output_path = Path(output_path)
     if not output_path.exists():
         return False
     meta = _load_edited_source_meta(output_path)
+    if not meta or meta.get("clip_plan_fingerprint") != cut_plan_fingerprint(validated_plan):
+        return False
+    expected_sources = _source_fingerprints_for_plan(validated_plan, input_video)
+    meta_sources = meta.get("source_fingerprints")
+    if meta_sources is None and input_video is not None:
+        meta_sources = {str(Path(input_video)): meta.get("source_video_fingerprint")}
     return bool(
-        meta
-        and meta.get("clip_plan_fingerprint") == cut_plan_fingerprint(validated_plan)
-        and meta.get("source_video_fingerprint") == file_fingerprint(input_video)
+        meta_sources == expected_sources
         and meta.get("edited_source_fingerprint") == file_fingerprint(output_path)
     )
 
+
+
+def _manifest_source_entries(sources_manifest):
+    """Return source rows from common multi-source manifest shapes."""
+    if isinstance(sources_manifest, dict):
+        if isinstance(sources_manifest.get("sources"), list):
+            return sources_manifest["sources"]
+        rows = []
+        for source_id, value in sources_manifest.items():
+            if source_id in {"schema_version", "version"}:
+                continue
+            if isinstance(value, dict):
+                row = dict(value)
+                row.setdefault("source_id", source_id)
+                rows.append(row)
+        if rows:
+            return rows
+    elif isinstance(sources_manifest, list):
+        return sources_manifest
+    raise ValueError("sources manifest must be a list, a {sources:[...]} object, or a source_id map")
+
+
+def normalize_sources_manifest(sources_manifest):
+    """Normalize source manifest rows to {source_id: {source_path, duration}}."""
+    sources = {}
+    for idx, raw in enumerate(_manifest_source_entries(sources_manifest)):
+        if not isinstance(raw, dict):
+            raise ValueError(f"source #{idx + 1} must be an object")
+        source_id = raw.get("source_id", raw.get("id", raw.get("name")))
+        if source_id in (None, ""):
+            raise ValueError(f"source #{idx + 1} is missing source_id")
+        source_id = str(source_id)
+        source_path = raw.get("source_path", raw.get("path", raw.get("video_path", raw.get("video", raw.get("file")))))
+        if not source_path:
+            raise ValueError(f"source {source_id} is missing source_path/path")
+        duration = raw.get("duration", raw.get("duration_seconds", raw.get("source_duration")))
+        if duration in (None, ""):
+            duration = get_video_duration(source_path)
+        try:
+            duration = max(0.0, float(duration or 0.0))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"source {source_id} has invalid duration") from exc
+        sources[source_id] = {"source_id": source_id, "source_path": str(source_path), "duration": duration}
+    if not sources:
+        raise ValueError("sources manifest has no sources")
+    return sources
+
+
+def normalize_multi_source_clip_plan(raw_plan, sources_manifest, target_duration=None, clip_padding=0.0, min_clip_duration=0.3, allow_overlap=False):
+    """Validate a multi-source clip plan and map source_id clips to source paths/durations.
+
+    Clip order follows the raw plan; overlap validation is isolated per source_id.
+    """
+    sources = normalize_sources_manifest(sources_manifest)
+    if isinstance(raw_plan, dict):
+        raw_clips = raw_plan.get("clips", [])
+        plan_target = raw_plan.get("target_duration") or raw_plan.get("target_duration_seconds")
+        if target_duration is None and plan_target not in (None, ""):
+            target_duration = parse_duration_seconds(plan_target)
+    elif isinstance(raw_plan, list):
+        raw_clips = raw_plan
+    else:
+        raise ValueError("clip_plan.json must be a JSON array or an object with a clips array")
+
+    if not isinstance(raw_clips, list):
+        raise ValueError("clip_plan.json field `clips` must be an array")
+
+    padding = max(0.0, float(clip_padding or 0.0))
+    min_duration = max(0.05, float(min_clip_duration or 0.05))
+    clips = []
+    source_ranges = {}
+    cursor = 0.0
+
+    for idx, raw in enumerate(raw_clips):
+        if not isinstance(raw, dict):
+            log(f"  跳过无效 clip #{idx + 1}: not an object")
+            continue
+        source_id = raw.get("source_id", raw.get("id"))
+        if source_id in (None, ""):
+            raise ValueError(f"clip #{idx + 1} is missing source_id")
+        source_id = str(source_id)
+        source = sources.get(source_id)
+        if not source:
+            raise ValueError(f"clip #{idx + 1} references unknown source_id: {source_id}")
+        try:
+            raw_start = float(_clip_value(raw, "start", "source_start", "in"))
+            raw_end = float(_clip_value(raw, "end", "source_end", "out"))
+        except (TypeError, ValueError):
+            log(f"  跳过无效 clip #{idx + 1}: missing numeric start/end")
+            continue
+        if raw_end - raw_start < min_duration:
+            log(f"  跳过过短 clip #{idx + 1}: {raw_start:.1f}-{raw_end:.1f}s")
+            continue
+        source_duration = source["duration"]
+        start = round(max(0.0, min(raw_start - padding, source_duration)), 3)
+        end = round(max(0.0, min(raw_end + padding, source_duration)), 3)
+        if end - start < min_duration:
+            log(f"  跳过过短 clip #{idx + 1}: {start:.1f}-{end:.1f}s")
+            continue
+        ranges = source_ranges.setdefault(source_id, [])
+        overlaps = [r for r in ranges if start < r[1] and end > r[0]]
+        if overlaps and not allow_overlap:
+            raise ValueError(
+                f"clip #{idx + 1} overlaps an earlier source range for source_id {source_id}; "
+                "split or remove duplicate source footage before mapping narration"
+            )
+        ranges.append((start, end))
+
+        duration = round(end - start, 3)
+        clip = {
+            "clip_id": len(clips),
+            "source_id": source_id,
+            "source_path": source["source_path"],
+            "source_start": start,
+            "source_end": end,
+            "output_start": round(cursor, 3),
+            "output_end": round(cursor + duration, 3),
+            "duration": duration,
+            "reason": str(raw.get("reason", raw.get("note", ""))).strip(),
+        }
+        clips.append(clip)
+        cursor += duration
+
+    if not clips:
+        raise ValueError("clip_plan.json has no valid clips")
+
+    total_duration = round(sum(c["duration"] for c in clips), 3)
+    plan = {
+        "clips": clips,
+        "total_duration": total_duration,
+        "target_duration": round(float(target_duration), 3) if target_duration else None,
+        "sources": {sid: {"source_path": s["source_path"], "duration": round(s["duration"], 3)} for sid, s in sources.items()},
+        "allow_overlap": bool(allow_overlap),
+    }
+    if target_duration and total_duration > target_duration * 1.15:
+        plan["warning"] = (
+            f"validated clips total {total_duration:.1f}s exceeds target "
+            f"{float(target_duration):.1f}s by more than 15%"
+        )
+        log(f"警告: {plan['warning']}")
+    return plan
 
 def normalize_clip_plan(raw_plan, video_duration, target_duration=None, clip_padding=0.0, min_clip_duration=0.3, allow_overlap=False):
     """Validate and enrich an agent-authored clip plan.
@@ -557,31 +730,40 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
     if not clips:
         raise ValueError("validated clip plan has no clips")
 
-    has_audio = _has_audio_stream(input_video)
+    source_paths = []
+    for clip in clips:
+        source_path = str(clip.get("source_path") or input_video)
+        if source_path not in source_paths:
+            source_paths.append(source_path)
+    source_index = {path: idx for idx, path in enumerate(source_paths)}
+    audio_by_input = {path: _has_audio_stream(path) for path in source_paths}
+    has_audio = all(audio_by_input.values())
+
     parts = []
     concat_inputs = []
     for clip in clips:
         idx = clip["clip_id"]
+        input_idx = source_index[str(clip.get("source_path") or input_video)]
         start = clip["source_start"]
         end = clip["source_end"]
         parts.append(
-            f"[0:v]trim=start={start:.3f}:end={end:.3f},setpts=PTS-STARTPTS[v{idx}]"
+            f"[{input_idx}:v]trim=start={start:.3f}:end={end:.3f},setpts=PTS-STARTPTS[v{idx}]"
         )
         concat_inputs.append(f"[v{idx}]")
         if has_audio:
             parts.append(
-                f"[0:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS[a{idx}]"
+                f"[{input_idx}:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS[a{idx}]"
             )
             concat_inputs.append(f"[a{idx}]")
 
+    extra_inputs = []
     if has_audio:
         parts.append("".join(concat_inputs) + f"concat=n={len(clips)}:v=1:a=1[v][a]")
         maps = ["-map", "[v]", "-map", "[a]"]
-        extra_inputs = []
     else:
         total = validated_plan.get("total_duration") or sum(c["duration"] for c in clips)
         parts.append("".join(concat_inputs) + f"concat=n={len(clips)}:v=1:a=0[v]")
-        maps = ["-map", "[v]", "-map", "1:a", "-shortest"]
+        maps = ["-map", "[v]", "-map", f"{len(source_paths)}:a", "-shortest"]
         extra_inputs = ["-f", "lavfi", "-t", f"{float(total):.3f}", "-i", "anullsrc=channel_layout=stereo:sample_rate=48000"]
 
     filter_complex = ";".join(parts)
@@ -591,7 +773,10 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
     else:
         filter_args = ["-filter_complex", filter_complex]
 
-    cmd = ["ffmpeg", "-y", "-i", str(input_video), *extra_inputs, *filter_args, *maps,
+    input_args = []
+    for source_path in source_paths:
+        input_args.extend(["-i", str(source_path)])
+    cmd = ["ffmpeg", "-y", *input_args, *extra_inputs, *filter_args, *maps,
            "-c:v", "libx264", "-preset", "veryfast", "-crf", "18", "-c:a", "aac", "-b:a", "192k", str(output_path)]
     result = run_cmd(cmd)
     if result.returncode != 0:
@@ -610,6 +795,8 @@ def main():
     parser.add_argument("video", help="source video path")
     parser.add_argument("--work-dir", required=True, help="dir holding clip_plan.json (and optionally narration.json)")
     parser.add_argument("--clip-plan", default=None, help="clip plan json (default: <work-dir>/clip_plan.json)")
+    parser.add_argument("--sources-manifest", default=None,
+                        help="multi-source manifest json mapping source_id values to source media")
     parser.add_argument("--narration", default=None, help="narration json to map (default: <work-dir>/narration.json)")
     parser.add_argument("--target-duration", default=None, help="target output duration, e.g. 10m / 600 / 00:10:00")
     parser.add_argument("--clip-padding", type=float, default=0.0, help="seconds to pad each clip on both ends")
@@ -630,16 +817,27 @@ def main():
     raw_plan = load_clip_plan(clip_plan_path)
 
     target_seconds = parse_duration_seconds(args.target_duration) if args.target_duration else None
-    video_duration = get_video_duration(args.video)
-    validated_plan = normalize_clip_plan(
-        raw_plan,
-        video_duration,
-        target_duration=target_seconds,
-        clip_padding=args.clip_padding,
-        allow_overlap=args.allow_overlap,
-    )
+    sources_manifest = json.loads(Path(args.sources_manifest).read_text(encoding="utf-8")) if args.sources_manifest else None
+    if sources_manifest is not None:
+        validated_plan = normalize_multi_source_clip_plan(
+            raw_plan,
+            sources_manifest,
+            target_duration=target_seconds,
+            clip_padding=args.clip_padding,
+            allow_overlap=args.allow_overlap,
+        )
+        video_duration = None
+    else:
+        video_duration = get_video_duration(args.video)
+        validated_plan = normalize_clip_plan(
+            raw_plan,
+            video_duration,
+            target_duration=target_seconds,
+            clip_padding=args.clip_padding,
+            allow_overlap=args.allow_overlap,
+        )
 
-    if CONFIG.get("snap_clip_line_end", True):
+    if sources_manifest is None and CONFIG.get("snap_clip_line_end", True):
         silence_path = work_dir / "silence_periods.json"
         silence_periods = []
         if silence_path.exists():
@@ -659,7 +857,7 @@ def main():
     # Keep boundaries off the original footage's hard cuts (avoids 闪烁 at the edit point).
     # Runs after the line-snap so it refines the final source ranges; video-clean wins on the rare
     # boundary that is both in a quiet window and beside a shot-change.
-    if CONFIG.get("scene_cut_snap", True):
+    if sources_manifest is None and CONFIG.get("scene_cut_snap", True):
         validated_plan = snap_clips_off_shot_changes(
             validated_plan,
             args.video,

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -716,6 +716,45 @@ def _has_audio_stream(video_path):
     return result.returncode == 0 and bool(result.stdout.strip())
 
 
+def _probe_video_geometry(video_path):
+    """Best-effort (width, height, fps) for a source; falls back to a safe even-sized canvas.
+
+    Used to normalize heterogeneous multi-source segments to one geometry before concat
+    (ffmpeg's concat filter rejects mismatched width/height/SAR/pixel-format/fps).
+    """
+    width = height = 0
+    fps = 0.0
+    cmd = [
+        "ffprobe", "-v", "error", "-select_streams", "v:0",
+        "-show_entries", "stream=width,height,r_frame_rate",
+        "-of", "csv=p=0:s=,", str(video_path),
+    ]
+    try:
+        result = run_cmd(cmd)
+    except Exception:  # noqa: BLE001 - probing is best-effort; fall back to defaults
+        result = None
+    if result is not None and getattr(result, "returncode", 1) == 0 and (result.stdout or "").strip():
+        parts = result.stdout.strip().splitlines()[0].split(",")
+        try:
+            width, height = int(float(parts[0])), int(float(parts[1]))
+        except (IndexError, ValueError):
+            width = height = 0
+        if len(parts) >= 3 and "/" in parts[2]:
+            num, _, den = parts[2].partition("/")
+            try:
+                num_f, den_f = float(num), float(den)
+                fps = num_f / den_f if den_f > 0 else 0.0
+            except ValueError:
+                fps = 0.0
+    if width <= 0 or height <= 0:
+        width, height = 1280, 720
+    width -= width % 2          # libx264/yuv420p require even dimensions
+    height -= height % 2
+    if not 0 < fps <= 120:
+        fps = 30.0
+    return width, height, round(fps, 3)
+
+
 def _write_filter_script(filter_complex, work_dir):
     script_path = Path(work_dir) / "edit_filter_complex.txt"
     script_path.write_text(filter_complex, encoding="utf-8")
@@ -737,34 +776,68 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
             source_paths.append(source_path)
     source_index = {path: idx for idx, path in enumerate(source_paths)}
     audio_by_input = {path: _has_audio_stream(path) for path in source_paths}
-    has_audio = all(audio_by_input.values())
 
     parts = []
     concat_inputs = []
-    for clip in clips:
-        idx = clip["clip_id"]
-        input_idx = source_index[str(clip.get("source_path") or input_video)]
-        start = clip["source_start"]
-        end = clip["source_end"]
-        parts.append(
-            f"[{input_idx}:v]trim=start={start:.3f}:end={end:.3f},setpts=PTS-STARTPTS[v{idx}]"
-        )
-        concat_inputs.append(f"[v{idx}]")
-        if has_audio:
-            parts.append(
-                f"[{input_idx}:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS[a{idx}]"
-            )
-            concat_inputs.append(f"[a{idx}]")
-
     extra_inputs = []
-    if has_audio:
+    if len(source_paths) > 1:
+        # Distinct sources almost always differ in resolution/SAR/fps/pixel-format (and
+        # some may lack audio), which the bare concat filter rejects. Normalize every video
+        # segment to one canvas and give every clip an audio segment (real or synthesized
+        # silence) so concat always succeeds with a continuous track and no source's audio
+        # is dropped just because a sibling source is silent.
+        canvas_w, canvas_h, canvas_fps = _probe_video_geometry(source_paths[0])
+        vnorm = (f"scale={canvas_w}:{canvas_h}:force_original_aspect_ratio=decrease,"
+                 f"pad={canvas_w}:{canvas_h}:(ow-iw)/2:(oh-ih)/2,setsar=1,"
+                 f"fps={canvas_fps},format=yuv420p")
+        for clip in clips:
+            idx = clip["clip_id"]
+            clip_source = str(clip.get("source_path") or input_video)
+            input_idx = source_index[clip_source]
+            start = clip["source_start"]
+            end = clip["source_end"]
+            dur = max(0.0, float(end) - float(start))
+            parts.append(
+                f"[{input_idx}:v]trim=start={start:.3f}:end={end:.3f},setpts=PTS-STARTPTS,{vnorm}[v{idx}]"
+            )
+            if audio_by_input.get(clip_source):
+                parts.append(
+                    f"[{input_idx}:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS,"
+                    f"aresample=48000,aformat=sample_rates=48000:channel_layouts=stereo[a{idx}]"
+                )
+            else:
+                parts.append(
+                    f"anullsrc=r=48000:cl=stereo,atrim=duration={dur:.3f},asetpts=PTS-STARTPTS,"
+                    f"aformat=sample_rates=48000:channel_layouts=stereo[a{idx}]"
+                )
+            concat_inputs.append(f"[v{idx}][a{idx}]")
         parts.append("".join(concat_inputs) + f"concat=n={len(clips)}:v=1:a=1[v][a]")
         maps = ["-map", "[v]", "-map", "[a]"]
     else:
-        total = validated_plan.get("total_duration") or sum(c["duration"] for c in clips)
-        parts.append("".join(concat_inputs) + f"concat=n={len(clips)}:v=1:a=0[v]")
-        maps = ["-map", "[v]", "-map", f"{len(source_paths)}:a", "-shortest"]
-        extra_inputs = ["-f", "lavfi", "-t", f"{float(total):.3f}", "-i", "anullsrc=channel_layout=stereo:sample_rate=48000"]
+        has_audio = all(audio_by_input.values())
+        for clip in clips:
+            idx = clip["clip_id"]
+            input_idx = source_index[str(clip.get("source_path") or input_video)]
+            start = clip["source_start"]
+            end = clip["source_end"]
+            parts.append(
+                f"[{input_idx}:v]trim=start={start:.3f}:end={end:.3f},setpts=PTS-STARTPTS[v{idx}]"
+            )
+            concat_inputs.append(f"[v{idx}]")
+            if has_audio:
+                parts.append(
+                    f"[{input_idx}:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS[a{idx}]"
+                )
+                concat_inputs.append(f"[a{idx}]")
+
+        if has_audio:
+            parts.append("".join(concat_inputs) + f"concat=n={len(clips)}:v=1:a=1[v][a]")
+            maps = ["-map", "[v]", "-map", "[a]"]
+        else:
+            total = validated_plan.get("total_duration") or sum(c["duration"] for c in clips)
+            parts.append("".join(concat_inputs) + f"concat=n={len(clips)}:v=1:a=0[v]")
+            maps = ["-map", "[v]", "-map", f"{len(source_paths)}:a", "-shortest"]
+            extra_inputs = ["-f", "lavfi", "-t", f"{float(total):.3f}", "-i", "anullsrc=channel_layout=stereo:sample_rate=48000"]
 
     filter_complex = ";".join(parts)
     if len(filter_complex.encode("utf-8")) > 7000:

--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -57,6 +57,21 @@ Runs video-understanding (using `background_research.json` if you wrote it), wri
 **video-script** skill (read the brief first).
 Cut mode (`--edit-mode cut --target-duration 10m`) also requires `clip_plan.json`.
 
+Multi-video is cut-only. Use multiple positional videos plus `--edit-mode cut`; the generated project brief lists stable `source_id` values, and every `clip_plan.json` clip must include the chosen `source_id`:
+
+```bash
+python3 scripts/recap.py ep1.mp4 ep2.mp4 --edit-mode cut --target-duration 10m --work-dir work_dir_multi_ep
+```
+
+Optional filesystem material library:
+
+```bash
+python3 scripts/recap.py ep1.mp4 --material-library-dir .video-materials --save-materials
+python3 scripts/recap.py ep1.mp4 ep2.mp4 --edit-mode cut --material-library-dir .video-materials --use-materials
+```
+
+Search is plain grep over JSON/MD/JSONL (for example `grep -R "keyword" .video-materials`). No raw media, DB, embeddings, or semantic search are part of the MVP.
+
 ### 2. Continue → produce the recap
 
 Rerun the **same command** (narration.json now exists):
@@ -103,7 +118,7 @@ python3 scripts/recap.py --doctor
 ## Options (passed through to the stage skills)
 `--context`, `--scene-threshold`, `--style`, `--edit-mode {full,cut,dub}`, `--target-duration`,
 `--skip-asr`, `--mimo-video-overview`, `--consolidate`, `--consolidate-asr`, `--mimo-tts-voice`,
-`--no-burn-subtitles` (burn is on by default), `--output-dir`.
+`--no-burn-subtitles` (burn is on by default), `--output-dir`, `--material-library-dir`, `--use-materials`, `--save-materials`.
 
 ## What this skill does NOT do
 - Does NOT write narration.json / clip_plan.json — the agent authors those (see the video-script skill).

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -135,6 +135,26 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 常见 code：`invalid_time`、`empty_narration`、`time_overlap`、`outside_clip_plan`、`over_budget`、`incomplete_sentence`、`slot_too_short`、`under_narrated`、`over_narrated`、`fragmented_beats`、`no_original_blocks`。
 
+## multi_source_manifest.json（多视频 cut）
+
+多视频剪辑模式下，项目级 `work_dir/multi_source_manifest.json` 是 `recap.py` / `cut.py` / `assemble.py` 的来源契约。`source_id` 默认由源文件 SHA-256 派生为 `src_<fingerprint[:12]>`；同一项目里重复 fingerprint 的不同路径会追加短 path hash 后缀。
+
+```json
+{
+  "schema_version": 1,
+  "sources": [
+    {
+      "source_id": "src_0123456789ab",
+      "source_path": "/abs/episode1.mp4",
+      "source_name": "episode1.mp4",
+      "source_video_fingerprint": "0123456789abcdef...",
+      "source_work_dir": "sources/src_0123456789ab",
+      "material_id": "episode1-0123456789ab"
+    }
+  ]
+}
+```
+
 ## clip_plan.json
 
 cut 模式下 Agent 选择要保留的原片片段，数组或 `{ "clips": [...] }` 都可接受。默认片段不能重叠，避免同一原片时间映射到多个输出位置：
@@ -153,6 +173,18 @@ cut 模式下 Agent 选择要保留的原片片段，数组或 `{ "clips": [...]
 | `start` | float | 原视频片段开始秒数 |
 | `end` | float | 原视频片段结束秒数 |
 | `reason` | string | 选择该片段的剧情/信息原因 |
+
+多视频 cut 的 `clip_plan.json` 必须给每个片段加 `source_id`；重叠检测按 `source_id` 分开计算，不同源视频的相同时间范围不互相冲突：
+
+```json
+{
+  "target_duration": "10m",
+  "clips": [
+    {"source_id": "src_0123456789ab", "start": 12.0, "end": 38.0, "reason": "episode 1 hook"},
+    {"source_id": "src_fedcba987654", "start": 4.0, "end": 22.0, "reason": "episode 2 payoff"}
+  ]
+}
+```
 
 ## clip_plan_validated.json
 
@@ -175,6 +207,44 @@ CLI 校验 `clip_plan.json` 后写出，额外包含输出时间轴：
   "target_duration": 600.0
 }
 ```
+
+多视频 validated clip 会额外保留来源字段，供 pass2 brief、timeline 和剪映导出追溯原素材：
+
+```json
+{
+  "clips": [
+    {
+      "clip_id": 0,
+      "source_id": "src_0123456789ab",
+      "source_path": "/abs/episode1.mp4",
+      "source_start": 12.0,
+      "source_end": 38.0,
+      "output_start": 0.0,
+      "output_end": 26.0,
+      "duration": 26.0,
+      "reason": "episode 1 hook"
+    }
+  ]
+}
+```
+
+## material library（可选，grep 复用）
+
+`--material-library-dir <dir> --save-materials` 会把每个源视频的已分析小文件复制到 `<dir>/materials/<material_id>/`，不复制原始媒体。`--use-materials` 会在 fingerprint 和 settings fingerprint 匹配时把这些 JSON/MD 产物恢复到当前 per-source `work_dir`。
+
+```text
+.video-materials/
+  materials_index.jsonl          # 追加式 grep journal；旧行可保留为历史
+  materials/<material_id>/
+    material.json                # 当前权威 metadata
+    material.md                  # grep 友好摘要
+    artifacts/scenes.json
+    artifacts/asr_result.json
+    artifacts/vlm_analysis.json
+    artifacts/understanding_index.json
+```
+
+`materials_index.jsonl` 每次保存追加一行，字段包括 `schema_version`, `event`, `material_id`, `source_name`, `source_path`, `source_video_fingerprint`, `settings_fingerprint`, `summary`, `tags`, `material_dir`, `updated_at`。当前权威状态始终以 `materials/<material_id>/material.json` 为准。MVP 只承诺 `grep -R "关键词" <library>` 这类文件检索；没有 DB、embedding 或语义搜索。
 
 ## narration_mapped.json
 

--- a/skills/video-recap/scripts/materials.py
+++ b/skills/video-recap/scripts/materials.py
@@ -28,9 +28,26 @@ ALLOWED_ARTIFACTS = {
     "reference_match_report.json",
     "recap_run_manifest.json",
 }
-SECRET_PATTERNS = ("tp-", "MIMO_API_KEY", "api_key", "mimo_api_key")
-SECRET_TOKEN_RE = re.compile(r"tp-[A-Za-z0-9_-]{3,}")
-SECRET_WORD_RE = re.compile(r"(?i)MIMO_API_KEY|mimo_api_key|api_key|secret|token")
+# Redaction targets credential VALUE shapes, not English/Chinese dictionary words — the
+# library must stay a faithful copy of the analysis. Bare words like "secret"/"token"
+# legitimately appear in transcripts/summaries and must NOT be touched.
+SECRET_VALUE_RES = (
+    re.compile(r"\btp-[A-Za-z0-9_-]{8,}\b"),     # MiMo Token Plan keys
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),    # OpenAI-style keys
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),  # GitHub tokens
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),         # AWS access key id
+    re.compile(r"\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\b"),  # JWT
+)
+# `KEY=VALUE` / `"key": "value"` assignments whose key denotes a credential -> mask the VALUE.
+SECRET_ASSIGN_RE = re.compile(
+    r"(?i)(\b(?:mimo(?:_\w+)?_api_key|api_key|secret_key|access_token|refresh_token|"
+    r"authorization|password|passwd|bearer)\b\s*[:=]\s*)(\"?)([^\s\"',;]+)(\"?)"
+)
+# Exact JSON/dict key names whose VALUE is a credential and must be dropped (key name kept).
+SECRET_KEY_NAMES = frozenset({
+    "api_key", "mimo_api_key", "mimo_asr_api_key", "mimo_tts_api_key", "mimo_video_api_key",
+    "secret_key", "access_token", "refresh_token", "authorization", "password", "passwd",
+})
 
 
 def utc_now_iso() -> str:
@@ -118,8 +135,11 @@ def _safe_text(value, limit: int = 600) -> str:
 
 
 def _redact_text(text: str) -> str:
-    text = SECRET_TOKEN_RE.sub("[redacted-token]", str(text or ""))
-    return SECRET_WORD_RE.sub("[redacted-key]", text)
+    """Redact credential value shapes only; leave ordinary words (secret/token/…) intact."""
+    text = str(text or "")
+    for rx in SECRET_VALUE_RES:
+        text = rx.sub("[redacted-token]", text)
+    return SECRET_ASSIGN_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}[redacted-key]{m.group(4)}", text)
 
 
 def _redact_json(value):
@@ -127,8 +147,10 @@ def _redact_json(value):
         out = {}
         for key, item in value.items():
             key_text = str(key)
-            if SECRET_WORD_RE.search(key_text):
-                out["redacted_key"] = "[redacted]"
+            # Drop only the value of an exact credential-named key; keep the key name and
+            # never coalesce distinct keys (so benign fields like token_economy survive).
+            if key_text.strip().lower() in SECRET_KEY_NAMES:
+                out[key_text] = "[redacted]"
             else:
                 out[key_text] = _redact_json(item)
         return out

--- a/skills/video-recap/scripts/materials.py
+++ b/skills/video-recap/scripts/materials.py
@@ -1,0 +1,383 @@
+"""Filesystem material library helpers for video-recap.
+
+The library is intentionally grep-friendly: JSON/MD/JSONL files on disk, no DB,
+no embeddings, no raw-media copies. Current metadata lives in each material
+folder; the root ``materials_index.jsonl`` is an append-only journal for grep and
+history.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ALLOWED_ARTIFACTS = {
+    "scenes.json",
+    "asr_result.json",
+    "vlm_analysis.json",
+    "silence_periods.json",
+    "timeline_fusion.json",
+    "understanding_index.json",
+    "understanding_index.md",
+    "agent_narration_brief.md",
+    "background_research.json",
+    "reference_profile.json",
+    "reference_match_report.json",
+    "recap_run_manifest.json",
+}
+SECRET_PATTERNS = ("tp-", "MIMO_API_KEY", "api_key", "mimo_api_key")
+SECRET_TOKEN_RE = re.compile(r"tp-[A-Za-z0-9_-]{3,}")
+SECRET_WORD_RE = re.compile(r"(?i)MIMO_API_KEY|mimo_api_key|api_key|secret|token")
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def file_fingerprint(path: str | Path, chunk_size: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def stable_json_dumps(value) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def settings_fingerprint(settings) -> str:
+    return hashlib.sha256(stable_json_dumps(settings or {}).encode("utf-8")).hexdigest()
+
+
+def source_id_from_fingerprint(fingerprint: str) -> str:
+    return f"src_{str(fingerprint)[:12]}"
+
+
+def assign_source_ids(sources: list[dict]) -> list[dict]:
+    """Assign deterministic source_id values to manifest source records.
+
+    Base id is ``src_<sha256[:12]>``. When the same fingerprint appears more than
+    once in one project, the first keeps the base id and later distinct paths get
+    ``_<pathhash6>`` suffixes. Input order does not affect the id for unique
+    fingerprints, and duplicate suffixes are derived from resolved path text.
+    """
+    seen: dict[str, set[str]] = {}
+    assigned = []
+    for raw in sources:
+        item = dict(raw)
+        fp = str(item.get("source_video_fingerprint") or item.get("fingerprint") or "")
+        if not fp:
+            raise ValueError("source fingerprint is required")
+        base = source_id_from_fingerprint(fp)
+        path = str(Path(item.get("source_path") or item.get("path") or "").resolve())
+        used = seen.setdefault(fp, set())
+        if not used:
+            sid = base
+        else:
+            suffix = hashlib.sha256(path.encode("utf-8")).hexdigest()[:6]
+            sid = f"{base}_{suffix}"
+        # Avoid accidental path-hash collisions within one manifest.
+        while sid in used:
+            suffix = hashlib.sha256((path + sid).encode("utf-8")).hexdigest()[:6]
+            sid = f"{base}_{suffix}"
+        used.add(sid)
+        item["source_id"] = sid
+        item["source_path"] = path
+        assigned.append(item)
+    return assigned
+
+
+def _slug(text: str, max_len: int = 48) -> str:
+    raw = Path(str(text or "material")).stem.lower()
+    raw = re.sub(r"[^a-z0-9\u4e00-\u9fff._-]+", "-", raw).strip("-._")
+    return (raw or "material")[:max_len].strip("-._") or "material"
+
+
+def material_id_for(source_path: str | Path, source_fingerprint: str) -> str:
+    return f"{_slug(str(source_path))}-{str(source_fingerprint)[:12]}"
+
+
+def material_dir(library_dir: str | Path, material_id: str) -> Path:
+    return Path(library_dir) / "materials" / material_id
+
+
+def _load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _safe_text(value, limit: int = 600) -> str:
+    text = str(value or "").replace("\x00", " ").strip()
+    return _redact_text(text)[:limit]
+
+
+def _redact_text(text: str) -> str:
+    text = SECRET_TOKEN_RE.sub("[redacted-token]", str(text or ""))
+    return SECRET_WORD_RE.sub("[redacted-key]", text)
+
+
+def _redact_json(value):
+    if isinstance(value, dict):
+        out = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if SECRET_WORD_RE.search(key_text):
+                out["redacted_key"] = "[redacted]"
+            else:
+                out[key_text] = _redact_json(item)
+        return out
+    if isinstance(value, list):
+        return [_redact_json(item) for item in value]
+    if isinstance(value, str):
+        return _redact_text(value)
+    return value
+
+
+def copy_artifact_redacted(src: Path, dst: Path) -> None:
+    """Copy an allowed JSON/MD artifact without persisting obvious secret markers."""
+    try:
+        text = src.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"refusing to persist non-text material artifact: {src.name}") from exc
+    if src.suffix.lower() == ".json":
+        try:
+            data = json.loads(text)
+        except ValueError:
+            dst.write_text(_redact_text(text), encoding="utf-8")
+        else:
+            dst.write_text(json.dumps(_redact_json(data), ensure_ascii=False, indent=2), encoding="utf-8")
+    else:
+        dst.write_text(_redact_text(text), encoding="utf-8")
+
+
+def summarize_work_dir(work_dir: str | Path, *, source_name: str = "") -> dict:
+    """Best-effort small summary for material.md/index grep."""
+    work = Path(work_dir)
+    summary_parts = []
+    tags = []
+    idx = _load_json(work / "understanding_index.json")
+    if isinstance(idx, dict):
+        for key in ("summary", "story_summary", "overall_summary", "one_sentence"):
+            if idx.get(key):
+                summary_parts.append(_safe_text(idx.get(key)))
+                break
+        for key in ("characters", "entities", "keywords", "tags"):
+            vals = idx.get(key)
+            if isinstance(vals, list):
+                tags.extend(_safe_text(v, 80) for v in vals[:12])
+    vlm = _load_json(work / "vlm_analysis.json")
+    if isinstance(vlm, dict):
+        for key in ("summary", "overall_summary", "video_summary"):
+            if vlm.get(key):
+                summary_parts.append(_safe_text(vlm.get(key)))
+                break
+    scenes = _load_json(work / "scenes.json")
+    if isinstance(scenes, list):
+        tags.append(f"scenes:{len(scenes)}")
+    asr = _load_json(work / "asr_result.json")
+    if isinstance(asr, list):
+        tags.append(f"asr:{len(asr)}")
+    summary = " | ".join(p for p in summary_parts if p) or f"Analyzed video material: {source_name or work.name}"
+    dedup_tags = []
+    for tag in tags:
+        if tag and tag not in dedup_tags:
+            dedup_tags.append(tag)
+    return {"summary": summary, "tags": dedup_tags[:20]}
+
+
+def allowed_artifact_paths(work_dir: str | Path) -> list[Path]:
+    work = Path(work_dir)
+    return [work / name for name in sorted(ALLOWED_ARTIFACTS) if (work / name).is_file()]
+
+
+def write_material_md(path: Path, metadata: dict, summary: str, tags: list[str]) -> None:
+    artifact_lines = "\n".join(f"- `{a.get('name')}` → `{a.get('path')}`" for a in metadata.get("artifacts", []))
+    tags_text = ", ".join(tags) if tags else "(none)"
+    text = f"""# Material: {metadata.get('source_name') or metadata.get('material_id')}
+
+- material_id: `{metadata.get('material_id')}`
+- source: `{metadata.get('source_path')}`
+- source_fingerprint: `{metadata.get('source_video_fingerprint')}`
+- settings_fingerprint: `{metadata.get('settings_fingerprint')}`
+- updated_at: `{metadata.get('updated_at')}`
+- tags: {tags_text}
+
+## Summary
+{_safe_text(summary, 2000)}
+
+## Artifacts
+{artifact_lines or '- (none)'}
+"""
+    path.write_text(text, encoding="utf-8")
+
+
+def save_material(
+    library_dir: str | Path,
+    work_dir: str | Path,
+    source_path: str | Path,
+    source_fingerprint: str,
+    settings_fp: str,
+    *,
+    duration: float | None = None,
+    source_id: str | None = None,
+    material_id: str | None = None,
+    now: str | None = None,
+) -> dict:
+    """Persist small reusable analysis artifacts into the filesystem library."""
+    lib = Path(library_dir)
+    mid = material_id or material_id_for(source_path, source_fingerprint)
+    dest = material_dir(lib, mid)
+    artifacts_dir = dest / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    now = now or utc_now_iso()
+
+    copied = []
+    for src in allowed_artifact_paths(work_dir):
+        dst = artifacts_dir / src.name
+        copy_artifact_redacted(src, dst)
+        copied.append({"name": src.name, "path": f"artifacts/{src.name}", "sha256": file_fingerprint(dst)})
+
+    existing = _load_json(dest / "material.json")
+    created_at = existing.get("created_at") if isinstance(existing, dict) and existing.get("created_at") else now
+    source_path = Path(source_path).resolve()
+    summary_info = summarize_work_dir(work_dir, source_name=source_path.name)
+    metadata = {
+        "schema_version": 1,
+        "material_id": mid,
+        "source_id": source_id,
+        "source_name": source_path.name,
+        "source_path": str(source_path),
+        "source_video_fingerprint": source_fingerprint,
+        "duration": duration,
+        "settings_fingerprint": settings_fp,
+        "artifacts": copied,
+        "created_at": created_at,
+        "updated_at": now,
+    }
+    (dest / "material.json").write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+    write_material_md(dest / "material.md", metadata, summary_info["summary"], summary_info["tags"])
+
+    index_record = {
+        "schema_version": 1,
+        "event": "saved",
+        "material_id": mid,
+        "source_name": metadata["source_name"],
+        "source_path": metadata["source_path"],
+        "source_video_fingerprint": source_fingerprint,
+        "settings_fingerprint": settings_fp,
+        "summary": summary_info["summary"],
+        "tags": summary_info["tags"],
+        "material_dir": str(dest),
+        "updated_at": now,
+    }
+    lib.mkdir(parents=True, exist_ok=True)
+    with (lib / "materials_index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(index_record, ensure_ascii=False, separators=(",", ":")) + "\n")
+    return metadata
+
+
+def find_material_by_fingerprint(library_dir: str | Path, source_fingerprint: str) -> dict | None:
+    root = Path(library_dir) / "materials"
+    if not root.exists():
+        return None
+    candidates = []
+    for meta_path in root.glob("*/material.json"):
+        data = _load_json(meta_path)
+        if isinstance(data, dict) and data.get("source_video_fingerprint") == source_fingerprint:
+            data["material_dir"] = str(meta_path.parent)
+            candidates.append(data)
+    if not candidates:
+        return None
+    # Deterministic fallback policy for legacy/manual callers that do not know
+    # the expected material_id: newest wins, then material_id for stable ties.
+    candidates.sort(key=lambda d: (str(d.get("updated_at") or ""), str(d.get("material_id") or "")), reverse=True)
+    return candidates[0]
+
+
+def restore_material(
+    library_dir: str | Path,
+    work_dir: str | Path,
+    *,
+    source_fingerprint: str,
+    settings_fp: str,
+    material_id: str | None = None,
+    overwrite: bool = True,
+    prune_stale_allowed: bool = True,
+) -> dict:
+    """Restore allowed artifacts when fingerprint/settings match.
+
+    Returns a status dict and never partially restores on mismatch.
+
+    By default the restored material is treated as the authoritative analysis
+    snapshot for ``work_dir``: allowed analysis artifacts are staged first, then
+    stale allowed artifacts in the destination are pruned before replacement.
+    This prevents reused work dirs from mixing old scenes/ASR/VLM files with a
+    newly restored material. Non-allowed files (for example narration.json or
+    clip_plan.json) are never removed here.
+    """
+    lib = Path(library_dir)
+    if material_id:
+        meta = _load_json(material_dir(lib, material_id) / "material.json")
+        if isinstance(meta, dict):
+            meta["material_dir"] = str(material_dir(lib, material_id))
+    else:
+        meta = find_material_by_fingerprint(lib, source_fingerprint)
+    if not isinstance(meta, dict):
+        return {"restored": False, "reason": "material not found"}
+    if meta.get("source_video_fingerprint") != source_fingerprint:
+        return {"restored": False, "reason": "source fingerprint mismatch", "material_id": meta.get("material_id")}
+    if meta.get("settings_fingerprint") != settings_fp:
+        return {"restored": False, "reason": "settings fingerprint mismatch", "material_id": meta.get("material_id")}
+
+    src_dir = Path(meta.get("material_dir") or material_dir(lib, meta["material_id"])) / "artifacts"
+    if not src_dir.exists():
+        return {"restored": False, "reason": "material artifacts missing", "material_id": meta.get("material_id")}
+    dest = Path(work_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    staged = []
+    with tempfile.TemporaryDirectory(prefix=".material_restore_", dir=str(dest)) as tmp_name:
+        tmp = Path(tmp_name)
+        for artifact in meta.get("artifacts") or []:
+            name = artifact.get("name") if isinstance(artifact, dict) else None
+            if name not in ALLOWED_ARTIFACTS:
+                continue
+            src = src_dir / name
+            if not src.exists():
+                continue
+            copy_artifact_redacted(src, tmp / name)
+            staged.append(name)
+        if not staged:
+            return {
+                "restored": False,
+                "reason": "material artifacts empty",
+                "material_id": meta.get("material_id"),
+            }
+
+        pruned = []
+        if prune_stale_allowed:
+            for name in sorted(ALLOWED_ARTIFACTS):
+                out = dest / name
+                if out.exists():
+                    out.unlink()
+                    pruned.append(name)
+
+        restored = []
+        for name in staged:
+            out = dest / name
+            if out.exists() and not overwrite:
+                continue
+            (tmp / name).replace(out)
+            restored.append(name)
+    return {
+        "restored": bool(restored),
+        "material_id": meta.get("material_id"),
+        "artifacts": restored,
+        "pruned_artifacts": pruned,
+        "material": meta,
+    }

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -22,11 +22,13 @@ import sys
 from pathlib import Path
 
 from doctor import ffmpeg_has_subtitles_filter
+import materials as material_lib
 
 BUNDLE = Path(__file__).resolve().parents[2]  # the skills/ directory
 RUN_MANIFEST = "recap_run_manifest.json"
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
 PHASE_LEDGER = "recap_phase.json"
+MULTI_SOURCE_MANIFEST = "multi_source_manifest.json"
 
 
 def _entry(skill, script):
@@ -152,28 +154,110 @@ def _file_fingerprint(path, chunk_size=1024 * 1024):
     return h.hexdigest()
 
 
+def _analysis_settings(args):
+    return {
+        "context": args.context,
+        "scene_threshold": args.scene_threshold,
+        "style": args.style,
+        "edit_mode": args.edit_mode,
+        "target_duration": args.target_duration,
+        "skip_asr": bool(args.skip_asr),
+        "mimo_video_overview": bool(args.mimo_video_overview),
+        "consolidate": bool(args.consolidate),
+        "consolidate_asr": bool(args.consolidate_asr),
+    }
+
+
+def _material_settings_fingerprint(args):
+    return material_lib.settings_fingerprint(_analysis_settings(args))
+
+
+def _coerce_videos(video_or_videos):
+    if isinstance(video_or_videos, (list, tuple)):
+        return [Path(v).resolve() for v in video_or_videos]
+    return [Path(video_or_videos).resolve()]
+
+
 def _run_manifest_payload(video, args):
     return {
         "schema_version": 1,
         "source_video": str(Path(video).resolve()),
         "source_video_fingerprint": _file_fingerprint(video),
-        "settings": {
-            "context": args.context,
-            "scene_threshold": args.scene_threshold,
-            "style": args.style,
-            "edit_mode": args.edit_mode,
-            "target_duration": args.target_duration,
-            "skip_asr": bool(args.skip_asr),
-            "mimo_video_overview": bool(args.mimo_video_overview),
-            "consolidate": bool(args.consolidate),
-            "consolidate_asr": bool(args.consolidate_asr),
-        },
+        "settings": _analysis_settings(args),
     }
 
 
 def _write_run_manifest(work_dir, video, args):
     payload = _run_manifest_payload(video, args)
     (work_dir / RUN_MANIFEST).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _build_multi_source_records(videos, work_dir, args):
+    records = []
+    for video in _coerce_videos(videos):
+        fp = _file_fingerprint(video)
+        records.append({
+            "source_path": str(video),
+            "source_name": video.name,
+            "source_video_fingerprint": fp,
+            "settings_fingerprint": _material_settings_fingerprint(args),
+            "material_id": material_lib.material_id_for(video, fp),
+        })
+    records = material_lib.assign_source_ids(records)
+    for record in records:
+        record["source_work_dir"] = f"sources/{record['source_id']}"
+    return records
+
+
+def _multi_run_manifest_payload(videos, args, source_records):
+    return {
+        "schema_version": 2,
+        "mode": "multi_source",
+        "sources": [
+            {
+                "source_id": s.get("source_id"),
+                "source_path": s.get("source_path"),
+                "source_video_fingerprint": s.get("source_video_fingerprint"),
+                "source_work_dir": s.get("source_work_dir"),
+                "material_id": s.get("material_id"),
+            }
+            for s in source_records
+        ],
+        "source_videos": [str(v) for v in _coerce_videos(videos)],
+        "settings": _analysis_settings(args),
+    }
+
+
+def _write_project_run_manifest(work_dir, videos, args, source_records):
+    payload = _multi_run_manifest_payload(videos, args, source_records)
+    (work_dir / RUN_MANIFEST).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_multi_source_manifest(work_dir, source_records):
+    path = Path(work_dir) / MULTI_SOURCE_MANIFEST
+    payload = {
+        "schema_version": 1,
+        "sources": [
+            {
+                "source_id": s["source_id"],
+                "source_path": s["source_path"],
+                "source_name": s["source_name"],
+                "source_video_fingerprint": s["source_video_fingerprint"],
+                "source_work_dir": s["source_work_dir"],
+                "material_id": s.get("material_id"),
+            }
+            for s in source_records
+        ],
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def _load_multi_source_manifest(work_dir):
+    data = _load_json(Path(work_dir) / MULTI_SOURCE_MANIFEST)
+    if isinstance(data, dict) and isinstance(data.get("sources"), list):
+        return data
+    return None
 
 
 def _load_run_manifest(work_dir):
@@ -281,6 +365,38 @@ def _manifest_mismatches(work_dir, video, args):
     return mismatches
 
 
+def _multi_manifest_mismatches(work_dir, videos, args, source_records):
+    expected = _multi_run_manifest_payload(videos, args, source_records)
+    actual = _load_run_manifest(work_dir)
+    if not actual:
+        return ["缺少或无法读取 recap_run_manifest.json；不能证明 work_dir 属于当前多视频/参数"]
+    mismatches = []
+    if actual.get("mode") != "multi_source":
+        mismatches.append(f"mode: expected 'multi_source', got {actual.get('mode')!r}")
+    expected_sources = [
+        {
+            "source_id": s.get("source_id"),
+            "source_path": s.get("source_path"),
+            "source_video_fingerprint": s.get("source_video_fingerprint"),
+        }
+        for s in expected.get("sources", [])
+    ]
+    actual_sources = [
+        {
+            "source_id": s.get("source_id"),
+            "source_path": s.get("source_path"),
+            "source_video_fingerprint": s.get("source_video_fingerprint"),
+        }
+        for s in actual.get("sources", [])
+        if isinstance(s, dict)
+    ]
+    if actual_sources != expected_sources:
+        mismatches.append("sources: 当前输入视频列表/顺序/source_id/fingerprint 与 Phase A manifest 不匹配")
+    if _settings_for_compare(actual.get("settings")) != _settings_for_compare(expected.get("settings")):
+        mismatches.append("settings: 当前 CLI/env 参数与 Phase A manifest 不匹配")
+    return mismatches
+
+
 def _read_assembly_output(work_dir):
     manifest = _load_json(Path(work_dir) / ASSEMBLY_MANIFEST)
     if isinstance(manifest, dict) and manifest.get("final_output"):
@@ -323,7 +439,8 @@ def _cut_narration_is_stale(ledger, current_clip_plan_fp):
 
 
 def _continuation_command(video, work_dir, args):
-    parts = [sys.executable, str(_entry("video-recap", "recap.py")), str(video), "--work-dir", str(work_dir)]
+    videos = _coerce_videos(video)
+    parts = [sys.executable, str(_entry("video-recap", "recap.py")), *[str(v) for v in videos], "--work-dir", str(work_dir)]
     if args.context:
         parts += ["--context", args.context]
     if args.scene_threshold is not None:
@@ -362,12 +479,302 @@ def _continuation_command(video, work_dir, args):
         parts.append("--review-narration" if args.review_narration else "--no-review-narration")
     if getattr(args, "require_narration_review", False):
         parts.append("--require-narration-review")
+    if getattr(args, "material_library_dir", None):
+        parts += ["--material-library-dir", args.material_library_dir]
+    if getattr(args, "use_materials", False):
+        parts.append("--use-materials")
+    if getattr(args, "save_materials", False):
+        parts.append("--save-materials")
     return " ".join(shlex.quote(part) for part in parts)
+
+
+def _source_work_dir(project_work_dir, source_record):
+    return Path(project_work_dir) / source_record["source_work_dir"]
+
+
+def _understand_args_for_source(source_record, source_work_dir, args):
+    uargs = [source_record["source_path"], "--work-dir", str(source_work_dir), "--style", args.style]
+    if args.context:
+        uargs += ["--context", args.context]
+    if args.scene_threshold is not None:
+        uargs += ["--scene-threshold", str(args.scene_threshold)]
+    if args.edit_mode:
+        uargs += ["--edit-mode", args.edit_mode]
+    if args.target_duration:
+        uargs += ["--target-duration", args.target_duration]
+    if args.skip_asr:
+        uargs.append("--skip-asr")
+    if args.mimo_video_overview:
+        uargs.append("--mimo-video-overview")
+    uargs.append("--consolidate" if args.consolidate else "--no-consolidate")
+    if args.consolidate_asr:
+        uargs.append("--consolidate-asr")
+    return uargs
+
+
+def _brief_excerpt(path, limit=1200):
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    return text[:limit]
+
+
+def _write_multi_source_clip_brief(work_dir, source_records, args):
+    lines = [
+        "# Multi-source Clip Plan Brief",
+        "",
+        "你正在做多视频剪辑复盘。当前 MVP 只支持 `--edit-mode cut`：先写 `clip_plan.json`，下一步会剪出 `edited_source.mp4`，再对 OUTPUT 时间轴写 `narration.json`。",
+        "",
+        "## 必须写入的格式",
+        "",
+        "```json",
+        "{\"target_duration\":\"10m\",\"clips\":[{\"source_id\":\"src_xxx\",\"start\":12.0,\"end\":38.0,\"reason\":\"hook\"}]}",
+        "```",
+        "",
+        "- 每个 clip 必须带 `source_id`。",
+        "- `start`/`end` 是对应 source 原视频时间（秒）。",
+        "- 不同 `source_id` 的相同时间段不算重叠；同一 `source_id` 内不要重复/重叠，除非你明确接受稀疏/重复剪辑风险。",
+        "- 素材库是文件系统 JSON/MD/JSONL；需要找历史素材时直接 `grep -R \"关键词\" <material-library-dir>`。",
+    ]
+    if args.target_duration:
+        lines.append(f"- 目标时长：`{args.target_duration}`。")
+    lines += ["", "## Sources", ""]
+    for s in source_records:
+        swd = _source_work_dir(work_dir, s)
+        lines += [
+            f"### {s['source_id']} — {s['source_name']}",
+            f"- path: `{s['source_path']}`",
+            f"- work_dir: `{swd}`",
+            f"- fingerprint: `{s['source_video_fingerprint']}`",
+            f"- material_id: `{s.get('material_id')}`",
+        ]
+        excerpt = _brief_excerpt(swd / "agent_narration_brief.md")
+        if excerpt:
+            lines += ["", "#### per-source brief excerpt", "", excerpt, ""]
+    (Path(work_dir) / "agent_narration_brief.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _write_multi_source_output_brief(work_dir, source_records, validated_plan_path):
+    plan = _load_json(validated_plan_path)
+    clips = plan.get("clips", []) if isinstance(plan, dict) else []
+    source_by_id = {s["source_id"]: s for s in source_records}
+    lines = [
+        "# Multi-source Output Narration Brief",
+        "",
+        "现在 `edited_source.mp4` 已经由多个源视频剪好。请对剪后成片的 OUTPUT 时间轴写 `narration.json`。",
+        "",
+        "## narration.json 格式",
+        "",
+        "```json",
+        "[{\"start\":0.0,\"end\":4.0,\"narration\":\"...\"}]",
+        "```",
+        "",
+        "注意：`start`/`end` 是剪后成片时间，不是原视频时间。",
+        "",
+        "## Kept clips (output → source)",
+    ]
+    for c in clips:
+        sid = c.get("source_id")
+        src = source_by_id.get(sid, {})
+        lines.append(
+            f"- output {_fmt_range(c.get('output_start'), c.get('output_end'))} → "
+            f"{sid} `{src.get('source_path', c.get('source_path', ''))}` "
+            f"source {_fmt_range(c.get('source_start'), c.get('source_end'))} "
+            f"{('— ' + str(c.get('reason'))) if c.get('reason') else ''}"
+        )
+    lines += ["", "## Source work dirs"]
+    for s in source_records:
+        lines.append(f"- {s['source_id']}: `{_source_work_dir(work_dir, s)}`")
+    (Path(work_dir) / "agent_narration_brief.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _fmt_range(start, end):
+    try:
+        return f"{float(start):.3f}-{float(end):.3f}s"
+    except (TypeError, ValueError):
+        return f"{start}-{end}s"
+
+
+def _material_library_dir(args):
+    return args.material_library_dir or os.environ.get("VIDEO_RECAP_MATERIAL_LIBRARY_DIR") or None
+
+
+def _materials_enabled(args):
+    return bool(_material_library_dir(args) and args.use_materials)
+
+
+def _save_materials_enabled(args):
+    return bool(_material_library_dir(args) and args.save_materials)
+
+
+def _pause_for_agent(work_dir, need_text, cont, inspect_hint=None):
+    brief = Path(work_dir) / "agent_narration_brief.md"
+    print("=" * 50)
+    if brief.exists() and "Research the story FIRST" in brief.read_text(encoding="utf-8"):
+        print("[video-recap] ⚑ 理解素材偏薄：先按 brief 顶部「Research the story FIRST」调研并写 "
+              "background_research.json，再写解说，避免看图说话。")
+    print(f"[video-recap] ⏸  阅读 {brief}（按 video-script 规则）后写入 {need_text}")
+    if inspect_hint:
+        print(f"[video-recap]    先核对状态/时间轴（建议性）: {inspect_hint}")
+    print(f"[video-recap]    写完后重跑继续: {cont}")
+    print("=" * 50)
+
+
+def _run_or_restore_understanding(source_record, source_work_dir, args):
+    """Run video-understanding for one source, or restore it from the material library."""
+    source_work_dir = Path(source_work_dir)
+    source_work_dir.mkdir(parents=True, exist_ok=True)
+    source_fp = source_record["source_video_fingerprint"]
+    settings_fp = source_record.get("settings_fingerprint") or _material_settings_fingerprint(args)
+    lib_dir = _material_library_dir(args)
+    restored = False
+    if lib_dir and _materials_enabled(args):
+        result = material_lib.restore_material(
+            lib_dir,
+            source_work_dir,
+            source_fingerprint=source_fp,
+            settings_fp=settings_fp,
+        )
+        restored = bool(result.get("restored"))
+        if restored:
+            print(f"[video-recap] ♻️  复用素材库: {result.get('material_id')} → {source_work_dir}", flush=True)
+        elif result.get("reason"):
+            print(f"[video-recap] 素材库未复用 {source_record['source_name']}: {result['reason']}", flush=True)
+
+    if not restored:
+        _run("video-understanding", "understand.py", *_understand_args_for_source(source_record, source_work_dir, args))
+
+    _write_run_manifest(source_work_dir, source_record["source_path"], args)
+    if lib_dir and _save_materials_enabled(args):
+        meta = material_lib.save_material(
+            lib_dir,
+            source_work_dir,
+            source_record["source_path"],
+            source_fp,
+            settings_fp,
+            source_id=source_record.get("source_id"),
+            material_id=source_record.get("material_id"),
+        )
+        source_record["material_id"] = meta.get("material_id")
+        print(f"[video-recap] 💾 已沉淀素材: {meta.get('material_id')} → {lib_dir}", flush=True)
+    return restored
+
+
+def _rebuild_understanding_brief(source_record, source_work_dir, args):
+    """Rebuild agent_narration_brief.md from cached/restored analysis only.
+
+    Cut pass 2 needs an OUTPUT-time brief after edited_source.mp4 exists. A
+    material restore may have supplied pass-1 analysis artifacts (and even a
+    source-time brief), but it must not skip this phase-specific brief rebuild.
+    """
+    _run(
+        "video-understanding",
+        "understand.py",
+        *_understand_args_for_source(source_record, source_work_dir, args),
+        "--brief-only",
+    )
+
+
+def _reject_stale_multi_manifest(work_dir, videos, args, source_records):
+    mismatches = _multi_manifest_mismatches(work_dir, videos, args, source_records)
+    if mismatches:
+        details = "\n  - ".join(mismatches)
+        raise SystemExit(
+            "work_dir 与当前多视频 recap 输入不匹配，拒绝复用既有 narration/clip_plan；"
+            "请使用新的 --work-dir，或删除旧产物后重新运行 Phase A。\n"
+            f"  - {details}")
+
+
+def _run_multi_cut(videos, work_dir, args):
+    """Multi-video MVP: cut-first/narrate-second over a project work_dir."""
+    videos = _coerce_videos(videos)
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    source_records = _build_multi_source_records(videos, work_dir, args)
+    narration_json = work_dir / "narration.json"
+    clip_plan_json = work_dir / "clip_plan.json"
+    edited_source = work_dir / "edited_source.mp4"
+    inspect_py = _entry("video-recap", "recap_inspect.py")
+
+    # If a project manifest already exists, it must match before any Phase-B reuse.
+    if (work_dir / RUN_MANIFEST).exists():
+        _reject_stale_multi_manifest(work_dir, videos, args, source_records)
+    manifest_path = _write_multi_source_manifest(work_dir, source_records)
+
+    if not clip_plan_json.exists():
+        for record in source_records:
+            _run_or_restore_understanding(record, _source_work_dir(work_dir, record), args)
+        manifest_path = _write_multi_source_manifest(work_dir, source_records)
+        _write_project_run_manifest(work_dir, videos, args, source_records)
+        _write_multi_source_clip_brief(work_dir, source_records, args)
+        _pause_for_agent(
+            work_dir,
+            f"{clip_plan_json}（多视频剪辑计划；每个 clip 必须带 source_id）",
+            _continuation_command(videos, work_dir, args),
+            inspect_hint=f"python3 {inspect_py} --work-dir {work_dir} state",
+        )
+        return
+
+    _reject_stale_multi_manifest(work_dir, videos, args, source_records)
+    cp_fp = _file_md5(clip_plan_json)
+    crender = [str(videos[0]), "--work-dir", str(work_dir), "--sources-manifest", str(manifest_path), "--no-narration-map"]
+    if args.target_duration:
+        crender += ["--target-duration", args.target_duration]
+    if getattr(args, "allow_sparse_cut", False):
+        crender.append("--allow-sparse-cut")
+    _run("video-cut", "cut.py", *crender)
+    if not narration_json.exists():
+        _write_multi_source_output_brief(work_dir, source_records, work_dir / "clip_plan_validated.json")
+        _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp, edited_source_rendered=True, multi_source=True)
+        _pause_for_agent(
+            work_dir,
+            f"{narration_json}（用成片 OUTPUT 时间轴写解说，对着 {edited_source}）",
+            _continuation_command(videos, work_dir, args),
+            inspect_hint=(f"python3 {inspect_py} --work-dir {work_dir} "
+                          "clip-map --output-start <s> --output-end <e>"),
+        )
+        return
+    if _cut_narration_is_stale(_read_phase_ledger(work_dir), cp_fp):
+        raise SystemExit(
+            "clip_plan.json 已改变，但 narration.json 仍是对旧剪辑写的，会与剪后画面对不上。"
+            "请删除 narration.json，重跑后按新成片重新写解说。")
+    _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp,
+                        narration_fingerprint=_file_md5(narration_json), narration_written=True, multi_source=True)
+    output_duration = _read_video_duration_or_raise(edited_source)
+    _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", "cut_output",
+         "--output-duration", f"{output_duration:.3f}")
+    review_ran = _run_narration_review(work_dir, args, timeline="cut_output")
+    vargs = ["--work-dir", str(work_dir), "--narration", str(narration_json)]
+    if args.mimo_tts_voice:
+        vargs += ["--mimo-voice", args.mimo_tts_voice]
+    if args.allow_partial_tts:
+        vargs.append("--allow-partial-tts")
+    _run("video-voiceover", "voiceover.py", *vargs)
+
+    recap_stem = f"multi_{videos[0].stem}"
+    aargs = [str(edited_source), "--work-dir", str(work_dir), "--recap-stem", recap_stem]
+    if args.output_dir:
+        aargs += ["--output-dir", args.output_dir]
+    if args.burn_subtitles is not None:
+        aargs.append("--burn-subtitles" if args.burn_subtitles else "--no-burn-subtitles")
+    if args.export_jianying:
+        aargs.append("--export-jianying")
+    if args.jianying_bundle_media:
+        aargs.append("--jianying-bundle-media")
+    if args.jianying_no_bundle_media:
+        aargs.append("--jianying-no-bundle-media")
+    _run("video-assemble", "assemble.py", *aargs)
+
+    final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
+    final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + recap_stem + ".mp4"))
+    print(f"[video-recap] ✅ 完成: {final_output}")
+    _print_narration_review_pointer(work_dir, review_ran=review_ran)
 
 
 def main():
     ap = argparse.ArgumentParser(description="Full video recap orchestrator (video-* skill bundle).")
-    ap.add_argument("video", nargs="?")
+    ap.add_argument("video", nargs="*")
     ap.add_argument("--work-dir", default=None)
     ap.add_argument("--context", default="")
     ap.add_argument("--scene-threshold", type=float, default=None)
@@ -397,6 +804,12 @@ def main():
                     help="copy media into the 剪映 draft (default on; portable to another machine)")
     ap.add_argument("--jianying-no-bundle-media", action="store_true",
                     help="reference media in place instead of copying it into the draft")
+    ap.add_argument("--material-library-dir", default=None,
+                    help="filesystem material library dir (or VIDEO_RECAP_MATERIAL_LIBRARY_DIR)")
+    ap.add_argument("--use-materials", action=argparse.BooleanOptionalAction, default=False,
+                    help="restore compatible analyzed artifacts from the material library")
+    ap.add_argument("--save-materials", action="store_true",
+                    help="save analyzed JSON/MD artifacts into the material library")
     ap.add_argument("--doctor", action="store_true")
     args = ap.parse_args()
 
@@ -406,11 +819,24 @@ def main():
     if not args.video:
         ap.error("video is required (unless --doctor)")
 
+    videos = _coerce_videos(args.video)
+    if len(videos) > 1 and args.edit_mode != "cut":
+        raise SystemExit("多视频输入当前 MVP 只支持 --edit-mode cut；full/dub 请一次输入一个视频。")
+
     # Fail fast before any expensive understanding/VLM/ASR/TTS work if the run will burn
     # subtitles but this ffmpeg can't (otherwise it only blows up at the final render).
     _preflight_burn_subtitles(args)
 
-    video = Path(args.video).resolve()
+    if len(videos) > 1:
+        work_dir = (
+            Path(args.work_dir).resolve()
+            if args.work_dir
+            else videos[0].parent / f"work_dir_multi_{videos[0].stem}"
+        )
+        _run_multi_cut(videos, work_dir, args)
+        return
+
+    video = videos[0]
     work_dir = Path(args.work_dir).resolve() if args.work_dir else video.parent / f"work_dir_{video.stem}"
     work_dir.mkdir(parents=True, exist_ok=True)
     cut = args.edit_mode == "cut"
@@ -420,23 +846,29 @@ def main():
     edited_source = work_dir / "edited_source.mp4"
 
     def _understand():
-        uargs = [str(video), "--work-dir", str(work_dir), "--style", args.style]
-        if args.context:
-            uargs += ["--context", args.context]
-        if args.scene_threshold is not None:
-            uargs += ["--scene-threshold", str(args.scene_threshold)]
-        if args.edit_mode:
-            uargs += ["--edit-mode", args.edit_mode]
-        if args.target_duration:
-            uargs += ["--target-duration", args.target_duration]
-        if args.skip_asr:
-            uargs.append("--skip-asr")
-        if args.mimo_video_overview:
-            uargs.append("--mimo-video-overview")
-        uargs.append("--consolidate" if args.consolidate else "--no-consolidate")
-        if args.consolidate_asr:
-            uargs.append("--consolidate-asr")
-        _run("video-understanding", "understand.py", *uargs)
+        fp = _file_fingerprint(video)
+        source_record = {
+            "source_id": material_lib.source_id_from_fingerprint(fp),
+            "source_path": str(video),
+            "source_name": video.name,
+            "source_video_fingerprint": fp,
+            "settings_fingerprint": _material_settings_fingerprint(args),
+            "material_id": material_lib.material_id_for(video, fp),
+        }
+        _run_or_restore_understanding(source_record, work_dir, args)
+        return source_record
+
+    def _rebuild_output_brief():
+        fp = _file_fingerprint(video)
+        source_record = {
+            "source_id": material_lib.source_id_from_fingerprint(fp),
+            "source_path": str(video),
+            "source_name": video.name,
+            "source_video_fingerprint": fp,
+            "settings_fingerprint": _material_settings_fingerprint(args),
+            "material_id": material_lib.material_id_for(video, fp),
+        }
+        _rebuild_understanding_brief(source_record, work_dir, args)
 
     inspect_py = _entry("video-recap", "recap_inspect.py")
 
@@ -517,7 +949,7 @@ def main():
         _run("video-cut", "cut.py", *crender)
         if not narration_json.exists():
             # PASS 2: rebuild the brief (now an OUTPUT-timeline variant) and pause for narration.
-            _understand()
+            _rebuild_output_brief()
             _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp, edited_source_rendered=True)
             _pause(f"{narration_json}（用成片 OUTPUT 时间轴写解说，对着 {edited_source}）",
                    inspect_hint=(f"python3 {inspect_py} --work-dir {work_dir} "

--- a/skills/video-recap/scripts/recap_inspect.py
+++ b/skills/video-recap/scripts/recap_inspect.py
@@ -33,6 +33,7 @@ _UNDERSTANDING_ARTIFACTS = [
     "agent_narration_brief.md",
 ]
 _CUT_ARTIFACTS = [
+    "multi_source_manifest.json",
     "clip_plan.json",
     "clip_plan_validated.json",
     "edited_source.mp4",
@@ -126,6 +127,25 @@ def _discover_source(work_dir):
     return {"path": None, "fingerprint": None, "origin": "unknown"}
 
 
+def _discover_multi_source(work_dir):
+    data, _ = _load_json(Path(work_dir) / "multi_source_manifest.json")
+    if not isinstance(data, dict) or not isinstance(data.get("sources"), list):
+        return None
+    sources = []
+    for raw in data.get("sources") or []:
+        if not isinstance(raw, dict):
+            continue
+        sources.append({
+            "source_id": raw.get("source_id"),
+            "source_path": raw.get("source_path"),
+            "source_name": raw.get("source_name"),
+            "source_video_fingerprint": raw.get("source_video_fingerprint"),
+            "source_work_dir": raw.get("source_work_dir"),
+            "material_id": raw.get("material_id"),
+        })
+    return {"schema_version": data.get("schema_version", 1), "sources": sources}
+
+
 # --- clip plan loading + forward affine map ----------------------------------
 def _clip_entries(plan):
     """Normalize a clip plan (dict-with-clips or bare list) to the list of clip dicts."""
@@ -170,6 +190,8 @@ def _normalize_clips(entries):
                 cursor = max(cursor, out_e)
         clips.append({
             "clip_id": c.get("clip_id", idx),
+            "source_id": c.get("source_id"),
+            "source_path": c.get("source_path"),
             "source_start": ss,
             "source_end": se,
             "output_start": out_s,
@@ -281,6 +303,7 @@ def cmd_state(work_dir, compact):
         "mode": mode,
         "forward_state_files": forward,
         "source_video": source,
+        "multi_source": _discover_multi_source(work_dir),
         "next_pause": (
             {"artifact": pause[0], "hint": pause[1]} if pause else None
         ),
@@ -302,6 +325,15 @@ def _render_state_md(state, compact):
     fp = src["fingerprint"]
     fp_short = (fp[:12] + "…") if isinstance(fp, str) and len(fp) > 12 else (fp or "unknown")
     lines.append(f"源视频: {_truncate(path, compact)}  (fp {fp_short}, 来源 {src['origin']})")
+    if state.get("multi_source"):
+        lines.append("多源素材:")
+        for s in state["multi_source"].get("sources", []):
+            fp = s.get("source_video_fingerprint")
+            short = (fp[:12] + "…") if isinstance(fp, str) and len(fp) > 12 else (fp or "unknown")
+            lines.append(
+                f"  - {s.get('source_id')}: {_truncate(s.get('source_path'), compact)} "
+                f"(fp {short}, work_dir {s.get('source_work_dir')}, material {s.get('material_id')})"
+            )
     lines.append("")
 
     if state["next_pause"]:
@@ -386,6 +418,8 @@ def _map_output_window(out_start, out_end, clips, compact):
             continue
         segments.append({
             "clip_id": clip["clip_id"],
+            "source_id": clip.get("source_id"),
+            "source_path": clip.get("source_path"),
             "output": [round(ov[0], 3), round(ov[1], 3)],
             "source": [_output_to_source(ov[0], clip), _output_to_source(ov[1], clip)],
             "reason": _truncate(clip.get("reason"), compact),
@@ -416,6 +450,8 @@ def _map_source_window(src_start, src_end, clips, compact):
         covered.append(ov)
         segments.append({
             "clip_id": clip["clip_id"],
+            "source_id": clip.get("source_id"),
+            "source_path": clip.get("source_path"),
             "source": [round(ov[0], 3), round(ov[1], 3)],
             "output": [_source_to_output(ov[0], clip), _source_to_output(ov[1], clip)],
             "reason": _truncate(clip.get("reason"), compact),
@@ -459,7 +495,9 @@ def _render_clip_map_md(result, compact):
             src = f"{_fmt_seconds(s['source'][0])}–{_fmt_seconds(s['source'][1])}"
             out = f"{_fmt_seconds(s['output'][0])}–{_fmt_seconds(s['output'][1])}"
             reason = f"  〔{s['reason']}〕" if s.get("reason") else ""
-            lines.append(f"  clip {s['clip_id']}: 源 {src}  ↔  输出 {out}{reason}")
+            sid = f" {s.get('source_id')}" if s.get("source_id") else ""
+            spath = f" `{_truncate(s.get('source_path'), compact)}`" if s.get("source_path") else ""
+            lines.append(f"  clip {s['clip_id']}{sid}{spath}: 源 {src}  ↔  输出 {out}{reason}")
         if q["cut_out_source_gaps"]:
             lines.append("  ✂️ 被剪掉的源区间（不在成片里）:")
             for g in q["cut_out_source_gaps"]:

--- a/skills/video-understanding/scripts/understand.py
+++ b/skills/video-understanding/scripts/understand.py
@@ -524,6 +524,84 @@ def _research_context(work_dir):
     return " ".join(parts).strip()[:1200]
 
 
+def _load_understanding_artifacts_for_brief(work_dir):
+    """Load existing analysis artifacts for a brief-only regeneration pass.
+
+    Material-library restores are allowed to reuse expensive analysis artifacts,
+    but cut pass 2 must still rebuild `agent_narration_brief.md` against the
+    rendered OUTPUT timeline. This helper deliberately performs no extraction,
+    ASR, VLM, or external API calls; it only reads already-present JSON.
+    """
+    work_dir = Path(work_dir)
+    scenes = []
+    for name in ("vlm_analysis.json", "scenes.json"):
+        path = work_dir / name
+        if not path.exists():
+            continue
+        try:
+            data = _load_json(path)
+        except (OSError, ValueError, TypeError):
+            continue
+        if isinstance(data, list):
+            scenes = data
+            break
+    asr_result = []
+    if (work_dir / "asr_result.json").exists():
+        try:
+            data = _load_json(work_dir / "asr_result.json")
+        except (OSError, ValueError, TypeError):
+            data = []
+        if isinstance(data, list):
+            asr_result = data
+    silence_periods = []
+    if (work_dir / "silence_periods.json").exists():
+        try:
+            data = _load_json(work_dir / "silence_periods.json")
+        except (OSError, ValueError, TypeError):
+            data = []
+        if isinstance(data, list):
+            silence_periods = data
+    return scenes, asr_result, silence_periods
+
+
+def _write_brief_from_existing_artifacts(video, work_dir, args, video_duration):
+    """Regenerate only the agent brief/timeline-fusion from existing artifacts."""
+    scenes, asr_result, silence_periods = _load_understanding_artifacts_for_brief(work_dir)
+    overview_path = Path(work_dir) / "mimo_video_overview.json"
+    if CONFIG.get("mimo_video_overview", False):
+        scenes = _merge_overview_into_scenes(scenes, overview_path)
+
+    source_storyboard = None
+    edited_storyboard = None
+    scenes_json = Path(work_dir) / "scenes.json"
+    if scenes_json.exists():
+        source_storyboard = _generate_source_storyboard(work_dir, Path(video), scenes, scenes_json, force=False)
+    edited_storyboard = _generate_edited_storyboard(work_dir, video, force=False)
+    cut_mode = (Path(work_dir) / "clip_plan_validated.json").exists()
+
+    substrate = assess_understanding_substrate(scenes, asr_result)
+    if substrate["level"] != "rich":
+        banner = "理解素材为空" if substrate["level"] == "empty" else "理解素材偏薄"
+        log(f"⚠️  {banner}：ASR {substrate['asr_chars']} 字 | 场景 {substrate['scene_count']} | "
+            f"带 frame_facts 的场景 {substrate['scenes_with_frame_facts']} | 平均画面描述 {substrate['avg_description_len']} 字")
+    brief_path = build_agent_brief(
+        scenes, asr_result, silence_periods, video_duration, work_dir, args.style,
+        mimo_overview_enabled=CONFIG.get("mimo_video_overview", False),
+        mimo_overview_video_path=video,
+    )
+    _prepend_storyboard_brief_header(brief_path, source_storyboard, edited_storyboard, cut_mode=cut_mode)
+    log("=" * 50)
+    log(f"brief-only 完成。写作 brief: {brief_path}")
+    print(json.dumps({
+        "status": "brief_only",
+        "work_dir": str(work_dir),
+        "brief": str(brief_path),
+        "substrate": substrate["level"],
+        "scenes": len(scenes),
+        "asr_segments": len(asr_result),
+    }, ensure_ascii=False))
+
+
 def main():
     ap = argparse.ArgumentParser(description="Analyze a video into an understanding index + narration brief.")
     ap.add_argument("video")
@@ -536,6 +614,8 @@ def main():
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
     ap.add_argument("--force", action="store_true", help="ignore cached artifacts and recompute")
+    ap.add_argument("--brief-only", action="store_true",
+                    help="rebuild agent_narration_brief.md from existing artifacts only; no extraction/API")
     ap.add_argument("--consolidate", action=argparse.BooleanOptionalAction, default=True,
                     help="build the global understanding story index (Pass B); default ON, --no-consolidate to skip")
     ap.add_argument("--consolidate-asr", action="store_true", help="also clean the ASR transcript (Pass A)")
@@ -566,6 +646,10 @@ def main():
     if CONFIG["fps"] <= 0:
         CONFIG["fps"] = 2 if video_duration <= 60 else (1.5 if video_duration <= 300 else 1)
     log(f"FPS: {CONFIG['fps']} (视频时长: {video_duration:.1f}s)")
+
+    if args.brief_only:
+        _write_brief_from_existing_artifacts(video, work_dir, args, video_duration)
+        return
 
     scenes_json = work_dir / "scenes.json"
     asr_json = work_dir / "asr_result.json"

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -74,8 +74,8 @@ def test_build_video_clips_prefers_fingerprint_matched_validated_cut_plan(monkey
     clips = _build_video_clips(edited, tmp_path, duration_s=15.0)
 
     assert clips == [
-        {"source_path": str(original), "source_start": 10.0, "source_end": 20.0, "timeline_start": 0.0, "timeline_end": 10.0},
-        {"source_path": str(original), "source_start": 40.0, "source_end": 45.0, "timeline_start": 10.0, "timeline_end": 15.0},
+        {"source_id": None, "source_path": str(original), "source_start": 10.0, "source_end": 20.0, "timeline_start": 0.0, "timeline_end": 10.0},
+        {"source_id": None, "source_path": str(original), "source_start": 40.0, "source_end": 45.0, "timeline_start": 10.0, "timeline_end": 15.0},
     ]
 
 
@@ -126,7 +126,7 @@ def test_build_video_clips_ignores_stale_validated_cut_plan(monkeypatch, tmp_pat
     clips = _build_video_clips(edited, tmp_path, duration_s=5.0)
 
     assert clips == [
-        {"source_path": str(original), "source_start": 40.0, "source_end": 45.0, "timeline_start": 0.0, "timeline_end": 5.0},
+        {"source_id": None, "source_path": str(original), "source_start": 40.0, "source_end": 45.0, "timeline_start": 0.0, "timeline_end": 5.0},
     ]
 
 

--- a/tests/assemble/test_timeline.py
+++ b/tests/assemble/test_timeline.py
@@ -230,20 +230,24 @@ def test_build_video_clips_prefers_per_clip_source_path_without_explicit_source_
     assert clips[1]["timeline_start"] == 1.0
 
 
-def test_build_video_clips_missing_multi_source_path_falls_back_to_rendered_clip(monkeypatch, tmp_path):
+def test_build_video_clips_degrades_only_missing_clip_keeps_present_provenance(monkeypatch, tmp_path):
+    """One stale source must degrade ONLY its own clip; clips whose source is present keep
+    their real source_id/source_path provenance (no whole-timeline collapse)."""
     sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
     import assemble
 
     rendered = tmp_path / "edited_source.mp4"
     rendered.write_bytes(b"e")
+    present = tmp_path / "present.mp4"
+    present.write_bytes(b"p")
     work = tmp_path / "work"
     work.mkdir()
     (work / "clip_plan_validated.json").write_text(json.dumps({
         "clips": [
-            {"source_path": str(tmp_path / "missing.mp4"), "source_start": 1.0, "source_end": 2.0,
-             "output_start": 0.0, "output_end": 1.0},
-            {"source_path": str(rendered), "source_start": 3.0, "source_end": 5.0,
-             "output_start": 1.0, "output_end": 3.0},
+            {"source_id": "src_miss", "source_path": str(tmp_path / "missing.mp4"),
+             "source_start": 1.0, "source_end": 2.0, "output_start": 0.0, "output_end": 1.0},
+            {"source_id": "src_ok", "source_path": str(present),
+             "source_start": 3.0, "source_end": 5.0, "output_start": 1.0, "output_end": 3.0},
         ]
     }), encoding="utf-8")
     monkeypatch.setitem(assemble.CONFIG, "source_video_explicit", False)
@@ -251,10 +255,16 @@ def test_build_video_clips_missing_multi_source_path_falls_back_to_rendered_clip
 
     clips = assemble._build_video_clips(rendered, work, 3.0)
 
-    assert clips == [{"source_path": str(rendered), "source_start": 0.0,
-                      "source_end": 3.0, "timeline_start": 0.0, "timeline_end": 3.0,
-                      "provenance_degraded": True,
-                      "provenance_reason": f"missing_source_path:{tmp_path / 'missing.mp4'}"}]
+    assert len(clips) == 2
+    ok = clips[1]
+    assert ok["source_path"] == str(present) and ok["source_id"] == "src_ok"
+    assert ok["source_start"] == 3.0 and ok["source_end"] == 5.0
+    assert not ok.get("provenance_degraded")
+    bad = clips[0]
+    assert bad["provenance_degraded"] is True and bad["source_id"] == "src_miss"
+    assert bad["source_path"] == str(rendered)
+    assert bad["timeline_start"] == 0.0 and bad["timeline_end"] == 1.0
+    assert bad["provenance_reason"].startswith("missing_source_path:")
 
 
 def test_emit_timeline_marks_degraded_multi_source_fallback(monkeypatch, tmp_path):

--- a/tests/assemble/test_timeline.py
+++ b/tests/assemble/test_timeline.py
@@ -201,3 +201,83 @@ def test_variable_ducking_keyframes_do_not_release_to_idle_between_close_windows
     # level — the duck never swells back to idle between them.
     held = [kf["gain"] for kf in keyframes if 1.0 <= kf["t"] <= 5.0]
     assert held and all(g == 0.12 for g in held)
+
+
+def test_build_video_clips_prefers_per_clip_source_path_without_explicit_source_video(monkeypatch, tmp_path):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
+    import assemble
+
+    a = tmp_path / "a.mp4"
+    b = tmp_path / "b.mp4"
+    rendered = tmp_path / "edited_source.mp4"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
+    rendered.write_bytes(b"e")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "clip_plan_validated.json").write_text(json.dumps({
+        "clips": [
+            {"source_path": str(a), "source_start": 1.0, "source_end": 2.0, "output_start": 0.0, "output_end": 1.0},
+            {"source_path": str(b), "source_start": 3.0, "source_end": 5.0, "output_start": 1.0, "output_end": 3.0},
+        ]
+    }), encoding="utf-8")
+    monkeypatch.setitem(assemble.CONFIG, "source_video_explicit", False)
+    monkeypatch.setitem(assemble.CONFIG, "source_video", "")
+
+    clips = assemble._build_video_clips(rendered, work, 3.0)
+
+    assert [c["source_path"] for c in clips] == [str(a), str(b)]
+    assert clips[1]["timeline_start"] == 1.0
+
+
+def test_build_video_clips_missing_multi_source_path_falls_back_to_rendered_clip(monkeypatch, tmp_path):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
+    import assemble
+
+    rendered = tmp_path / "edited_source.mp4"
+    rendered.write_bytes(b"e")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "clip_plan_validated.json").write_text(json.dumps({
+        "clips": [
+            {"source_path": str(tmp_path / "missing.mp4"), "source_start": 1.0, "source_end": 2.0,
+             "output_start": 0.0, "output_end": 1.0},
+            {"source_path": str(rendered), "source_start": 3.0, "source_end": 5.0,
+             "output_start": 1.0, "output_end": 3.0},
+        ]
+    }), encoding="utf-8")
+    monkeypatch.setitem(assemble.CONFIG, "source_video_explicit", False)
+    monkeypatch.setitem(assemble.CONFIG, "source_video", "")
+
+    clips = assemble._build_video_clips(rendered, work, 3.0)
+
+    assert clips == [{"source_path": str(rendered), "source_start": 0.0,
+                      "source_end": 3.0, "timeline_start": 0.0, "timeline_end": 3.0,
+                      "provenance_degraded": True,
+                      "provenance_reason": f"missing_source_path:{tmp_path / 'missing.mp4'}"}]
+
+
+def test_emit_timeline_marks_degraded_multi_source_fallback(monkeypatch, tmp_path):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
+    import assemble
+
+    rendered = tmp_path / "edited_source.mp4"
+    rendered.write_bytes(b"e")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "clip_plan_validated.json").write_text(json.dumps({
+        "clips": [
+            {"source_path": str(tmp_path / "missing.mp4"), "source_start": 1.0, "source_end": 2.0,
+             "output_start": 0.0, "output_end": 1.0},
+        ]
+    }), encoding="utf-8")
+    monkeypatch.setitem(assemble.CONFIG, "source_video_explicit", False)
+    monkeypatch.setitem(assemble.CONFIG, "source_video", "")
+    monkeypatch.setattr(assemble, "_probe_canvas", lambda _path: {"width": 100, "height": 100, "fps": 25})
+    monkeypatch.setattr(assemble, "_combined_subtitle_entries", lambda *_args: [])
+
+    timeline = assemble._emit_timeline(rendered, [], work, 3.0, has_bgm=False)
+
+    assert timeline["provenance"]["degraded"] is True
+    assert timeline["provenance"]["degraded_clips"][0]["reason"].startswith("missing_source_path:")
+    assert json.loads((work / "timeline.json").read_text(encoding="utf-8"))["provenance"]["degraded"] is True

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -613,11 +613,62 @@ def test_build_edited_source_video_multi_source_uses_multiple_inputs_and_cache_m
     out = cut.build_edited_source_video("ignored.mp4", plan, work_dir)
 
     ffmpeg_cmd = [cmd for cmd in commands if cmd[0] == "ffmpeg"][0]
-    assert ffmpeg_cmd.count("-i") == 3  # two media inputs + generated silent audio
+    # Only the two media inputs — audio is now synthesized per-clip inside filter_complex,
+    # not via a single global anullsrc input.
+    assert ffmpeg_cmd.count("-i") == 2
     joined = " ".join(ffmpeg_cmd)
     assert f"-i {a}" in joined and f"-i {b}" in joined
     assert "[0:v]trim=start=0.000:end=1.000" in joined
     assert "[1:v]trim=start=2.000:end=3.000" in joined
     assert "[0:v]trim=start=4.000:end=5.000" in joined
-    assert "concat=n=3" in joined
+    # Heterogeneous sources are normalized to one canvas before concat (probe is mocked
+    # empty -> default 1280x720), and each clip gets an audio segment (silent here).
+    assert "scale=1280:720" in joined and "setsar=1" in joined and "format=yuv420p" in joined
+    assert "anullsrc=r=48000:cl=stereo" in joined
+    assert "concat=n=3:v=1:a=1" in joined
     assert cut.should_reuse_edited_source(out, plan, "ignored.mp4") is True
+
+
+def test_build_edited_source_video_multi_resolution_mixed_audio_real_render(tmp_path):
+    """Real ffmpeg: heterogeneous sources (different resolution/fps, one silent) must concat
+    into ONE playable output with an audio track. This path was previously all-mocked, hiding
+    the missing scale/setsar/fps normalization (concat would abort) and the all-or-nothing
+    audio drop."""
+    import shutil
+    import subprocess
+    if not (shutil.which("ffmpeg") and shutil.which("ffprobe")):
+        pytest.skip("ffmpeg/ffprobe required for real render")
+    import cut
+
+    a = tmp_path / "a_1080_audio.mp4"   # 1920x1080@30, WITH audio
+    b = tmp_path / "b_480_silent.mp4"   # 854x480@24, NO audio
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "testsrc=size=1920x1080:rate=30:duration=2",
+                    "-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+                    "-shortest", "-pix_fmt", "yuv420p", str(a)], check=True, capture_output=True)
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "testsrc=size=854x480:rate=24:duration=2",
+                    "-pix_fmt", "yuv420p", str(b)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    plan = cut.normalize_multi_source_clip_plan([
+        {"source_id": "a", "start": 0.0, "end": 1.0},
+        {"source_id": "b", "start": 0.0, "end": 1.0},
+        {"source_id": "a", "start": 1.0, "end": 2.0},
+    ], {"sources": [
+        {"source_id": "a", "source_path": str(a), "duration": 2.0},
+        {"source_id": "b", "source_path": str(b), "duration": 2.0},
+    ]})
+
+    out = cut.build_edited_source_video(str(a), plan, work)
+    assert out.exists() and out.stat().st_size > 0
+
+    def _has_stream(kind):
+        r = subprocess.run(["ffprobe", "-v", "error", "-select_streams", kind,
+                            "-show_entries", "stream=index", "-of", "csv=p=0", str(out)],
+                           capture_output=True, text=True)
+        return bool(r.stdout.strip())
+
+    assert _has_stream("v:0"), "no video stream in concatenated output"
+    assert _has_stream("a:0"), "audio track dropped even though one source had audio"
+    dur = float(subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                                "-of", "csv=p=0", str(out)], capture_output=True, text=True).stdout.strip())
+    assert dur > 2.0, f"expected ~3s of concatenated clips, got {dur}s"

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -546,3 +546,78 @@ def test_detect_shot_changes_offsets_by_seek_and_filters_window(monkeypatch):
                         types.SimpleNamespace(run=lambda *a, **k: CompletedProcess(a, 0, "", stderr)))
     out = cut._detect_shot_changes("v.mkv", 55.0, 68.0, 0.4)  # seek=54.75
     assert out == [56.512, 60.616]  # 54.8 (54.75+0.05) is < win_start → filtered
+
+
+def test_normalize_multi_source_clip_plan_maps_sources_and_validates_per_source_overlap(tmp_path):
+    manifest = {
+        "sources": [
+            {"source_id": "a", "source_path": str(tmp_path / "a.mp4"), "duration": 10.0},
+            {"source_id": "b", "source_path": str(tmp_path / "b.mp4"), "duration": 5.0},
+        ]
+    }
+    plan = cut.normalize_multi_source_clip_plan([
+        {"source_id": "a", "start": 1.0, "end": 4.0, "reason": "A"},
+        {"source_id": "b", "start": 4.0, "end": 8.0, "reason": "B"},
+        {"source_id": "b", "start": 0.0, "end": 1.0, "reason": "B2"},
+    ], manifest, clip_padding=0.5)
+
+    assert plan["total_duration"] == 7.0
+    assert [c["source_id"] for c in plan["clips"]] == ["a", "b", "b"]
+    assert plan["clips"][0]["source_path"].endswith("a.mp4")
+    assert plan["clips"][0]["source_start"] == 0.5
+    assert plan["clips"][1]["source_end"] == 5.0  # clamped to source b duration
+    assert plan["clips"][2]["output_start"] == 5.5
+
+    with pytest.raises(ValueError, match="source_id a"):
+        cut.normalize_multi_source_clip_plan([
+            {"source_id": "a", "start": 1.0, "end": 4.0},
+            {"source_id": "a", "start": 3.5, "end": 5.0},
+        ], manifest)
+    with pytest.raises(ValueError, match="missing source_id"):
+        cut.normalize_multi_source_clip_plan([
+            {"start": 1.0, "end": 2.0},
+        ], manifest)
+    with pytest.raises(ValueError, match="unknown source_id"):
+        cut.normalize_multi_source_clip_plan([
+            {"source_id": "missing", "start": 1.0, "end": 2.0},
+        ], manifest)
+
+
+def test_build_edited_source_video_multi_source_uses_multiple_inputs_and_cache_meta(monkeypatch, tmp_path):
+    a = tmp_path / "a.mp4"
+    b = tmp_path / "b.mp4"
+    a.write_bytes(b"aaa")
+    b.write_bytes(b"bbb")
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    plan = cut.normalize_multi_source_clip_plan([
+        {"source_id": "a", "start": 0, "end": 1},
+        {"source_id": "b", "start": 2, "end": 3},
+        {"source_id": "a", "start": 4, "end": 5},
+    ], {"sources": [
+        {"source_id": "a", "source_path": str(a), "duration": 10},
+        {"source_id": "b", "source_path": str(b), "duration": 10},
+    ]})
+    commands = []
+
+    def fake_run_cmd(cmd):
+        commands.append(cmd)
+        if cmd[0] == "ffprobe":
+            return CompletedProcess(cmd, 0, stdout="", stderr="")
+        Path(cmd[-1]).write_bytes(b"edited")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("cut.run_cmd", fake_run_cmd)
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 3.0)
+
+    out = cut.build_edited_source_video("ignored.mp4", plan, work_dir)
+
+    ffmpeg_cmd = [cmd for cmd in commands if cmd[0] == "ffmpeg"][0]
+    assert ffmpeg_cmd.count("-i") == 3  # two media inputs + generated silent audio
+    joined = " ".join(ffmpeg_cmd)
+    assert f"-i {a}" in joined and f"-i {b}" in joined
+    assert "[0:v]trim=start=0.000:end=1.000" in joined
+    assert "[1:v]trim=start=2.000:end=3.000" in joined
+    assert "[0:v]trim=start=4.000:end=5.000" in joined
+    assert "concat=n=3" in joined
+    assert cut.should_reuse_edited_source(out, plan, "ignored.mp4") is True

--- a/tests/inspect/test_inspect.py
+++ b/tests/inspect/test_inspect.py
@@ -292,3 +292,37 @@ def test_clip_map_bare_list_plan_with_derived_output(tmp_path):
         source_start=51.0, source_end=54.0, compact=True)
     seg = result["queries"][0]["segments"][0]
     assert seg["output"] == [11.0, 14.0]
+
+
+def test_state_surfaces_multi_source_manifest(tmp_path):
+    (tmp_path / "multi_source_manifest.json").write_text(json.dumps({
+        "schema_version": 1,
+        "sources": [
+            {"source_id": "src_a", "source_path": "/videos/a.mp4", "source_name": "a.mp4",
+             "source_video_fingerprint": "a" * 64, "source_work_dir": "sources/src_a", "material_id": "a-src_a"},
+            {"source_id": "src_b", "source_path": "/videos/b.mp4", "source_name": "b.mp4",
+             "source_video_fingerprint": "b" * 64, "source_work_dir": "sources/src_b", "material_id": "b-src_b"},
+        ],
+    }), encoding="utf-8")
+    state = recap_inspect.cmd_state(tmp_path, compact=True)
+    assert state["mode"] == "cut"
+    assert [s["source_id"] for s in state["multi_source"]["sources"]] == ["src_a", "src_b"]
+    md = recap_inspect._render_state_md(state, compact=True)
+    assert "多源素材" in md
+    assert "src_a" in md and "sources/src_b" in md
+
+
+def test_clip_map_includes_multi_source_provenance(tmp_path):
+    _write_plan(tmp_path, {
+        "clips": [
+            {"clip_id": 0, "source_id": "src_a", "source_path": "/videos/a.mp4",
+             "source_start": 10.0, "source_end": 12.0, "output_start": 0.0, "output_end": 2.0},
+        ]
+    })
+    result = recap_inspect.cmd_clip_map(tmp_path, output_start=0.5, output_end=1.0,
+                                        source_start=None, source_end=None, compact=True)
+    seg = result["queries"][0]["segments"][0]
+    assert seg["source_id"] == "src_a"
+    assert seg["source_path"] == "/videos/a.mp4"
+    md = recap_inspect._render_clip_map_md(result, compact=True)
+    assert "src_a" in md and "/videos/a.mp4" in md

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -878,3 +878,219 @@ def test_review_status_does_not_gate_on_bare_model_verdict(tmp_path):
     _write({"verdict": "PASS", "findings": [{"severity": "error", "category": "hallucination", "issue": "x"}]})
     status = recap._review_result_status(tmp_path)
     assert status["ok"] is False and status["errors"] == 1
+
+
+def test_recap_rejects_multi_video_non_cut(monkeypatch, tmp_path):
+    v1 = tmp_path / "a.mp4"
+    v2 = tmp_path / "b.mp4"
+    v1.write_bytes(b"a")
+    v2.write_bytes(b"b")
+    monkeypatch.setattr("recap._run", lambda *args: (_ for _ in ()).throw(AssertionError("must fail first")))
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(v1), str(v2), "--edit-mode", "full"])
+
+    with pytest.raises(SystemExit, match="多视频输入当前 MVP 只支持 --edit-mode cut"):
+        recap.main()
+
+
+def test_recap_multi_video_phase_a_writes_manifest_and_pauses(monkeypatch, tmp_path, capsys):
+    v1 = tmp_path / "a.mp4"
+    v2 = tmp_path / "b.mp4"
+    v1.write_bytes(b"a source")
+    v2.write_bytes(b"b source")
+    work = tmp_path / "project"
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(a) for a in cli_args]))
+        if script == "understand.py":
+            wd = Path(cli_args[cli_args.index("--work-dir") + 1])
+            wd.mkdir(parents=True, exist_ok=True)
+            (wd / "agent_narration_brief.md").write_text("# per-source\n", encoding="utf-8")
+            (wd / "scenes.json").write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(v1), str(v2), "--work-dir", str(work), "--edit-mode", "cut",
+        "--material-library-dir", str(tmp_path / "lib"), "--save-materials",
+    ])
+
+    recap.main()
+
+    manifest = json.loads((work / "multi_source_manifest.json").read_text(encoding="utf-8"))
+    assert len(manifest["sources"]) == 2
+    assert all(s["source_id"].startswith("src_") for s in manifest["sources"])
+    assert (work / "recap_run_manifest.json").exists()
+    assert "source_id" in (work / "agent_narration_brief.md").read_text(encoding="utf-8")
+    assert len([c for c in calls if c[:2] == ("video-understanding", "understand.py")]) == 2
+    assert (tmp_path / "lib" / "materials_index.jsonl").exists()
+    out = capsys.readouterr().out
+    assert "clip_plan.json" in out
+    assert "--material-library-dir" in out and "--save-materials" in out
+
+
+def test_recap_multi_video_phase_b_invokes_cut_with_sources_manifest(monkeypatch, tmp_path):
+    v1 = tmp_path / "a.mp4"
+    v2 = tmp_path / "b.mp4"
+    v1.write_bytes(b"a source")
+    v2.write_bytes(b"b source")
+    work = tmp_path / "project"
+    work.mkdir()
+    args = _manifest_args(edit_mode="cut")
+    records = recap._build_multi_source_records([v1.resolve(), v2.resolve()], work, args)
+    recap._write_multi_source_manifest(work, records)
+    recap._write_project_run_manifest(work, [v1.resolve(), v2.resolve()], args, records)
+    (work / "clip_plan.json").write_text(json.dumps({
+        "clips": [{"source_id": records[0]["source_id"], "start": 0, "end": 1}]
+    }), encoding="utf-8")
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(a) for a in cli_args]))
+        if script == "cut.py":
+            (work / "edited_source.mp4").write_bytes(b"edited")
+            (work / "clip_plan_validated.json").write_text(json.dumps({
+                "clips": [{"source_id": records[0]["source_id"], "source_path": str(v1.resolve()),
+                           "source_start": 0, "source_end": 1, "output_start": 0, "output_end": 1,
+                           "duration": 1}]
+            }), encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(v1), str(v2), "--work-dir", str(work), "--edit-mode", "cut"])
+
+    recap.main()
+
+    cut_args = next(c for c in calls if c[:2] == ("video-cut", "cut.py"))[2]
+    assert "--sources-manifest" in cut_args
+    assert cut_args[cut_args.index("--sources-manifest") + 1] == str(work / "multi_source_manifest.json")
+    assert "--no-narration-map" in cut_args
+    assert not any(c[1] in ("voiceover.py", "assemble.py") for c in calls)
+    assert recap._read_phase_ledger(work)["multi_source"] is True
+
+
+def test_continuation_command_preserves_multi_videos_and_material_flags(tmp_path):
+    args = _manifest_args(edit_mode="cut")
+    args.mimo_tts_voice = None
+    args.burn_subtitles = None
+    args.output_dir = None
+    args.export_jianying = False
+    args.jianying_bundle_media = False
+    args.jianying_no_bundle_media = False
+    args.allow_partial_tts = False
+    args.review_narration = None
+    args.require_narration_review = False
+    args.material_library_dir = str(tmp_path / "lib")
+    args.use_materials = True
+    args.save_materials = True
+
+    cmd = recap._continuation_command([tmp_path / "a.mp4", tmp_path / "b.mp4"], tmp_path / "work", args)
+
+    assert "a.mp4" in cmd and "b.mp4" in cmd
+    assert "--material-library-dir" in cmd
+    assert "--use-materials" in cmd
+    assert "--save-materials" in cmd
+
+
+def test_recap_single_video_phase_a_can_save_materials(monkeypatch, tmp_path):
+    video = tmp_path / "solo.mp4"
+    video.write_bytes(b"solo source")
+    work = tmp_path / "work"
+    lib = tmp_path / "materials"
+
+    def fake_run(skill, script, *cli_args):
+        assert (skill, script) == ("video-understanding", "understand.py")
+        wd = Path(cli_args[cli_args.index("--work-dir") + 1])
+        wd.mkdir(parents=True, exist_ok=True)
+        (wd / "agent_narration_brief.md").write_text("# solo brief", encoding="utf-8")
+        (wd / "scenes.json").write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work),
+        "--material-library-dir", str(lib), "--save-materials",
+    ])
+
+    recap.main()
+
+    assert (lib / "materials_index.jsonl").exists()
+    saved = list((lib / "materials").glob("*/material.json"))
+    assert saved
+    assert (work / "recap_run_manifest.json").exists()
+
+
+def test_recap_single_video_phase_a_uses_materials_without_understand(monkeypatch, tmp_path):
+    video = tmp_path / "solo.mp4"
+    video.write_bytes(b"solo source")
+    seed_work = tmp_path / "seed"
+    seed_work.mkdir()
+    (seed_work / "agent_narration_brief.md").write_text("# restored brief", encoding="utf-8")
+    (seed_work / "scenes.json").write_text("[]", encoding="utf-8")
+    args = _manifest_args(consolidate=True)
+    fp = recap._file_fingerprint(video)
+    settings_fp = recap._material_settings_fingerprint(args)
+    lib = tmp_path / "materials"
+    recap.material_lib.save_material(lib, seed_work, video, fp, settings_fp)
+    work = tmp_path / "work"
+
+    def fake_run(*_args):
+        raise AssertionError("understand.py should not run when material restore matches")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work),
+        "--material-library-dir", str(lib), "--use-materials",
+    ])
+
+    recap.main()
+
+    assert (work / "agent_narration_brief.md").read_text(encoding="utf-8") == "# restored brief"
+    assert (work / "scenes.json").exists()
+    assert (work / "recap_run_manifest.json").exists()
+
+
+def test_recap_single_video_cut_pass2_rebuilds_output_brief_with_materials_enabled(monkeypatch, tmp_path):
+    video = tmp_path / "solo.mp4"
+    video.write_bytes(b"solo source")
+    work = tmp_path / "work"
+    work.mkdir()
+    args = _manifest_args(edit_mode="cut", consolidate=True)
+    # Existing Phase A state: material restore may have produced a source-time brief, but
+    # pass 2 must replace it with an OUTPUT-time brief after edited_source.mp4 exists.
+    recap._write_run_manifest(work, video, args)
+    (work / "clip_plan.json").write_text(json.dumps({"clips": [{"start": 0, "end": 1}]}), encoding="utf-8")
+    (work / "agent_narration_brief.md").write_text("SOURCE-TIME BRIEF FROM MATERIAL", encoding="utf-8")
+    lib = tmp_path / "materials"
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "agent_narration_brief.md").write_text("SOURCE-TIME BRIEF FROM MATERIAL", encoding="utf-8")
+    (seed / "scenes.json").write_text("[]", encoding="utf-8")
+    recap.material_lib.save_material(
+        lib, seed, video, recap._file_fingerprint(video),
+        recap._material_settings_fingerprint(args),
+    )
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(a) for a in cli_args]))
+        if script == "cut.py":
+            (work / "edited_source.mp4").write_bytes(b"edited")
+            (work / "clip_plan_validated.json").write_text(json.dumps({
+                "raw_plan_fingerprint": "not-used-here",
+                "clips": [{"source_start": 0, "source_end": 1, "output_start": 0, "output_end": 1,
+                           "duration": 1}]
+            }), encoding="utf-8")
+        elif script == "understand.py":
+            assert "--brief-only" in [str(a) for a in cli_args]
+            (work / "agent_narration_brief.md").write_text("OUTPUT-TIME BRIEF", encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut",
+        "--material-library-dir", str(lib), "--use-materials",
+    ])
+
+    recap.main()
+
+    understand_calls = [c for c in calls if c[:2] == ("video-understanding", "understand.py")]
+    assert len(understand_calls) == 1
+    assert "--brief-only" in understand_calls[0][2]
+    assert (work / "agent_narration_brief.md").read_text(encoding="utf-8") == "OUTPUT-TIME BRIEF"

--- a/tests/orchestrator/test_materials.py
+++ b/tests/orchestrator/test_materials.py
@@ -1,0 +1,157 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-recap" / "scripts"))
+
+import materials  # noqa: E402
+
+
+def test_source_id_stable_and_duplicate_paths_get_suffix(tmp_path):
+    fp1 = "a" * 64
+    fp2 = "b" * 64
+    a = tmp_path / "a.mp4"
+    b = tmp_path / "b.mp4"
+    c = tmp_path / "copy.mp4"
+    for p in (a, b, c):
+        p.write_bytes(b"x")
+
+    first = materials.assign_source_ids([
+        {"source_path": b, "source_video_fingerprint": fp2},
+        {"source_path": a, "source_video_fingerprint": fp1},
+    ])
+    second = materials.assign_source_ids([
+        {"source_path": a, "source_video_fingerprint": fp1},
+        {"source_path": b, "source_video_fingerprint": fp2},
+    ])
+
+    assert {r["source_video_fingerprint"]: r["source_id"] for r in first} == {
+        r["source_video_fingerprint"]: r["source_id"] for r in second
+    }
+    dup = materials.assign_source_ids([
+        {"source_path": a, "source_video_fingerprint": fp1},
+        {"source_path": c, "source_video_fingerprint": fp1},
+    ])
+    assert dup[0]["source_id"] == "src_aaaaaaaaaaaa"
+    assert dup[1]["source_id"].startswith("src_aaaaaaaaaaaa_")
+    assert len(dup[1]["source_id"].split("_")[-1]) == 6
+
+
+def test_material_id_stable_for_same_basename_and_fingerprint(tmp_path):
+    fp = "1234567890abcdef" * 4
+    assert materials.material_id_for(tmp_path / "Episode 1.mp4", fp) == materials.material_id_for(tmp_path / "Episode 1.mp4", fp)
+    assert materials.material_id_for(tmp_path / "Episode 1.mp4", fp).endswith("-1234567890ab")
+
+
+def test_save_material_copies_allowed_files_writes_md_and_append_index(tmp_path):
+    lib = tmp_path / "library"
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "scenes.json").write_text(json.dumps([{"start": 0, "end": 1}]), encoding="utf-8")
+    (work / "understanding_index.json").write_text(json.dumps({"summary": "英雄入场", "tags": ["hero"]}), encoding="utf-8")
+    (work / "audio.wav").write_bytes(b"raw audio should not copy")
+    (work / "secret.json").write_text("tp-secret", encoding="utf-8")
+
+    meta = materials.save_material(lib, work, tmp_path / "ep1.mp4", "f" * 64, "settings", source_id="src_ffffffffffff")
+
+    mdir = lib / "materials" / meta["material_id"]
+    assert (mdir / "material.json").exists()
+    assert (mdir / "material.md").exists()
+    assert (mdir / "artifacts" / "scenes.json").exists()
+    assert not (mdir / "artifacts" / "audio.wav").exists()
+    assert not (mdir / "artifacts" / "secret.json").exists()
+    lines = (lib / "materials_index.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["event"] == "saved"
+    assert rec["summary"] == "英雄入场"
+    assert "hero" in rec["tags"]
+
+    materials.save_material(lib, work, tmp_path / "ep1.mp4", "f" * 64, "settings", source_id="src_ffffffffffff")
+    assert len((lib / "materials_index.jsonl").read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_restore_material_requires_matching_fingerprint_and_settings(tmp_path):
+    lib = tmp_path / "library"
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "asr_result.json").write_text(json.dumps([{"text": "hello"}]), encoding="utf-8")
+    meta = materials.save_material(lib, work, tmp_path / "ep.mp4", "a" * 64, "s1")
+
+    dest = tmp_path / "dest"
+    mismatch = materials.restore_material(lib, dest, source_fingerprint="b" * 64, settings_fp="s1", material_id=meta["material_id"])
+    assert mismatch["restored"] is False
+    assert not dest.exists()
+
+    mismatch = materials.restore_material(lib, dest, source_fingerprint="a" * 64, settings_fp="s2", material_id=meta["material_id"])
+    assert mismatch["restored"] is False
+    assert not dest.exists()
+
+    ok = materials.restore_material(lib, dest, source_fingerprint="a" * 64, settings_fp="s1", material_id=meta["material_id"])
+    assert ok["restored"] is True
+    assert (dest / "asr_result.json").exists()
+
+
+def test_restore_material_prunes_stale_allowed_artifacts_before_copy(tmp_path):
+    lib = tmp_path / "library"
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "scenes.json").write_text(json.dumps([{"start": 0, "end": 1}]), encoding="utf-8")
+    meta = materials.save_material(lib, seed, tmp_path / "ep.mp4", "e" * 64, "settings")
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "vlm_analysis.json").write_text(json.dumps({"summary": "stale"}), encoding="utf-8")
+    (dest / "narration.json").write_text("[]", encoding="utf-8")
+
+    restored = materials.restore_material(
+        lib,
+        dest,
+        source_fingerprint="e" * 64,
+        settings_fp="settings",
+        material_id=meta["material_id"],
+    )
+
+    assert restored["restored"] is True
+    assert (dest / "scenes.json").exists()
+    assert not (dest / "vlm_analysis.json").exists()
+    assert (dest / "narration.json").exists(), "non-material files are not pruned"
+    assert "vlm_analysis.json" in restored["pruned_artifacts"]
+
+
+def test_material_files_do_not_include_api_key_string(tmp_path):
+    lib = tmp_path / "library"
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "understanding_index.json").write_text(json.dumps({"summary": "safe"}), encoding="utf-8")
+    materials.save_material(lib, work, tmp_path / "ep.mp4", "c" * 64, "settings")
+    all_text = "\n".join(p.read_text(encoding="utf-8") for p in lib.rglob("*.json"))
+    all_text += "\n" + "\n".join(p.read_text(encoding="utf-8") for p in lib.rglob("*.md"))
+    all_text += "\n" + (lib / "materials_index.jsonl").read_text(encoding="utf-8")
+    assert "tp-secret" not in all_text
+    assert "MIMO_API_KEY" not in all_text
+
+
+def test_allowed_artifacts_are_redacted_before_copy_and_restore(tmp_path):
+    lib = tmp_path / "library"
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "understanding_index.json").write_text(
+        json.dumps({"summary": "token tp-secret-value", "api_key": "tp-real-looking"}),
+        encoding="utf-8",
+    )
+    (work / "agent_narration_brief.md").write_text("MIMO_API_KEY=tp-another-secret", encoding="utf-8")
+    meta = materials.save_material(lib, work, tmp_path / "ep.mp4", "d" * 64, "settings")
+
+    persisted = "\n".join(p.read_text(encoding="utf-8") for p in (lib / "materials").rglob("*") if p.is_file())
+    assert "tp-secret-value" not in persisted
+    assert "tp-real-looking" not in persisted
+    assert "MIMO_API_KEY" not in persisted
+    assert "api_key" not in persisted.lower()
+
+    dest = tmp_path / "dest"
+    materials.restore_material(lib, dest, source_fingerprint="d" * 64, settings_fp="settings",
+                               material_id=meta["material_id"])
+    restored = (dest / "understanding_index.json").read_text(encoding="utf-8")
+    assert "tp-secret-value" not in restored
+    assert "redacted" in restored

--- a/tests/orchestrator/test_materials.py
+++ b/tests/orchestrator/test_materials.py
@@ -132,26 +132,69 @@ def test_material_files_do_not_include_api_key_string(tmp_path):
     assert "MIMO_API_KEY" not in all_text
 
 
-def test_allowed_artifacts_are_redacted_before_copy_and_restore(tmp_path):
+def test_allowed_artifacts_redact_secret_values_but_keep_legitimate_words(tmp_path):
+    """Redaction must remove credential VALUES while leaving ordinary analysis words
+    (secret/token/api_key as plain text, benign field names) intact — the library is a
+    faithful, reusable copy of the analysis, not a word-censored one."""
     lib = tmp_path / "library"
     work = tmp_path / "work"
     work.mkdir()
     (work / "understanding_index.json").write_text(
-        json.dumps({"summary": "token tp-secret-value", "api_key": "tp-real-looking"}),
+        json.dumps({
+            "summary": "主角发现了一个秘密 secret，一枚 token 在黑市流通",   # legit words -> must survive
+            "api_key": "tp-abcdef12345678",                                  # credential key -> value dropped
+            "token_economy": "影片解释 token 的发行机制",                     # benign name containing 'token' -> kept
+            "notes": "调试时漏了 key: sk-ABCDEFGHIJKLMNOP1234 和 tp-zzzzzzzz9999",  # value shapes -> redacted
+        }, ensure_ascii=False),
         encoding="utf-8",
     )
-    (work / "agent_narration_brief.md").write_text("MIMO_API_KEY=tp-another-secret", encoding="utf-8")
+    (work / "agent_narration_brief.md").write_text(
+        "MIMO_API_KEY=tp-another-secret-value\n剧情梗概：一个关于 secret 和 token 的故事", encoding="utf-8")
     meta = materials.save_material(lib, work, tmp_path / "ep.mp4", "d" * 64, "settings")
 
     persisted = "\n".join(p.read_text(encoding="utf-8") for p in (lib / "materials").rglob("*") if p.is_file())
-    assert "tp-secret-value" not in persisted
-    assert "tp-real-looking" not in persisted
-    assert "MIMO_API_KEY" not in persisted
-    assert "api_key" not in persisted.lower()
+    # secret VALUES are gone
+    for secret in ("tp-abcdef12345678", "sk-ABCDEFGHIJKLMNOP1234", "tp-zzzzzzzz9999", "tp-another-secret-value"):
+        assert secret not in persisted, secret
+    # legitimate words and benign field names PRESERVED (the over-redaction fix)
+    assert "主角发现了一个秘密" in persisted
+    assert "secret" in persisted and "token" in persisted
+    assert "token_economy" in persisted
+
+    idx = json.loads((lib / "materials" / meta["material_id"] / "artifacts" / "understanding_index.json")
+                     .read_text(encoding="utf-8"))
+    assert idx["api_key"] == "[redacted]"                 # value dropped, key name kept, not coalesced
+    assert "secret" in idx["summary"] and "token" in idx["summary"]
+    assert idx["token_economy"] == "影片解释 token 的发行机制"
 
     dest = tmp_path / "dest"
     materials.restore_material(lib, dest, source_fingerprint="d" * 64, settings_fp="settings",
                                material_id=meta["material_id"])
     restored = (dest / "understanding_index.json").read_text(encoding="utf-8")
-    assert "tp-secret-value" not in restored
-    assert "redacted" in restored
+    assert "tp-abcdef12345678" not in restored
+    assert "secret" in restored and "token" in restored
+
+
+def test_redact_json_keeps_distinct_secret_named_keys_without_coalescing(tmp_path):
+    """A dict with multiple credential-named keys must keep every key (each value dropped),
+    never collapse them into one 'redacted_key', and must not touch benign look-alike names."""
+    out = materials._redact_json({
+        "api_key": "tp-realvalue123456",
+        "access_token": "sk-ABCDEFGHIJKLMNOP1234",
+        "tokenized_scenes": ["镜头1", "镜头2"],   # benign name with 'token' substring -> untouched
+        "secrets_revealed": "结局揭晓的秘密",       # benign name with 'secret' substring -> untouched
+        "title": "ok",
+    })
+    assert out["api_key"] == "[redacted]"
+    assert out["access_token"] == "[redacted]"
+    assert "redacted_key" not in out                 # no coalescing
+    assert out["tokenized_scenes"] == ["镜头1", "镜头2"]
+    assert out["secrets_revealed"] == "结局揭晓的秘密"
+    assert out["title"] == "ok"
+
+
+def test_redact_text_leaves_plain_words_but_strips_token_shapes():
+    assert materials._redact_text("the secret garden hides a golden token") == \
+        "the secret garden hides a golden token"
+    assert "tp-" not in materials._redact_text("key is tp-abcdef12345678 ok")
+    assert "ghp_" not in materials._redact_text("token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")


### PR DESCRIPTION
## 原始需求

用户反馈当前 `video-recap` skill 只支持单视频剪辑，限制较大，并希望：

1. 支持输入多个视频，最终剪辑成一个视频。
2. 把每个视频解析/分析后的结果沉淀为素材库，后续可以复用已沉淀的视频素材。
3. 注意这是 **skill**，不是新工程项目；应优先利用文件系统能力。
4. 需求边界选定为 `fs-index-mvp`：用文件系统索引即可，检索支持 `grep` 就够。

## 需求注意点 / 边界

- 不引入数据库、embedding、向量检索或新依赖。
- 素材库只保存 grep-friendly 的 `JSON / Markdown / JSONL` 派生分析产物，不复制原始媒体文件。
- 多视频 MVP 仅支持 `--edit-mode cut`；单视频原有 `full / cut / dub` 行为保持兼容。
- 多源剪辑必须保留 `source_id` / `source_path` provenance，避免后续 assemble / inspect 丢失素材来源。
- 素材恢复需要防止旧 work dir 中残留 stale artifact，且不能把 secret-like 内容写入可复用素材。
- 本地 MiMo key 仅用于验证，写入被 git 忽略的 `.env`；PR 不包含密钥。

## 实现摘要

- `video-recap` 支持多个 positional video 输入，并生成项目级 `multi_source_manifest.json`。
- 新增文件系统素材库 helper：
  - `material.json` 作为权威元数据。
  - `materials_index.jsonl` 作为 append-only grep 索引。
  - 稳定 `material_id` / `source_id`，支持按 fingerprint 恢复。
  - 保存/恢复时对 key/token-like 内容做 redaction。
- `video-cut` 支持 `--sources-manifest`，按 source 校验 clip overlap，并用 multi-input ffmpeg concat 输出一个剪辑视频。
- `video-assemble` 和 `recap_inspect` 透出多源 provenance；缺失 source path 时显式标记 degraded provenance。
- `video-understanding` 新增 `--brief-only`，用于从已恢复 artifact 重新生成 brief/timeline，避免复用单视频 cut pass2 的 stale brief。
- 文档补充多视频和素材库用法、schema、grep 检索示例。
- `.gitignore` 增加 `.env` / `.env.*` 忽略并保留 `!.env.example`。

## 验证

- `python3 scripts/test.py` ✅
  - understanding: 133 passed
  - cut: 33 passed
  - voiceover: 45 passed
  - assemble: 148 passed
  - script: 67 passed
  - orchestrator: 78 passed
  - inspect: 24 passed
- `python3 -m ruff check .` ✅
- `python3 -m compileall -q skills tests scripts conftest.py` ✅
- `git diff --check` ✅
- MiMo live smoke ✅：Token Plan CN endpoint + `mimo-v2.5` 返回 1 个 choice 和 usage metadata（密钥未输出）。
- Secret safety ✅：`.env` 已被 git ignore；仓库扫描未发现本地 MiMo key 泄漏。
- Code review gate ✅：code-reviewer final recommendation `APPROVE`，architectural status `CLEAR`。

## 剩余风险

- 多视频目前只开放 `--edit-mode cut`，其他模式仍需后续设计。
- 素材库检索是 grep-only；没有语义检索、排序或 DB 能力。
- 大型真实用户素材的端到端多视频渲染未在 PR 内上传验证；自动化覆盖使用 fixture/mock。
- 下游工具必须继续尊重 `timeline_provenance.degraded`，避免把降级 provenance 当成完整素材映射。
