### PR TITLE
fix(multi-source): per-source snap + redaction/material-library hardening

### DIFF
--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -569,6 +569,64 @@ def snap_clips_off_shot_changes(plan, video, video_duration, margin, threshold, 
     return result
 
 
+def _load_silence_for_source(work_dir, source_id, source_work_dir=None):
+    """Read a source's silence_periods.json from the multi-source work layout (best-effort)."""
+    candidates = []
+    if source_work_dir:
+        candidates.append(Path(work_dir) / source_work_dir / "silence_periods.json")
+    candidates.append(Path(work_dir) / "sources" / str(source_id) / "silence_periods.json")
+    for path in candidates:
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                return []
+            return data if isinstance(data, list) else []
+    return []
+
+
+def snap_multi_source_clips(plan, sources, work_dir, *, line_max_extend, scene_margin,
+                            scene_threshold, do_line_snap=True, do_scene_snap=True):
+    """Per-source line/shot snapping for a multi-source validated plan.
+
+    Each clip is snapped using ITS OWN source's silence windows / shot changes and duration
+    (a clip in source B never constrains a clip in source A), then the global OUTPUT timeline
+    is recomputed once in plan order. Advisory: missing silence data or ffmpeg trouble leaves a
+    boundary unchanged. Mirrors the single-source snap_clip_ends_to_lines + snap_clips_off_shot_changes.
+    """
+    clips = plan.get("clips") or []
+    if not clips or not (do_line_snap or do_scene_snap):
+        return plan
+    allow_overlap = bool(plan.get("allow_overlap", False))
+    groups = {}
+    for clip in clips:
+        groups.setdefault(str(clip.get("source_id")), []).append(clip)
+    for sid, group in groups.items():
+        source = sources.get(sid, {}) if isinstance(sources, dict) else {}
+        duration = float(source.get("duration") or 0.0) or max(
+            (float(c["source_end"]) for c in group), default=0.0)
+        mini = {"clips": [dict(c) for c in group], "allow_overlap": allow_overlap}
+        if do_line_snap:
+            silence = _load_silence_for_source(work_dir, sid, source.get("source_work_dir"))
+            mini = snap_clip_ends_to_lines(mini, silence, duration, line_max_extend)
+        if do_scene_snap and source.get("source_path"):
+            mini = snap_clips_off_shot_changes(mini, source["source_path"], duration,
+                                               scene_margin, scene_threshold)
+        for original, snapped in zip(group, mini["clips"]):
+            original["source_start"] = snapped["source_start"]
+            original["source_end"] = snapped["source_end"]
+    # Recompute the global output timeline cursor-based, in plan order (not group order).
+    cursor = 0.0
+    for clip in clips:
+        duration = round(float(clip["source_end"]) - float(clip["source_start"]), 3)
+        clip["duration"] = duration
+        clip["output_start"] = round(cursor, 3)
+        clip["output_end"] = round(cursor + duration, 3)
+        cursor += duration
+    plan["total_duration"] = round(sum(c["duration"] for c in clips), 3)
+    return plan
+
+
 def source_time_to_output_time(source_time, clips):
     """Map a source timestamp into the post-concat output timeline."""
     ts = float(source_time)
@@ -937,6 +995,22 @@ def main():
             video_duration,
             CONFIG.get("scene_cut_snap_margin", 0.5),
             CONFIG.get("scene_cut_detect_threshold", 0.4),
+        )
+
+    # Multi-source: snap each clip against ITS OWN source's pauses/shot-changes (single-source
+    # snaps above can't, since silence_periods.json and args.video are per-project, not per-source).
+    if sources_manifest is not None and (
+        CONFIG.get("snap_clip_line_end", True) or CONFIG.get("scene_cut_snap", True)
+    ):
+        validated_plan = snap_multi_source_clips(
+            validated_plan,
+            validated_plan.get("sources", {}),
+            work_dir,
+            line_max_extend=CONFIG.get("clip_snap_max_extend", 2.0),
+            scene_margin=CONFIG.get("scene_cut_snap_margin", 0.5),
+            scene_threshold=CONFIG.get("scene_cut_detect_threshold", 0.4),
+            do_line_snap=CONFIG.get("snap_clip_line_end", True),
+            do_scene_snap=CONFIG.get("scene_cut_snap", True),
         )
 
     if isinstance(validated_plan, dict):

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -246,6 +246,8 @@ CLI 校验 `clip_plan.json` 后写出，额外包含输出时间轴：
 
 `materials_index.jsonl` 每次保存追加一行，字段包括 `schema_version`, `event`, `material_id`, `source_name`, `source_path`, `source_video_fingerprint`, `settings_fingerprint`, `summary`, `tags`, `material_dir`, `updated_at`。当前权威状态始终以 `materials/<material_id>/material.json` 为准。MVP 只承诺 `grep -R "关键词" <library>` 这类文件检索；没有 DB、embedding 或语义搜索。
 
