### PR TITLE
Stabilize recap audio timing

### DIFF
--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -18,6 +18,7 @@ SUBTITLE_STYLE_REF_W = 1280
 SUBTITLE_STYLE_REF_H = 720
 _SUBTITLE_TERMINAL_PUNCTUATION = "。！？!?…."
 _SUBTITLE_CLOSING_QUOTES = "」』”’）)]】》〉\"'"
+_TRUNCATION_ELLIPSIS = "…"
 
 
 def _stable_json_dumps(value):
@@ -398,6 +399,7 @@ def assembly_settings_fingerprint(work_dir=None):
             "tail_pad_seconds": CONFIG.get("narration_tail_pad_seconds", 0.1),
             "fade_ms": CONFIG.get("fade_ms", 120),
             "narration_speed": CONFIG.get("narration_speed", 1.0),
+            "max_cumulative_narration_tempo": CONFIG.get("max_cumulative_narration_tempo", 1.35),
         },
         "audio_mix": {
             "ducking_mode": CONFIG.get("ducking_mode", "fixed"),
@@ -473,6 +475,78 @@ def _subtitle_chunk_weight(text):
     """Weight raw subtitle chunks for timing, independent of display punctuation cleanup."""
     core = re.sub(r"\s+", "", str(text or ""))
     return max(1, len(core))
+
+
+def _text_char_count(text):
+    """Count effective spoken chars, ignoring punctuation/whitespace."""
+    return len(re.sub(r'[，。！？、；：…“”‘’《》〈〉\s"\'「」『』（）()【】\[\]—～·,.!?;:\\-]', '', text or ""))
+
+
+def _truncate_at_sentence(text, max_chars):
+    """Sentence-boundary truncation using effective spoken characters."""
+    if _text_char_count(text) <= max_chars:
+        return text
+    eff = 0
+    cutoff = len(text)
+    for i, ch in enumerate(text):
+        eff += 1 if _text_char_count(ch) else 0
+        if eff > max_chars:
+            cutoff = i + 1
+            break
+    idx = max(text[:cutoff].rfind(sep) for sep in ['。', '！', '？', '!', '?'])
+    if idx > 0:
+        return text[:idx + 1]
+    idx = max(text[:cutoff].rfind(sep) for sep in ['，', '、', '；', ','])
+    if idx > 3:
+        return text[:idx] + '。'
+    return ""
+
+
+def _truncate_text_to_ratio(text, ratio):
+    """Return display/spoken text that fits the retained audio ratio.
+
+    Prefer a sentence/phrase boundary. If no boundary fits, shorten conservatively
+    and visibly mark the line as clipped so subtitles never show unspoken text as
+    if it were complete narration.
+    """
+    original = str(text or "").strip()
+    if not original:
+        return ""
+    ratio = max(0.0, min(1.0, float(ratio or 0.0)))
+    if ratio >= 0.995:
+        return original
+    budget = max(1, int(_text_char_count(original) * ratio))
+    boundary = _truncate_at_sentence(original, budget)
+    if boundary and boundary != original:
+        return boundary
+
+    eff = 0
+    cutoff = 0
+    for i, ch in enumerate(original):
+        eff += 1 if _text_char_count(ch) else 0
+        cutoff = i + 1
+        if eff >= budget:
+            break
+    shortened = original[:cutoff].rstrip(" \t\r\n，。！？、；：…,.!?;:")
+    if not shortened:
+        shortened = original[:max(1, cutoff)].strip()
+    return shortened.rstrip(_TRUNCATION_ELLIPSIS) + _TRUNCATION_ELLIPSIS
+
+
+def _mark_segment_truncated(seg, *, original_duration, played_duration, reason):
+    """Persist truncation metadata and align viewer-facing narration text."""
+    current_text = str(seg.get("narration") or "").strip()
+    original_text = str(seg.get("narration_original") or current_text).strip()
+    if original_text:
+        seg["narration_original"] = original_text
+    if current_text:
+        ratio = (float(played_duration) / float(original_duration)) if float(original_duration or 0) > 0 else 0.0
+        seg["narration"] = _truncate_text_to_ratio(current_text, ratio)
+    seg["truncated"] = True
+    seg["truncation_reason"] = str(reason)
+    seg["truncation_original_duration"] = float(original_duration or 0.0)
+    seg["truncation_played_duration"] = float(played_duration or 0.0)
+    seg["truncation_cut_duration"] = max(0.0, float(original_duration or 0.0) - float(played_duration or 0.0))
 
 
 def _subtitle_entry_chunks(raw_chunks):
@@ -578,6 +652,8 @@ def _subtitle_entries(narration):
         chunks = _subtitle_entry_chunks(_split_subtitle_chunks(text, max_chars))
         if not chunks:
             continue
+        if seg.get("truncated") and text.endswith(_TRUNCATION_ELLIPSIS):
+            chunks[-1]["text"] = chunks[-1]["text"].rstrip(_TRUNCATION_ELLIPSIS) + _TRUNCATION_ELLIPSIS
         if len(chunks) == 1:
             entries.append({"start": start, "end": end, "text": chunks[0]["text"]})
             continue
@@ -1154,19 +1230,80 @@ def _output_downscale_filter(max_h):
     return f"scale=-2:'2*trunc(min(ih,{max_h})/2)':flags=lanczos"
 
 
-def final_loudnorm_filter():
-    """Final-mix loudness normalization filter from CONFIG, or None when disabled.
+def _loudnorm_targets():
+    return {
+        "I": float(CONFIG.get("target_lufs", -14.0)),
+        "TP": float(CONFIG.get("target_true_peak", -1.0)),
+        "LRA": float(CONFIG.get("target_lra", 11.0)),
+    }
+
+
+def _loudnorm_base_filter():
+    targets = _loudnorm_targets()
+    return f"loudnorm=I={targets['I']}:TP={targets['TP']}:LRA={targets['LRA']}"
+
+
+def loudnorm_measure_filter():
+    """First-pass loudnorm measurement filter."""
+    if not CONFIG.get("final_loudnorm", True):
+        return None
+    return f"{_loudnorm_base_filter()}:print_format=json"
+
+
+def parse_loudnorm_stats(output_text):
+    """Parse ffmpeg loudnorm JSON from stdout/stderr and validate required fields."""
+    text = str(output_text or "")
+    required = ("input_i", "input_tp", "input_lra", "input_thresh", "target_offset")
+    matches = re.findall(r"\{[\s\S]*?\}", text)
+    for raw in reversed(matches):
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            continue
+        if not all(k in data for k in required):
+            continue
+        stats = {k: str(data[k]).strip() for k in required}
+        try:
+            for value in stats.values():
+                float(value)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(f"loudnorm 测量结果包含无效数值: {stats}") from exc
+        return stats
+    raise RuntimeError("无法解析 final loudnorm 一阶段测量 JSON，已中止以避免回退到动态单通道响度归一")
+
+
+def loudnorm_render_filter(stats):
+    """Second-pass linear loudnorm render filter with measured values injected."""
+    if not CONFIG.get("final_loudnorm", True):
+        return None
+    if not isinstance(stats, dict):
+        raise RuntimeError("final loudnorm 二阶段缺少一阶段测量数据")
+    required = ("input_i", "input_tp", "input_lra", "input_thresh", "target_offset")
+    missing = [k for k in required if k not in stats]
+    if missing:
+        raise RuntimeError(f"final loudnorm 二阶段缺少测量字段: {', '.join(missing)}")
+    return (
+        f"{_loudnorm_base_filter()}"
+        f":measured_I={stats['input_i']}"
+        f":measured_TP={stats['input_tp']}"
+        f":measured_LRA={stats['input_lra']}"
+        f":measured_thresh={stats['input_thresh']}"
+        f":offset={stats['target_offset']}"
+        ":linear=true"
+    )
+
+
+def final_loudnorm_filter(stats=None):
+    """Final-mix loudness normalization descriptor/render filter, or None when disabled.
 
     Ducking branches set only relative balance; this single stage owns the
     absolute output loudness so the recap is not left too quiet.
     """
     if not CONFIG.get("final_loudnorm", True):
         return None
-    return (
-        f"loudnorm=I={CONFIG.get('target_lufs', -14.0)}"
-        f":TP={CONFIG.get('target_true_peak', -1.0)}"
-        f":LRA={CONFIG.get('target_lra', 11.0)}"
-    )
+    if stats is not None:
+        return loudnorm_render_filter(stats)
+    return f"{_loudnorm_base_filter()}:linear=true"
 
 
 def _apply_narration_speed(tts_segments, work_dir):
@@ -1230,6 +1367,14 @@ def _seg_place_window(seg):
     return s, e
 
 
+def _per_segment_atempo_max(tts_rate_offset=0.0, narration_speed=None):
+    """Cap per-segment atempo so TTS rate × global speed × local atempo stays bounded."""
+    global_speed = float(narration_speed if narration_speed is not None else CONFIG.get("narration_speed", 1.0) or 1.0)
+    rate_multiplier = max(0.001, 1.0 + float(tts_rate_offset or 0.0))
+    tempo_ceiling = max(1.0, float(CONFIG.get("max_cumulative_narration_tempo", 1.35) or 1.35))
+    return max(1.0, tempo_ceiling / (max(0.001, global_speed) * rate_multiplier))
+
+
 def _amix_tail(narr_vol, bgm_chain=""):
     """Mix the prepared original track [orig] (+ optional BGM bed) with the boosted
     narration [narr] into [aout]. bgm_chain, when given, defines [bgm] from input [2:a]."""
@@ -1240,10 +1385,11 @@ def _amix_tail(narr_vol, bgm_chain=""):
 
 
 def _duck_ramp(s, e, fade):
-    """A 0→1 trapezoid over [s,e] with `fade`-second ramps at each edge (no clicks)."""
+    """A 0→1 trapezoid whose ramps sit outside [s,e] so narration is fully ducked inside."""
     if float(fade or 0) <= 0:
         return f"between(t,{s:.2f},{e:.2f})"
-    return f"min(1,max(0,min(t-{s:.2f},{e:.2f}-t)/{fade:.2f}))"
+    fade = float(fade)
+    return f"min(1,max(0,min(t-({s - fade:.2f}),({e + fade:.2f})-t)/{fade:.2f}))"
 
 
 def _placement_windows(tts_segments, level_for):
@@ -1385,6 +1531,46 @@ def _build_audio_filter_complex(
     return orig + _amix_tail(narr_vol, bgm_chain)
 
 
+def _filter_complex_args(filter_complex, work_dir, suffix=""):
+    """Return ffmpeg filter-complex args, spilling long graphs to a script file."""
+    filter_complex_bytes = filter_complex.encode("utf-8")
+    if len(filter_complex_bytes) <= 8000:
+        return ["-filter_complex", filter_complex], None, len(filter_complex_bytes)
+    fc_script = Path(work_dir) / f".filter_complex{suffix}.txt"
+    fc_script.write_text(filter_complex, encoding="utf-8")
+    log(f"使用 filter_complex_script (表达式长度 {len(filter_complex_bytes)} bytes)")
+    return ["-filter_complex_script", str(fc_script)], fc_script, len(filter_complex_bytes)
+
+
+def _measure_loudnorm(input_video, narration_wav, original_audio_input, bgm_input,
+                      filter_complex, work_dir, video_duration):
+    measure_filter = loudnorm_measure_filter()
+    if not measure_filter:
+        return None
+    measured_label = "[aoutln]"
+    measure_complex = f"{filter_complex};[aout]{measure_filter}{measured_label}"
+    fc_args, fc_script, _ = _filter_complex_args(measure_complex, work_dir, "_loudnorm_measure")
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", str(input_video),
+        "-i", str(narration_wav),
+        *original_audio_input,
+        *bgm_input,
+        *fc_args,
+        "-map", measured_label,
+        "-t", str(video_duration),
+        "-f", "null", "-",
+    ]
+    try:
+        result = run_cmd(cmd)
+        if result.returncode != 0:
+            raise RuntimeError(f"final loudnorm 一阶段测量失败: {result.stderr}")
+        return parse_loudnorm_stats(f"{result.stderr}\n{result.stdout}")
+    finally:
+        if fc_script:
+            fc_script.unlink(missing_ok=True)
+
+
 def assemble_video(input_video, tts_segments, work_dir, output_path):
     """组装最终视频"""
     if not tts_segments:
@@ -1438,43 +1624,31 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
         bgm_audio_label=bgm_audio_label,
     )
 
-    # 对于超长 volume 表达式（多段解说），使用 -filter_complex_script 避免命令行溢出
-    # 末端整体响度归一：ducking 只管相对平衡，这一步统一成片绝对响度
-    aout_label = "[aout]"
-    final_ln = final_loudnorm_filter()
-    if final_ln:
-        filter_complex += f";[aout]{final_ln}[aoutln]"
-        aout_label = "[aoutln]"
-        log(f"成片响度归一: {final_ln}")
-
     # BGM is input [2:a]; -stream_loop -1 loops it to cover the whole timeline (amix
     # duration=first + -t trim it back to the video length).
     bgm_input = ["-stream_loop", "-1", "-i", str(bgm_path)] if has_bgm else []
 
-    filter_complex_bytes = filter_complex.encode('utf-8')
-    if len(filter_complex_bytes) > 8000:
-        fc_script = Path(work_dir) / ".filter_complex.txt"
-        fc_script.write_text(filter_complex, encoding="utf-8")
-        log(f"使用 filter_complex_script (表达式长度 {len(filter_complex_bytes)} bytes)")
-        cmd = [
-            "ffmpeg", "-y",
-            "-i", str(input_video),
-            "-i", str(narration_wav),
-            *original_audio_input,
-            *bgm_input,
-            "-filter_complex_script", str(fc_script),
-            "-map", "0:v", "-map", aout_label,
-        ]
-    else:
-        cmd = [
-            "ffmpeg", "-y",
-            "-i", str(input_video),
-            "-i", str(narration_wav),
-            *original_audio_input,
-            *bgm_input,
-            "-filter_complex", filter_complex,
-            "-map", "0:v", "-map", aout_label,
-        ]
+    # 对于超长 volume 表达式（多段解说），使用 -filter_complex_script 避免命令行溢出
+    # 末端整体响度归一：先测量，再用 measured_* 线性二阶段渲染，避免动态单通道 pumping
+    aout_label = "[aout]"
+    if CONFIG.get("final_loudnorm", True):
+        stats = _measure_loudnorm(input_video, narration_wav, original_audio_input, bgm_input,
+                                  filter_complex, work_dir, video_duration)
+        final_ln = loudnorm_render_filter(stats)
+        filter_complex += f";[aout]{final_ln}[aoutln]"
+        aout_label = "[aoutln]"
+        log(f"成片响度归一（二阶段 linear）: {final_ln}")
+
+    fc_args, fc_script, _filter_complex_len = _filter_complex_args(filter_complex, work_dir)
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", str(input_video),
+        "-i", str(narration_wav),
+        *original_audio_input,
+        *bgm_input,
+        *fc_args,
+        "-map", "0:v", "-map", aout_label,
+    ]
 
     # Video filter chain: mask source subtitles first (drawbox), then burn our subtitles
     # on top. Either one forces a re-encode; with neither, the video stream is copied.
@@ -1521,25 +1695,37 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             raise RuntimeError(f"视频组装失败: {result.stderr}")
     finally:
         # 清理临时 filter_complex 脚本（无论 ffmpeg 是否成功）
-        if len(filter_complex_bytes) > 8000:
+        if fc_script:
             fc_script.unlink(missing_ok=True)
 
     log(f"最终视频: {output_path} ({output_path.stat().st_size / 1024 / 1024:.1f}MB)")
     return output_path
 
 
-def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0):
+def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0, return_metadata=False):
     """如果 TTS 音频超过目标时长，用 ffmpeg atempo 温和加速"""
     audio_path = Path(audio_path)
     current_dur = get_video_duration(audio_path)
+    meta = {
+        "action": "unchanged",
+        "original_duration": current_dur,
+        "target_duration": target_duration,
+        "tts_rate_offset": float(tts_rate_offset or 0.0),
+        "effective_atempo_max": _per_segment_atempo_max(tts_rate_offset),
+    }
+
+    def _ret(path, duration, metadata=None):
+        data = meta if metadata is None else metadata
+        return (str(path), duration, data) if return_metadata else (str(path), duration)
+
     if current_dur <= target_duration or current_dur == 0:
-        return str(audio_path), current_dur
+        return _ret(audio_path, current_dur)
 
     ratio = current_dur / target_duration
 
-    # 累积上限：TTS rate × atempo ≤ 1.2x
-    effective_max = 1.2 / (1.0 + tts_rate_offset)
-    effective_max = max(1.0, effective_max)
+    # 累积上限：TTS rate × 全局 narration_speed × 分段 atempo ≤ max_cumulative_narration_tempo
+    effective_max = _per_segment_atempo_max(tts_rate_offset)
+    meta["effective_atempo_max"] = effective_max
 
     if ratio > effective_max:
         # 实际截断到目标时长，加 fade-out 防止爆音
@@ -1553,9 +1739,17 @@ def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0
         if result.returncode == 0:
             new_dur = get_video_duration(truncated_path)
             log(f"  TTS 截断: {current_dur:.1f}s → {new_dur:.1f}s (无法加速到 x{ratio:.2f})")
-            return str(truncated_path), new_dur
+            meta.update({
+                "action": "truncated",
+                "ratio": ratio,
+                "played_duration": new_dur,
+                "cut_duration": max(0.0, current_dur - new_dur),
+                "reason": "exceeds_cumulative_tempo_ceiling",
+            })
+            return _ret(truncated_path, new_dur, meta)
         log(f"  警告: TTS 截断失败，保留原音频 ({current_dur:.1f}s)")
-        return str(audio_path), current_dur
+        meta.update({"action": "truncate_failed", "ratio": ratio, "reason": "ffmpeg_truncate_failed"})
+        return _ret(audio_path, current_dur, meta)
 
     # 温和加速
     tempo = min(ratio, effective_max)
@@ -1567,8 +1761,15 @@ def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0
     if result.returncode == 0:
         new_dur = get_video_duration(adjusted_path)
         log(f"  TTS 温和加速: {current_dur:.1f}s → {new_dur:.1f}s (x{tempo:.2f})")
-        return str(adjusted_path), new_dur
-    return str(audio_path), current_dur
+        meta.update({
+            "action": "speed_adjusted",
+            "ratio": ratio,
+            "tempo": tempo,
+            "played_duration": new_dur,
+        })
+        return _ret(adjusted_path, new_dur, meta)
+    meta.update({"action": "speed_adjust_failed", "ratio": ratio, "tempo": tempo})
+    return _ret(audio_path, current_dur, meta)
 
 
 def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
@@ -1655,10 +1856,20 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         # 根据实际可用空间决定是否加速
         available_samples = end_boundary - actual_start
         available_duration = max(available_samples / sample_rate, 0)
+        adjust_meta = None
         if tts_dur > available_duration > 0:
-            wav_path, _actual_dur = _adjust_tts_speed(wav_path, available_duration, work_dir, tts_rate_offset)
-        else:
-            pass  # tts_dur <= available_duration, no speed adjust needed
+            wav_path, _actual_dur, adjust_meta = _adjust_tts_speed(
+                wav_path, available_duration, work_dir, tts_rate_offset, return_metadata=True)
+            if wav_path != original_wav_path:
+                seg["audio_path"] = wav_path
+                seg["audio_duration"] = _actual_dur
+            if adjust_meta and adjust_meta.get("action") == "truncated":
+                _mark_segment_truncated(
+                    seg,
+                    original_duration=adjust_meta.get("original_duration", tts_dur),
+                    played_duration=adjust_meta.get("played_duration", _actual_dur),
+                    reason=adjust_meta.get("reason", "exceeds_cumulative_tempo_ceiling"),
+                )
 
         # _adjust_tts_speed 输出固定 44100Hz mono 16bit，若文件被替换则无需 resample
         if wav_path != original_wav_path:
@@ -1684,6 +1895,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         audio_samples = len(wf_data) // 2
         available = end_boundary - actual_start
         write_samples = min(audio_samples, max(available, 0))
+        pre_boundary_audio_samples = audio_samples
 
         if write_samples <= 0:
             log(f"  跳过: {seg['start']:.1f}s-{seg['end']:.1f}s (无空间)")
@@ -1694,6 +1906,13 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
 
         # 裁剪到写入长度
         wf_data = wf_data[:write_samples * 2]
+        if write_samples < pre_boundary_audio_samples:
+            _mark_segment_truncated(
+                seg,
+                original_duration=pre_boundary_audio_samples / sample_rate,
+                played_duration=write_samples / sample_rate,
+                reason="placement_window_cut",
+            )
 
         # 重叠检测：跳过与前段重叠的部分（在 fade 之前，避免截断后丢失 fade-in）
         if actual_start < last_written_end:
@@ -1707,9 +1926,16 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
                 continue
             log(f"  重叠 {overlap_ms:.0f}ms，截断前部")
             skip_samples = last_written_end - actual_start
+            original_overlap_samples = write_samples
             wf_data = wf_data[skip_samples * 2:]
             write_samples -= skip_samples
             actual_start = last_written_end
+            _mark_segment_truncated(
+                seg,
+                original_duration=original_overlap_samples / sample_rate,
+                played_duration=write_samples / sample_rate,
+                reason="placement_overlap_cut",
+            )
 
         # fade-in / fade-out（在 overlap 裁剪之后应用，确保正确的音频包络）
         fade_len = min(int(CONFIG.get("fade_ms", 300) * sample_rate / 1000), write_samples // 4)

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -231,7 +231,8 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认降到安全区间；长片可设 1.0
+    "max_cumulative_narration_tempo": env_float("MAX_CUMULATIVE_NARRATION_TEMPO", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 分段 atempo 的默认累积上限
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说（仅用于段落起点）

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -219,7 +219,8 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认降到安全区间；长片可设 1.0
+    "max_cumulative_narration_tempo": env_float("MAX_CUMULATIVE_NARRATION_TEMPO", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 分段 atempo 的默认累积上限
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -229,7 +229,8 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认降到安全区间；长片可设 1.0
+    "max_cumulative_narration_tempo": env_float("MAX_CUMULATIVE_NARRATION_TEMPO", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 分段 atempo 的默认累积上限
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -235,7 +235,8 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认降到安全区间；长片可设 1.0
+    "max_cumulative_narration_tempo": env_float("MAX_CUMULATIVE_NARRATION_TEMPO", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 分段 atempo 的默认累积上限
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -229,7 +229,8 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认降到安全区间；长片可设 1.0
+    "max_cumulative_narration_tempo": env_float("MAX_CUMULATIVE_NARRATION_TEMPO", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 分段 atempo 的默认累积上限
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说

--- a/skills/video-voiceover/scripts/voiceover.py
+++ b/skills/video-voiceover/scripts/voiceover.py
@@ -22,6 +22,21 @@ def _parse_rate_offset(rate_str):
     return 0.0
 
 
+def _per_segment_atempo_max(tts_rate_offset=0.0, narration_speed=None):
+    """Cap assembly-time local atempo under the cumulative tempo ceiling."""
+    global_speed = float(narration_speed if narration_speed is not None else CONFIG.get("narration_speed", 1.0) or 1.0)
+    rate_multiplier = max(0.001, 1.0 + float(tts_rate_offset or 0.0))
+    tempo_ceiling = max(1.0, float(CONFIG.get("max_cumulative_narration_tempo", 1.35) or 1.35))
+    return max(1.0, tempo_ceiling / (max(0.001, global_speed) * rate_multiplier))
+
+
+def _raw_duration_budget(available_duration, tts_rate_offset=0.0):
+    """Raw synthesized-audio duration allowed before assemble must cut."""
+    narration_speed = float(CONFIG.get("narration_speed", 1.0) or 1.0)
+    return float(available_duration) * narration_speed * _per_segment_atempo_max(
+        tts_rate_offset, narration_speed)
+
+
 def _compute_tts_params(text, narration, seg_index):
     """根据内容特征和位置计算 TTS 语速/音高参数"""
     rate = "+5%"
@@ -85,6 +100,7 @@ def _synthesize_segment(i, seg, narration, tts_dir, engine):
     if prepared is None:
         return None
     text, output_wav, rate, pitch, cache_key = prepared
+    source_text = text
     cached = _reuse_tts_segment_cache(i, seg, output_wav, text, rate, cache_key)
     if cached:
         return cached
@@ -98,8 +114,8 @@ def _synthesize_segment(i, seg, narration, tts_dir, engine):
     # assemble speeds every segment up by narration_speed (global atempo) BEFORE placement, so the
     # slot actually holds raw_dur / narration_speed; fold that in (plus the local per-segment adjust
     # headroom atempo_max) or a 1.3x-authored BLOCK gets needlessly truncated into a clipped fragment.
-    narration_speed = float(CONFIG.get("narration_speed", 1.0) or 1.0)
-    raw_budget = available * narration_speed * 1.2
+    rate_offset = _parse_rate_offset(rate)
+    raw_budget = _raw_duration_budget(available, rate_offset)
     if dur > raw_budget and len(text) > 5:
         chars_per_sec = len(text) / dur if dur > 0 else 3.0
         target_chars = max(5, int(raw_budget * chars_per_sec) - 1)
@@ -110,11 +126,15 @@ def _synthesize_segment(i, seg, narration, tts_dir, engine):
             _run_tts_engine(engine, text, output_wav, rate=rate, pitch=pitch, emotion=seg.get("emotion"))
             dur = _get_audio_duration(output_wav)
 
-    _write_tts_segment_cache(output_wav, cache_key, text, dur, _parse_rate_offset(rate))
-    return _build_tts_segment_result(i, seg, text, output_wav, dur, _parse_rate_offset(rate))
+    _write_tts_segment_cache(output_wav, cache_key, text, dur, rate_offset)
+    return _build_tts_segment_result(
+        i, seg, text, output_wav, dur, rate_offset, source_text=source_text,
+        truncation_reason="voiceover_precheck_text_budget",
+    )
 
 
-def _build_tts_segment_result(index, seg, text, output_wav, duration, rate_offset):
+def _build_tts_segment_result(index, seg, text, output_wav, duration, rate_offset,
+                              source_text=None, truncation_reason=None):
     result = {
         "index": index,
         "start": seg["start"],
@@ -126,6 +146,10 @@ def _build_tts_segment_result(index, seg, text, output_wav, duration, rate_offse
         "pause_after_ms": seg.get("pause_after_ms", CONFIG.get("breath_ms", 250)),
         "overlaps_speech": seg.get("overlaps_speech", True),
     }
+    if source_text and str(source_text).strip() != str(text).strip():
+        result["narration_original"] = str(source_text).strip()
+        result["truncated"] = True
+        result["truncation_reason"] = truncation_reason or "voiceover_text_budget"
     for optional_key in ("source_start", "source_end", "source_clip_id", "emotion"):
         if optional_key in seg:
             result[optional_key] = seg[optional_key]
@@ -305,7 +329,10 @@ def _reuse_tts_segment_cache(index, seg, output_wav, source_text, rate, cache_ke
     spoken_text = str(cached.get("spoken_text") or source_text)
     rate_offset = float(cached.get("tts_rate_offset", _parse_rate_offset(rate)) or 0.0)
     log(f"  段 {index+1}: 复用已有 ({existing_dur:.1f}s)")
-    return _build_tts_segment_result(index, seg, spoken_text, output_wav, existing_dur, rate_offset)
+    return _build_tts_segment_result(
+        index, seg, spoken_text, output_wav, existing_dur, rate_offset,
+        source_text=source_text, truncation_reason="cached_voiceover_text_budget",
+    )
 
 
 def _tts_segment_cache_key(engine, index, seg, source_text, rate, pitch):
@@ -405,6 +432,8 @@ def tts_settings_fingerprint(engine=None):
         "mimo_tts_voice": CONFIG.get("mimo_tts_voice"),
         "mimo_tts_style": CONFIG.get("mimo_tts_style"),
         "narration_speed": float(CONFIG.get("narration_speed", 1.0) or 1.0),
+        "max_cumulative_narration_tempo": float(
+            CONFIG.get("max_cumulative_narration_tempo", 1.35) or 1.35),
     }
 
 

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -4,8 +4,42 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-a
 import json
 import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
-from assemble import _wrap_subtitle_text, _split_subtitle_chunks, _subtitle_entries, _adjust_tts_speed, _apply_narration_speed, _assembly_manifest_payload, _build_audio_filter_complex, _build_timed_narration, _build_video_clips, _emit_timeline, _resolve_final_output, _value_fingerprint, _escape_ass_text, _generate_ass, _generate_srt, _seconds_to_ass_time, _seconds_to_srt_time, _source_subtitle_mask_filter, _subtitle_burn_filter, _output_downscale_filter, assemble_video, assembly_settings_fingerprint, final_loudnorm_filter
+from assemble import (
+    _adjust_tts_speed,
+    _apply_narration_speed,
+    _assembly_manifest_payload,
+    _build_audio_filter_complex,
+    _build_timed_narration,
+    _build_video_clips,
+    _duck_ramp,
+    _emit_timeline,
+    _escape_ass_text,
+    _generate_ass,
+    _generate_srt,
+    _output_downscale_filter,
+    _per_segment_atempo_max,
+    _resolve_final_output,
+    _seconds_to_ass_time,
+    _seconds_to_srt_time,
+    _source_subtitle_mask_filter,
+    _split_subtitle_chunks,
+    _subtitle_burn_filter,
+    _subtitle_entries,
+    _value_fingerprint,
+    _wrap_subtitle_text,
+    assemble_video,
+    assembly_settings_fingerprint,
+    final_loudnorm_filter,
+    loudnorm_measure_filter,
+    loudnorm_render_filter,
+    parse_loudnorm_stats,
+)
 from lib import CONFIG
+
+
+def test_audio_tempo_defaults_are_safe():
+    assert CONFIG["narration_speed"] == pytest.approx(1.15)
+    assert CONFIG["max_cumulative_narration_tempo"] == pytest.approx(1.35)
 
 
 def test_adjust_tts_speed_derives_outputs_from_audio_name_only(monkeypatch, tmp_path):
@@ -51,6 +85,34 @@ def test_adjust_tts_speed_truncation_keeps_output_next_to_audio(monkeypatch, tmp
     assert actual_dur == 1.0
     assert Path(adjusted) == wav_parent / "narr_000_cut.wav"
     assert commands[-1][-1] == str(wav_parent / "narr_000_cut.wav")
+
+
+def test_adjust_tts_speed_uses_cumulative_aware_segment_cap(monkeypatch, tmp_path):
+    wav_parent = tmp_path / "episode.wav-cache"
+    wav_parent.mkdir()
+    src = wav_parent / "narr_000.wav"
+    src.write_bytes(b"wav")
+    commands = []
+
+    def fake_run_cmd(cmd, **kw):
+        commands.append(cmd)
+        Path(cmd[-1]).write_bytes(b"cut")
+        return CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.15)
+    monkeypatch.setitem(CONFIG, "max_cumulative_narration_tempo", 1.35)
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 2.26 if Path(path) == src else 2.0)
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    assert _per_segment_atempo_max(0.05) == pytest.approx(1.35 / (1.15 * 1.05))
+    adjusted, actual_dur, meta = _adjust_tts_speed(
+        src, target_duration=2.0, work_dir=tmp_path, tts_rate_offset=0.05, return_metadata=True)
+
+    assert actual_dur == 2.0
+    assert Path(adjusted) == wav_parent / "narr_000_cut.wav"
+    assert meta["action"] == "truncated"
+    assert commands[-1][-1] == str(wav_parent / "narr_000_cut.wav")
+    assert not any("atempo=" in " ".join(c) for c in commands)
 
 
 def test_build_video_clips_prefers_fingerprint_matched_validated_cut_plan(monkeypatch, tmp_path):
@@ -360,6 +422,122 @@ def test_build_timed_narration_clamps_delay_to_slot(monkeypatch, tmp_path):
     assert segment["actual_place_end"] == pytest.approx(0.9, abs=0.02)
 
 
+def test_build_timed_narration_truncation_aligns_subtitle_text(monkeypatch, tmp_path):
+    import wave
+
+    wav = tmp_path / "long.wav"
+    sample_rate = 44100
+    sample_count = int(sample_rate * 2.0)
+    with wave.open(str(wav), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\0\0" * sample_count)
+
+    original = "第一句。第二句不会被说出。"
+    segment = {
+        "index": 0,
+        "start": 0.0,
+        "end": 1.0,
+        "narration": original,
+        "audio_path": str(wav),
+        "audio_duration": 0.5,  # stale/too-small metadata must not hide the actual WAV cut
+        "pause_after_ms": 0,
+    }
+    monkeypatch.setitem(CONFIG, "narration_delay_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tail_pad_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "fade_ms", 0)
+
+    _build_timed_narration([segment], tmp_path / "out.wav", 2.0, tmp_path)
+
+    assert segment["truncated"] is True
+    assert segment["narration_original"] == original
+    assert segment["truncation_reason"] == "placement_window_cut"
+    assert "第二句" not in segment["narration"]
+    assert segment["narration"]
+    entries = _subtitle_entries([segment])
+    rendered_text = "".join(e["text"] for e in entries)
+    assert "第二句" not in rendered_text
+    assert original not in rendered_text
+
+
+def test_build_timed_narration_retruncates_current_spoken_text_only(monkeypatch, tmp_path):
+    import wave
+
+    wav = tmp_path / "pretrimmed.wav"
+    sample_rate = 44100
+    with wave.open(str(wav), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\0\0" * int(sample_rate * 2.0))
+
+    original = "第一句。第二句。第三句不会被说出。"
+    current_spoken = "第一句。第二句。"
+    segment = {
+        "index": 0,
+        "start": 0.0,
+        "end": 1.0,
+        "narration": current_spoken,
+        "narration_original": original,
+        "truncated": True,
+        "truncation_reason": "voiceover_precheck_text_budget",
+        "audio_path": str(wav),
+        "audio_duration": 0.5,
+        "pause_after_ms": 0,
+    }
+    monkeypatch.setitem(CONFIG, "narration_delay_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tail_pad_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "fade_ms", 0)
+
+    _build_timed_narration([segment], tmp_path / "out.wav", 2.0, tmp_path)
+
+    assert segment["truncated"] is True
+    assert segment["narration_original"] == original
+    assert segment["truncation_reason"] == "placement_window_cut"
+    assert segment["truncation_played_duration"] == pytest.approx(1.0)
+    assert "第二句" not in segment["narration"]
+    assert "第三句" not in segment["narration"]
+    rendered_text = "".join(e["text"] for e in _subtitle_entries([segment]))
+    assert "第二句" not in rendered_text
+    assert "第三句" not in rendered_text
+
+
+def test_build_timed_narration_truncation_fallback_marks_no_boundary_text(monkeypatch, tmp_path):
+    import wave
+
+    wav = tmp_path / "long_no_boundary.wav"
+    sample_rate = 44100
+    with wave.open(str(wav), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\0\0" * int(sample_rate * 2.0))
+
+    original = "没有句子边界的超长解说文本"
+    segment = {
+        "index": 0,
+        "start": 0.0,
+        "end": 0.6,
+        "narration": original,
+        "audio_path": str(wav),
+        "audio_duration": 0.5,
+        "pause_after_ms": 0,
+    }
+    monkeypatch.setitem(CONFIG, "narration_delay_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tail_pad_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "fade_ms", 0)
+
+    _build_timed_narration([segment], tmp_path / "out.wav", 2.0, tmp_path)
+
+    assert segment["truncated"] is True
+    assert segment["narration_original"] == original
+    assert segment["narration"].endswith("…")
+    assert segment["narration"] != original
+    entries = _subtitle_entries([segment])
+    assert "".join(e["text"] for e in entries).endswith("…")
+
+
 def test_subtitle_burn_filter_escapes_path():
     path = Path("/tmp/video recap/a:b,c[1].ass")
     filt = _subtitle_burn_filter(path)
@@ -383,6 +561,7 @@ def test_assemble_video_burns_ass_subtitles(monkeypatch, tmp_path):
 
     monkeypatch.setitem(CONFIG, "burn_subtitles", True)
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)  # isolate burn behavior from the mask default
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
     monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
     monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
@@ -451,6 +630,7 @@ def test_assemble_video_without_burn_keeps_video_copy(monkeypatch, tmp_path):
     monkeypatch.setitem(CONFIG, "burn_subtitles", False)
     monkeypatch.setitem(CONFIG, "force_video_reencode", False)
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)  # nothing should force a re-encode here
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
     monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
     monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
@@ -485,6 +665,7 @@ def test_assemble_video_no_burn_ignores_source_mask_default(monkeypatch, tmp_pat
 
     monkeypatch.setitem(CONFIG, "burn_subtitles", False)
     monkeypatch.setitem(CONFIG, "force_video_reencode", False)
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
     # mask_source_subtitles left at its default (True) on purpose
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
     monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
@@ -518,8 +699,8 @@ def test_build_audio_filter_complex_gap_fill_envelope(monkeypatch):
     ])
     assert "volume='max(0,min(1,0.85" in fc          # idle baseline holds the original up in the gaps
     assert "eval=frame" in fc
-    assert "min(t-0.00,2.00-t)/0.25" in fc            # faded duck under the dialogue-overlap beat
-    assert "min(t-5.00,7.00-t)/0.25" in fc            # faded duck under the quiet-window beat
+    assert "min(t-(-0.25),(2.25)-t)/0.25" in fc       # ramp starts before the audible dialogue-overlap beat
+    assert "min(t-(4.75),(7.25)-t)/0.25" in fc        # ramp ends after the audible quiet-window beat
     assert "(-0.650)" in fc                           # 0.85 -> 0.20 under dialogue
     assert "(-0.730)" in fc                           # 0.85 -> 0.12 in quiet window
     assert fc.endswith("[aout]")
@@ -537,7 +718,7 @@ def test_build_audio_filter_complex_all_overlap_still_fills_gaps(monkeypatch):
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
     ])
     assert "volume='max(0,min(1,0.85" in fc           # NOT a constant; idle baseline present
-    assert "min(t-0.00,2.00-t)/0.25" in fc            # ducks only under the narration window
+    assert "min(t-(-0.25),(2.25)-t)/0.25" in fc       # ducks fully inside the narration window
     assert "eval=frame" in fc
     assert fc.endswith("[aout]")
 
@@ -554,9 +735,9 @@ def test_build_audio_filter_complex_bridges_short_gaps(monkeypatch):
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
         {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": True},  # gap 2.0 < 6.0
     ])
-    assert "min(t-0.00,6.00-t)/0.25" in fc            # one held duck across both beats + the gap
-    assert "min(t-0.00,2.00-t)" not in fc             # NOT two separate dips
-    assert "min(t-4.00,6.00-t)" not in fc
+    assert "min(t-(-0.25),(6.25)-t)/0.25" in fc       # one held duck across both beats + the gap
+    assert "min(t-(-0.25),(2.25)-t)" not in fc        # NOT two separate dips
+    assert "min(t-(3.75),(6.25)-t)" not in fc
     assert fc.count("(-0.650)") == 1                  # a single coalesced duck term
 
 
@@ -572,8 +753,8 @@ def test_build_audio_filter_complex_releases_long_gaps(monkeypatch):
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
         {"actual_place_start": 10.0, "actual_place_end": 12.0, "overlaps_speech": True},  # gap 8.0 >= 6.0
     ])
-    assert "min(t-0.00,2.00-t)/0.25" in fc            # two separate dips with idle between
-    assert "min(t-10.00,12.00-t)/0.25" in fc
+    assert "min(t-(-0.25),(2.25)-t)/0.25" in fc       # two separate dips with idle between
+    assert "min(t-(9.75),(12.25)-t)/0.25" in fc
     assert fc.count("(-0.650)") == 2
 
 
@@ -592,8 +773,8 @@ def test_build_audio_filter_complex_original_blocks_play_full_volume(monkeypatch
     ])
     assert "volume='max(0,min(1,1.0" in fc            # full-volume original baseline (was 0.85)
     assert fc.count("(-0.800)") == 2                  # 1.0 -> 0.2 under each block, two separate dips
-    assert "min(t-0.00,8.00-t)/0.3" in fc            # first block ducks, then releases to full
-    assert "min(t-14.00,22.00-t)/0.3" in fc          # second block ducks; the 6s gap stays full between
+    assert "min(t-(-0.30),(8.30)-t)/0.30" in fc      # first block ducks, then releases to full
+    assert "min(t-(13.70),(22.30)-t)/0.30" in fc     # second block ducks; the 6s gap stays full between
 
 
 def test_build_audio_filter_complex_bridged_mixed_levels_flatten_to_min(monkeypatch):
@@ -609,7 +790,7 @@ def test_build_audio_filter_complex_bridged_mixed_levels_flatten_to_min(monkeypa
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},   # 0.2
         {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": False},  # 0.12, gap 2 < 6
     ])
-    assert "min(t-0.00,6.00-t)/0.25" in fc            # one coalesced span across both beats
+    assert "min(t-(-0.25),(6.25)-t)/0.25" in fc       # one coalesced span across both beats
     assert "(-0.730)" in fc                           # held at the MIN level (0.12)
     assert "(-0.650)" not in fc                       # NOT the speech level (0.2)
 
@@ -626,8 +807,8 @@ def test_build_audio_filter_complex_bgm_envelope_bridges_short_gaps(monkeypatch)
         {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": True},  # gap 2 < 6
     ], has_bgm=True)
     bgm_part = fc.split("[bgm]")[0]                    # the bgm chain comes first
-    assert "min(t-0.00,6.00-t)/0.25" in bgm_part      # one coalesced BGM dip across both beats
-    assert "min(t-0.00,2.00-t)" not in bgm_part
+    assert "min(t-(-0.25),(6.25)-t)/0.25" in bgm_part # one coalesced BGM dip across both beats
+    assert "min(t-(-0.25),(2.25)-t)" not in bgm_part
 
 
 def test_build_audio_filter_complex_all_quiet_ducks_to_zone(monkeypatch):
@@ -638,7 +819,7 @@ def test_build_audio_filter_complex_all_quiet_ducks_to_zone(monkeypatch):
     fc = _build_audio_filter_complex([
         {"actual_place_start": 1.0, "actual_place_end": 4.0, "overlaps_speech": False},
     ])
-    assert "min(t-1.00,4.00-t)/0.25" in fc            # smooth fade
+    assert "min(t-(0.75),(4.25)-t)/0.25" in fc        # smooth fade outside the audible window
     assert "(-0.730)" in fc                           # 0.85 -> 0.12
     assert "eval=frame" in fc
 
@@ -670,6 +851,11 @@ def test_build_audio_filter_complex_explicit_modes(monkeypatch):
     assert "sidechaincompress" in _build_audio_filter_complex(segs)
 
 
+def test_duck_ramp_fades_outside_audible_window():
+    assert _duck_ramp(1.0, 3.0, 0.5) == "min(1,max(0,min(t-(0.50),(3.50)-t)/0.50))"
+    assert _duck_ramp(1.0, 3.0, 0) == "between(t,1.00,3.00)"
+
+
 def test_assembly_settings_fingerprint_tracks_burn_style(monkeypatch):
     monkeypatch.setitem(CONFIG, "burn_subtitles", False)
     plain = assembly_settings_fingerprint()
@@ -689,15 +875,85 @@ def test_final_loudnorm_filter_and_fingerprint(monkeypatch):
     monkeypatch.setitem(CONFIG, "target_lufs", -14.0)
     monkeypatch.setitem(CONFIG, "target_true_peak", -1.0)
     monkeypatch.setitem(CONFIG, "target_lra", 11.0)
-    assert final_loudnorm_filter() == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0"
-    assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0"
+    assert loudnorm_measure_filter() == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0:print_format=json"
+    assert final_loudnorm_filter() == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0:linear=true"
+    assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0:linear=true"
 
     monkeypatch.setitem(CONFIG, "target_lufs", -11.9)
-    assert final_loudnorm_filter() == "loudnorm=I=-11.9:TP=-1.0:LRA=11.0"
+    assert final_loudnorm_filter() == "loudnorm=I=-11.9:TP=-1.0:LRA=11.0:linear=true"
 
     monkeypatch.setitem(CONFIG, "final_loudnorm", False)
     assert final_loudnorm_filter() is None
     assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "off"
+
+
+def test_loudnorm_parse_and_second_pass_filter(monkeypatch):
+    monkeypatch.setitem(CONFIG, "final_loudnorm", True)
+    monkeypatch.setitem(CONFIG, "target_lufs", -14.0)
+    monkeypatch.setitem(CONFIG, "target_true_peak", -1.0)
+    monkeypatch.setitem(CONFIG, "target_lra", 11.0)
+    stats = parse_loudnorm_stats(
+        'noise\\n{ "input_i": "-21.00", "input_tp": "-2.20", '
+        '"input_lra": "5.40", "input_thresh": "-31.00", "target_offset": "0.50" }\\n'
+    )
+
+    render = loudnorm_render_filter(stats)
+
+    assert "measured_I=-21.00" in render
+    assert "measured_TP=-2.20" in render
+    assert "measured_LRA=5.40" in render
+    assert "measured_thresh=-31.00" in render
+    assert "offset=0.50" in render
+    assert render.endswith(":linear=true")
+
+    with pytest.raises(RuntimeError, match="无法解析 final loudnorm"):
+        parse_loudnorm_stats("no json here")
+
+
+def test_assemble_video_uses_two_pass_loudnorm(monkeypatch, tmp_path):
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"video")
+    wav = tmp_path / "narr.wav"
+    wav.write_bytes(b"wav")
+    output = tmp_path / "output.mp4"
+    commands = []
+    loudnorm_json = (
+        '{ "input_i": "-21.00", "input_tp": "-2.20", "input_lra": "5.40", '
+        '"input_thresh": "-31.00", "target_offset": "0.50" }'
+    )
+
+    def fake_run_cmd(cmd):
+        commands.append(cmd)
+        if cmd[0] == "ffmpeg" and "-f" in cmd and "null" in cmd:
+            return CompletedProcess(cmd, 0, stdout="", stderr=loudnorm_json)
+        if cmd[0] == "ffmpeg":
+            output.write_bytes(b"mp4")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "final_loudnorm", True)
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.0)
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 4.0)
+    monkeypatch.setattr("assemble._has_audio_stream", lambda path: True)
+    monkeypatch.setattr("assemble._build_timed_narration", lambda segments, out, duration, wd: Path(out).write_bytes(b"narration"))
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    assemble_video(video, [{
+        "start": 0.0,
+        "end": 3.0,
+        "narration": "二阶段响度。",
+        "audio_path": str(wav),
+        "audio_duration": 1.0,
+    }], tmp_path, output)
+
+    ffmpeg_cmds = [cmd for cmd in commands if cmd[0] == "ffmpeg"]
+    assert len(ffmpeg_cmds) == 2
+    assert any("print_format=json" in str(part) for part in ffmpeg_cmds[0])
+    render_joined = " ".join(str(part) for part in ffmpeg_cmds[1])
+    assert "measured_I=-21.00" in render_joined
+    assert "linear=true" in render_joined
+    assert output.exists()
 
 
 def test_assembly_settings_fingerprint_tracks_render_affecting_settings(monkeypatch):

--- a/tests/voiceover/test_pure_voiceover.py
+++ b/tests/voiceover/test_pure_voiceover.py
@@ -5,7 +5,18 @@ import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
 from lib import CONFIG
 import voiceover
-from voiceover import _build_tts_segment_result, _detect_tts_engine, _parse_rate_offset, _run_tts_engine, _synthesize_segment, _tts_mimo, resolve_tts_engine, synthesize_tts
+from voiceover import (
+    _build_tts_segment_result,
+    _detect_tts_engine,
+    _parse_rate_offset,
+    _per_segment_atempo_max,
+    _raw_duration_budget,
+    _run_tts_engine,
+    _synthesize_segment,
+    _tts_mimo,
+    resolve_tts_engine,
+    synthesize_tts,
+)
 
 
 def test_parse_rate_offset():
@@ -78,12 +89,40 @@ def test_tts_cache_key_changes_with_narration_speed(monkeypatch, tmp_path):
     assert key_normal != key_fast
 
 
+def test_tts_cache_key_changes_with_cumulative_tempo_ceiling(monkeypatch, tmp_path):
+    seg = {"start": 0.0, "end": 2.0, "narration": "缓存语速上限。"}
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+    monkeypatch.setitem(CONFIG, "mimo_tts_model", "mimo-v2.5-tts")
+    monkeypatch.setitem(CONFIG, "mimo_tts_voice", "冰糖")
+
+    monkeypatch.setitem(CONFIG, "max_cumulative_narration_tempo", 1.20)
+    key_low = voiceover._prepare_tts_segment(0, seg, [seg], tts_dir, "mimo-tts")[4]
+    monkeypatch.setitem(CONFIG, "max_cumulative_narration_tempo", 1.35)
+    key_high = voiceover._prepare_tts_segment(0, seg, [seg], tts_dir, "mimo-tts")[4]
+
+    assert key_low != key_high
+
+
+def test_voiceover_raw_budget_matches_cumulative_tempo_ceiling(monkeypatch):
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.15)
+    monkeypatch.setitem(CONFIG, "max_cumulative_narration_tempo", 1.35)
+
+    assert _per_segment_atempo_max(0.05) == pytest.approx(1.35 / (1.15 * 1.05))
+    # Raw budget includes the global speed already applied by assemble, but the
+    # local headroom is capped so TTS rate × global atempo × local atempo ≤ 1.35.
+    assert _raw_duration_budget(10.0, 0.05) == pytest.approx(10.0 * 1.15 * (1.35 / (1.15 * 1.05)))
+
+
 def test_synthesize_segment_block_truncation_accounts_for_narration_speed(monkeypatch, tmp_path):
     # assemble speeds every segment up by narration_speed before placement, so the slot holds
     # raw_dur / narration_speed. A block whose RAW tts overflows the slot but fits after the 1.3x
     # speedup must NOT be truncated; only a block that overflows even then is trimmed.
     monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
-    monkeypatch.setitem(CONFIG, "narration_speed", 1.3)
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.15)
+    monkeypatch.setitem(CONFIG, "max_cumulative_narration_tempo", 1.35)
     monkeypatch.setitem(CONFIG, "mimo_tts_model", "mimo-v2.5-tts")
     calls = []
 
@@ -97,8 +136,9 @@ def test_synthesize_segment_block_truncation_accounts_for_narration_speed(monkey
     tts_dir = tmp_path / "tts_segments"
     tts_dir.mkdir()
 
-    # slot 12s, pause 0.2s -> available 11.8s; raw budget = 11.8 * 1.3 * 1.2 ≈ 18.4s.
-    # 50-char block -> raw 15s: over the old 14.2s (available*1.2) budget, but fits the speed-aware one.
+    # slot 12s, pause 0.2s -> available 11.8s; with default cumulative cap and +0% TTS
+    # rate, raw budget = 11.8 * 1.35 ≈ 15.9s.
+    # 50-char block -> raw 15s: fits the cumulative-aware budget and must not be cut.
     block = "情节推进。" * 10
     res = _synthesize_segment(0, {"start": 0.0, "end": 12.0, "narration": block, "pause_after_ms": 200},
                               [block], tts_dir, "mimo-tts")
@@ -112,6 +152,8 @@ def test_synthesize_segment_block_truncation_accounts_for_narration_speed(monkey
                                [huge], tts_dir, "mimo-tts")
     assert len(calls) == 2                         # re-synthesized after truncation
     assert len(res2["narration"]) < len(huge)
+    assert res2["truncated"] is True
+    assert res2["narration_original"] == huge
 
 
 def test_synthesize_segment_rejects_cache_when_wav_bytes_change(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Lower default narration speed to the safer 1.15× policy and add a 1.35× cumulative tempo ceiling across TTS rate, global atempo, and local atempo.
- Align voiceover pre-checks and assembly truncation metadata with the same ceiling, ensuring subtitles/text match actually written narration even after repeated cuts.
- Move ducking ramps outside audible narration windows and switch final mix loudnorm to measured two-pass linear mode.

## Scope
Approved audio/timing bundle only. Deferred: per-block TTS loudness normalization, cold-open/montage guidance, clip-start snapping, multi-source brief parity, and post-render QC/golden harness.

## Verification
- `python -m pytest tests/voiceover/test_pure_voiceover.py -q` → 29 passed
- `python -m pytest tests/assemble/test_pure_assemble.py -q` → 56 passed
- `python -m pytest tests/assemble/test_assemble_integration.py -q` → 7 passed
- `python scripts/test.py` → all skill groups passed
- `python -m ruff check .` → passed
- `python -m compileall -q skills tests scripts conftest.py` → passed
- `git diff --check` → passed
- Code-reviewer lane: APPROVE, 0 issues
- Architect lane: CLEAR / APPROVE
- Token-like secret scan: no Mimo token persisted

## Notes
- Native review lanes initially hit 429; after fixing the architect-reported repeated-truncation blocker, code-reviewer and architect gates both passed.
- No new dependencies.