+保存时会对凭证形态（`tp-`/`sk-`/`gh*_`/`AKIA`/JWT 与 `KEY=VALUE` 赋值）和凭证命名的 JSON key 做脱敏，但这只是**尽力而为**的兜底，不是保证：陌生格式的密钥仍可能漏过。请从源头避免把密钥写进分析产物——key 从环境变量/`.env` 读取，不需要落进 scenes/ASR/VLM/summary 等 JSON。
+
 ## narration_mapped.json
 
 仅 legacy direct `video-cut` 单 pass 路径会生成。orchestrated cut 模式不使用它：Agent 在 pass2 直接按剪后成片 OUTPUT 时间轴写 `narration.json`。当 legacy 路径启用时，`start/end` 已变成短视频输出时间，`source_start/source_end` 保留原视频时间：

--- a/skills/video-recap/scripts/materials.py
+++ b/skills/video-recap/scripts/materials.py
@@ -4,6 +4,14 @@ The library is intentionally grep-friendly: JSON/MD/JSONL files on disk, no DB,
 no embeddings, no raw-media copies. Current metadata lives in each material
 folder; the root ``materials_index.jsonl`` is an append-only journal for grep and
 history.
+
+Secret handling is BEST-EFFORT defense-in-depth, NOT a guarantee. ``_redact_text``
+masks common credential value shapes (``tp-``/``sk-``/``gh*_``/``AKIA``/JWT and
+``KEY=VALUE`` assignments) and ``_redact_json`` drops the value of exact
+credential-named keys, but a secret in an unrecognized format can still slip
+through. Keep secrets (API keys, tokens) out of the analysis artifacts in the
+first place — the key is read from the environment/``.env`` and never needs to be
+written into scenes/ASR/VLM/summary JSON.
 """
 from __future__ import annotations
 
@@ -259,8 +267,15 @@ def save_material(
     artifacts_dir.mkdir(parents=True, exist_ok=True)
     now = now or utc_now_iso()
 
+    sources = allowed_artifact_paths(work_dir)
+    fresh_names = {src.name for src in sources}
+    # Reconcile: drop allowed artifacts left from a previous (larger) save so the on-disk
+    # artifacts/ dir always matches material.json — a stale orphan must not surface in greps.
+    for stale in artifacts_dir.iterdir() if artifacts_dir.exists() else []:
+        if stale.is_file() and stale.name in ALLOWED_ARTIFACTS and stale.name not in fresh_names:
+            stale.unlink()
     copied = []
-    for src in allowed_artifact_paths(work_dir):
+    for src in sources:
         dst = artifacts_dir / src.name
         copy_artifact_redacted(src, dst)
         copied.append({"name": src.name, "path": f"artifacts/{src.name}", "sha256": file_fingerprint(dst)})
@@ -383,7 +398,13 @@ def restore_material(
 
         pruned = []
         if prune_stale_allowed:
+            staged_set = set(staged)
             for name in sorted(ALLOWED_ARTIFACTS):
+                # Never prune an artifact we are about to restore: the restore loop below
+                # honors `overwrite`, so pruning a staged name would (with overwrite=False)
+                # delete it and then skip the copy, losing the file.
+                if name in staged_set:
+                    continue
                 out = dest / name
                 if out.exists():
                     out.unlink()

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -672,3 +672,71 @@ def test_build_edited_source_video_multi_resolution_mixed_audio_real_render(tmp_
     dur = float(subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format=duration",
                                 "-of", "csv=p=0", str(out)], capture_output=True, text=True).stdout.strip())
     assert dur > 2.0, f"expected ~3s of concatenated clips, got {dur}s"
+
+
+def test_snap_multi_source_clips_line_snaps_each_clip_against_its_own_source(tmp_path):
+    """FF-D: each clip's end snaps to ITS OWN source's next pause (a clip in source B never
+    snaps to source A's silence), then the global output timeline is recomputed in plan order."""
+    import json as _json
+    work = tmp_path / "work"
+    (work / "sources" / "a").mkdir(parents=True)
+    (work / "sources" / "b").mkdir(parents=True)
+    (work / "sources" / "a" / "silence_periods.json").write_text(_json.dumps([{"start": 4.2, "end": 5.0}]), encoding="utf-8")
+    (work / "sources" / "b" / "silence_periods.json").write_text(_json.dumps([{"start": 9.0, "end": 9.5}]), encoding="utf-8")
+    plan = {
+        "allow_overlap": False,
+        "clips": [
+            {"clip_id": 0, "source_id": "a", "source_path": "/a.mp4", "source_start": 1.0, "source_end": 4.0,
+             "output_start": 0.0, "output_end": 3.0, "duration": 3.0},
+            {"clip_id": 1, "source_id": "b", "source_path": "/b.mp4", "source_start": 2.0, "source_end": 8.5,
+             "output_start": 3.0, "output_end": 9.5, "duration": 6.5},
+        ],
+        "total_duration": 9.5,
+    }
+    sources = {"a": {"source_path": "/a.mp4", "duration": 10.0}, "b": {"source_path": "/b.mp4", "duration": 12.0}}
+
+    out = cut.snap_multi_source_clips(plan, sources, work, line_max_extend=2.0,
+                                      scene_margin=0.5, scene_threshold=0.4, do_scene_snap=False)
+
+    assert out["clips"][0]["source_end"] == 4.2          # source a's pause
+    assert out["clips"][1]["source_end"] == 9.0          # source b's pause, NOT a's 4.2
+    assert out["clips"][0]["output_start"] == 0.0 and out["clips"][0]["output_end"] == 3.2
+    assert out["clips"][1]["output_start"] == 3.2 and out["clips"][1]["duration"] == 7.0
+    assert out["total_duration"] == 10.2
+
+
+def test_snap_multi_source_clips_routes_shot_detection_to_each_clips_source(monkeypatch, tmp_path):
+    """FF-D: shot-change detection runs against each clip's OWN source video, not one ambient file."""
+    seen = []
+    monkeypatch.setattr(cut, "_detect_shot_changes", lambda video, *a, **k: (seen.append(str(video)), [])[1])
+    plan = {
+        "allow_overlap": False,
+        "clips": [
+            {"clip_id": 0, "source_id": "a", "source_path": "/a.mp4", "source_start": 0.0, "source_end": 3.0,
+             "output_start": 0.0, "output_end": 3.0, "duration": 3.0},
+            {"clip_id": 1, "source_id": "b", "source_path": "/b.mp4", "source_start": 0.0, "source_end": 3.0,
+             "output_start": 3.0, "output_end": 6.0, "duration": 3.0},
+        ],
+        "total_duration": 6.0,
+    }
+    sources = {"a": {"source_path": "/a.mp4", "duration": 10.0}, "b": {"source_path": "/b.mp4", "duration": 10.0}}
+
+    cut.snap_multi_source_clips(plan, sources, tmp_path, line_max_extend=2.0,
+                                scene_margin=0.5, scene_threshold=0.4, do_line_snap=False)
+
+    assert "/a.mp4" in seen and "/b.mp4" in seen
+
+
+def test_snap_multi_source_clips_noops_without_silence_or_flags(tmp_path):
+    """No per-source silence data and scene-snap off -> boundaries unchanged (advisory degrade)."""
+    plan = {
+        "allow_overlap": False,
+        "clips": [{"clip_id": 0, "source_id": "a", "source_path": "/a.mp4", "source_start": 1.0,
+                   "source_end": 4.0, "output_start": 0.0, "output_end": 3.0, "duration": 3.0}],
+        "total_duration": 3.0,
+    }
+    out = cut.snap_multi_source_clips(plan, {"a": {"source_path": "/a.mp4", "duration": 10.0}}, tmp_path,
+                                      line_max_extend=2.0, scene_margin=0.5, scene_threshold=0.4,
+                                      do_scene_snap=False)
+    assert out["clips"][0]["source_end"] == 4.0
+    assert out["total_duration"] == 3.0

--- a/tests/orchestrator/test_materials.py
+++ b/tests/orchestrator/test_materials.py
@@ -198,3 +198,47 @@ def test_redact_text_leaves_plain_words_but_strips_token_shapes():
         "the secret garden hides a golden token"
     assert "tp-" not in materials._redact_text("key is tp-abcdef12345678 ok")
     assert "ghp_" not in materials._redact_text("token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
+
+
+def test_restore_overwrite_false_does_not_prune_then_lose_staged_file(tmp_path):
+    """FF-B: prune_stale_allowed + overwrite=False must NOT prune a staged file and then skip
+    restoring it. The staged file is preserved; only true (non-staged) stale orphans are pruned."""
+    lib = tmp_path / "library"
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "scenes.json").write_text(json.dumps([{"start": 0, "end": 1}]), encoding="utf-8")
+    meta = materials.save_material(lib, seed, tmp_path / "ep.mp4", "g" * 64, "settings")
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "scenes.json").write_text(json.dumps([{"keep": "existing"}]), encoding="utf-8")  # staged name, present
+    (dest / "vlm_analysis.json").write_text(json.dumps({"stale": 1}), encoding="utf-8")        # non-staged orphan
+
+    res = materials.restore_material(lib, dest, source_fingerprint="g" * 64, settings_fp="settings",
+                                     material_id=meta["material_id"], overwrite=False)
+
+    assert (dest / "scenes.json").exists(), "staged file must survive (not pruned-then-skipped)"
+    assert json.loads((dest / "scenes.json").read_text(encoding="utf-8")) == [{"keep": "existing"}]
+    assert not (dest / "vlm_analysis.json").exists(), "true stale orphan is pruned"
+    assert "vlm_analysis.json" in res["pruned_artifacts"]
+    assert "scenes.json" not in res["pruned_artifacts"]
+
+
+def test_save_material_reconciles_orphan_artifacts_on_resave(tmp_path):
+    """FF-C: re-saving with fewer artifacts removes the orphan from artifacts/ so the on-disk
+    set matches material.json (no stale blob lingering for greps)."""
+    lib = tmp_path / "library"
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "scenes.json").write_text("[]", encoding="utf-8")
+    (work / "asr_result.json").write_text(json.dumps([{"text": "hi"}]), encoding="utf-8")
+    meta = materials.save_material(lib, work, tmp_path / "ep.mp4", "h" * 64, "s")
+    adir = lib / "materials" / meta["material_id"] / "artifacts"
+    assert (adir / "asr_result.json").exists()
+
+    (work / "asr_result.json").unlink()  # a smaller / partial re-analysis
+    meta2 = materials.save_material(lib, work, tmp_path / "ep.mp4", "h" * 64, "s")
+
+    assert not (adir / "asr_result.json").exists(), "orphan artifact removed on re-save"
+    assert (adir / "scenes.json").exists()
+    assert {a["name"] for a in meta2["artifacts"]} == {"scenes.json"}


### PR DESCRIPTION
Fast-follow items from the PR #54 deep review that were intentionally deferred at the v0.3.3 release. No release/version change — code + tests + docs only.

### Changes
- **Per-source snap for multi-source cuts (`cut.py`).** New `snap_multi_source_clips`: each clip snaps to **its own source's** natural pauses (`sources/<id>/silence_periods.json`) and shot changes (its own source video), then the global output timeline is recomputed in plan order. Multi-source cuts previously skipped both snaps wholesale (single-source `silence_periods.json`/`args.video` don't apply per source), so edits could land mid-word or beside a hard cut. Advisory — degrades to no-op on missing silence data / ffmpeg trouble.
- **`restore_material` prune guard (`materials.py`).** `prune_stale_allowed=True` + `overwrite=False` no longer prunes a staged artifact and then skips restoring it (data-loss window). Staged names are preserved; only true non-staged stale orphans are pruned.
- **`save_material` orphan reconcile (`materials.py`).** A re-save with fewer artifacts removes the orphan from `artifacts/` so the on-disk set matches `material.json` (no stale blob surfacing in greps).
- **Redaction documented as best-effort (`materials.py` docstring + `data-schema.md`).** It masks common credential value shapes / credential-named keys but is defense-in-depth, not a guarantee — keep secrets out of analysis artifacts (key is read from env/`.env`).

### Tests
Per-source line-snap isolation (clip in source B never snaps to source A's silence) + shot-detection routing (each clip probed against its own video) + no-op degrade; restore `overwrite=False` guard; orphan reconcile. **Full per-skill suite passed; ruff + compileall clean.**

### Still open (lower priority)
Broaden under-redaction value-shape coverage further if real artifacts ever embed exotic key formats; otherwise this closes the review's deferred backlog.