### PR TITLE
feat(video-recap): add shift-left QC and golden eval

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -24,7 +24,9 @@ def main(argv):
     for group in groups:
         print(f"== {group} ==", flush=True)
         result = subprocess.run(
-            [sys.executable, "-m", "pytest", str(root / "tests" / group), "-q"],
+            # -rs prints skip reasons so a silently-skipped real-render test (e.g. ffmpeg
+            # missing) is visible in CI output instead of a bare "s".
+            [sys.executable, "-m", "pytest", str(root / "tests" / group), "-q", "-rs"],
             cwd=str(root),
         )
         if result.returncode != 0:

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from lib import CONFIG
 from lib import log, run_cmd, get_video_duration, narration_tempo_budget
 from timeline import build_timeline, save_timeline
-from audio_automation import coalesce_duck_windows, ducking_expression, duck_ramp_expression
+from audio_automation import coalesce_duck_windows, ducking_expression, default_bridge
 
 SUBTITLE_RENDER_VERSION = 6  # bumped: explicit visual QC/mask/overlay policy joins cache fingerprint
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
@@ -2126,10 +2126,6 @@ def _amix_tail(narr_vol, bgm_chain=""):
     return narr + "[orig][narr]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
 
 
-def _duck_ramp(s, e, fade):
-    """Compatibility wrapper for the canonical pre-roll/hold/post-roll ramp."""
-    return duck_ramp_expression(s, e, fade)
-
 def _placement_windows(tts_segments, level_for):
     """Collect [(start, end, level)] placement windows for the placed beats, using
     `level_for(seg)` to pick each beat's duck level. Skips non-dicts and empty spans."""
@@ -2144,11 +2140,6 @@ def _placement_windows(tts_segments, level_for):
     return windows
 
 
-def _coalesce_duck_windows(windows, bridge):
-    """Compatibility wrapper around the canonical audio automation coalescer."""
-    return coalesce_duck_windows(windows, bridge)
-
-
 def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=None):
     """Per-beat ducking automation for the ORIGINAL track.
 
@@ -2159,7 +2150,7 @@ def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=None)
     placement info (caller falls back to a constant).
     """
     if bridge is None:
-        bridge = 2 * float(fade or 0)
+        bridge = default_bridge(fade)
     windows = _placement_windows(
         tts_segments, lambda seg: speech_vol if seg.get("overlaps_speech", True) else quiet_vol)
     merged = coalesce_duck_windows(windows, bridge)
@@ -2169,7 +2160,7 @@ def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=None)
 def _bgm_envelope(tts_segments, base, duck, fade, bridge=None):
     """Per-beat ducking automation for the BGM track using the shared contract."""
     if bridge is None:
-        bridge = 2 * float(fade or 0)
+        bridge = default_bridge(fade)
     windows = _placement_windows(tts_segments, lambda seg: duck)
     merged = coalesce_duck_windows(windows, bridge)
     return ducking_expression(merged, base, fade)
@@ -2421,7 +2412,6 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             video_duration,
             output_path=output_path,
             source_has_audio=source_has_audio,
-            loudness_mode=_loudness_mode(loudnorm_measurement),
             loudnorm_measurement=loudnorm_measurement,
             visual_qc=visual_qc,
             render_delivery={

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -6,11 +6,16 @@ import wave
 from pathlib import Path
 
 from lib import CONFIG
-from lib import log, run_cmd, get_video_duration
+from lib import log, run_cmd, get_video_duration, narration_tempo_budget
 from timeline import build_timeline, save_timeline
+from audio_automation import coalesce_duck_windows, ducking_expression, duck_ramp_expression
 
-SUBTITLE_RENDER_VERSION = 5  # bumped: subtitle style now scales to the probed canvas (fixes 竖屏 distortion)
+SUBTITLE_RENDER_VERSION = 6  # bumped: explicit visual QC/mask/overlay policy joins cache fingerprint
 ASSEMBLY_MANIFEST = "assembly_manifest.json"
+ASSEMBLY_QC = "assembly_qc.json"
+VISUAL_QC = "visual_qc.json"
+VISUAL_OVERLAYS = "visual_overlays.json"
+SEGMENT_AUDIO_SCHEMA_VERSION = 1
 # The default subtitle metrics (font/margins/PlayRes) were tuned in this reference space.
 # For any other canvas we scale them to it so glyphs are never stretched (PlayRes aspect ==
 # frame aspect) and stay proportional; a 16:9 source reproduces the legacy look exactly.
@@ -18,6 +23,17 @@ SUBTITLE_STYLE_REF_W = 1280
 SUBTITLE_STYLE_REF_H = 720
 _SUBTITLE_TERMINAL_PUNCTUATION = "。！？!?…."
 _SUBTITLE_CLOSING_QUOTES = "」』”’）)]】》〉\"'"
+_VISUAL_DELIVERY_FORBIDDEN_KEYS = {
+    "video_encode_passes",
+    "reencode_reason",
+    "audio_sample_rate",
+    "final_compat_notes",
+    "double_encode",
+    "delivery_compatibility",
+    "loudness_mode",
+    "loudnorm_measurement",
+}
+_SUPPORTED_VISUAL_OVERLAY_TYPES = {"top_title", "inline_label_or_callout"}
 
 
 def _stable_json_dumps(value):
@@ -72,6 +88,8 @@ def _assembly_manifest_payload(input_video, tts_segments, work_dir, output_path,
     input_video = Path(input_video)
     output_path = Path(output_path)
     source_video, source_video_fingerprint = _source_video_identity()
+    qc_path = Path(work_dir) / ASSEMBLY_QC
+    qc = _load_work_json(work_dir, ASSEMBLY_QC) if qc_path.exists() else None
     payload = {
         "schema_version": 2,
         "input_video": str(input_video.resolve()),
@@ -81,6 +99,38 @@ def _assembly_manifest_payload(input_video, tts_segments, work_dir, output_path,
         "tts_segments": len(tts_segments or []),
         "assembly_settings": assembly_settings_fingerprint(work_dir),
         "output_path": str(output_path.resolve()),
+        "segment_audio_schema_version": SEGMENT_AUDIO_SCHEMA_VERSION,
+        "qc_path": str(qc_path.resolve()) if qc_path.exists() else None,
+        "qc_verdict": qc.get("verdict") if isinstance(qc, dict) else None,
+        "qc_blocking_codes": qc.get("blocking_codes", []) if isinstance(qc, dict) else [],
+        # The settings fingerprint records the configured/fallback loudness policy; these QC
+        # fields record what the just-finished render actually used after the loudnorm probe.
+        "qc_loudness_mode": qc.get("loudness_mode") if isinstance(qc, dict) else None,
+        "qc_loudnorm_measurement": qc.get("loudnorm_measurement") if isinstance(qc, dict) else None,
+        "audio_segments": [
+            {
+                "index": seg.get("index"),
+                "segment_audio_schema_version": seg.get("segment_audio_schema_version", SEGMENT_AUDIO_SCHEMA_VERSION),
+                "narration": seg.get("narration", ""),
+                "spoken_text": seg.get("spoken_text") or seg.get("narration", ""),
+                "truncated": bool(seg.get("truncated", False)),
+                "truncate_reason": seg.get("truncate_reason", "none"),
+                "fit_status": seg.get("fit_status"),
+                "blocking": bool(seg.get("blocking", False)),
+                "audio_duration": seg.get("audio_duration"),
+                "placed_audio_duration": seg.get("placed_audio_duration"),
+                "actual_place_start": seg.get("actual_place_start"),
+                "actual_place_end": seg.get("actual_place_end"),
+                "global_narration_speed": seg.get("global_narration_speed"),
+                "segment_tempo_factor": seg.get("segment_tempo_factor"),
+                "effective_tempo": seg.get("effective_tempo"),
+                "rms_dbfs_before": seg.get("rms_dbfs_before"),
+                "rms_dbfs_after": seg.get("rms_dbfs_after"),
+                "peak_after": seg.get("peak_after"),
+            }
+            for seg in (tts_segments or [])
+            if isinstance(seg, dict)
+        ],
     }
     if final_output is not None:
         payload["final_output"] = str(Path(final_output).resolve())
@@ -94,6 +144,186 @@ def _write_assembly_manifest(work_dir, manifest):
     path = Path(work_dir) / ASSEMBLY_MANIFEST
     path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
     return path
+
+
+def _visual_qc_rollup(visual_qc):
+    if not isinstance(visual_qc, dict):
+        return {
+            "present": False,
+            "verdict": "MISSING",
+            "blocking": True,
+            "blocking_codes": ["missing_visual_qc"],
+            "summary": {},
+        }
+    subtitles = visual_qc.get("subtitles") or visual_qc.get("subtitle") or {}
+    overlays = visual_qc.get("overlays") or visual_qc.get("overlay") or {}
+    return {
+        "present": True,
+        "artifact": visual_qc.get("artifact", VISUAL_QC),
+        "verdict": visual_qc.get("verdict"),
+        "blocking": bool(visual_qc.get("blocking", False)),
+        "blocking_codes": list(visual_qc.get("blocking_codes") or []),
+        "summary": visual_qc.get("summary", {}),
+        "geometry": visual_qc.get("geometry", {}),
+        "subtitles": {
+            "entries": subtitles.get("entries", 0),
+            "multi_line": subtitles.get("multi_line", False),
+            "overflow": subtitles.get("overflow", False),
+            "safe_area": subtitles.get("safe_area", {}),
+        },
+        "subtitle": subtitles,
+        "mask": visual_qc.get("mask", {}),
+        "overlays": {
+            "present": overlays.get("present", bool(overlays.get("items"))),
+            "rendered": overlays.get("rendered", len(overlays.get("items", [])) if isinstance(overlays.get("items"), list) else 0),
+            "unsupported": overlays.get("unsupported", []),
+            "overflow": overlays.get("overflow", []),
+        },
+        "overlay": overlays,
+    }
+
+
+def _build_assembly_qc(tts_segments, video_duration, *, output_path=None,
+                       source_has_audio=None, loudness_mode=None, loudnorm_measurement=None,
+                       visual_qc=None, render_delivery=None, delivery_qc=None):
+    """Machine-readable assembly release gate.
+
+    Visual facts are rolled up from visual_qc.json. Delivery/render facts live here
+    (or render/delivery QC in future), never in visual_qc.json.
+    """
+    hard_max = float(CONFIG.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40)
+    segments = [s for s in (tts_segments or []) if isinstance(s, dict)]
+    no_safe = [
+        int(s.get("index", i))
+        for i, s in enumerate(segments)
+        if s.get("fit_status") == "no_safe_fit"
+        or s.get("truncate_reason") in {"no_safe_boundary", "no_room"}
+        or bool(s.get("blocking", False))
+    ]
+    skipped = [
+        int(s.get("index", i))
+        for i, s in enumerate(segments)
+        if s.get("fit_status") == "skipped"
+    ]
+    fit_failed = [
+        int(s.get("index", i))
+        for i, s in enumerate(segments)
+        if s.get("fit_status") == "speed_adjust_failed"
+    ]
+    tempo_exceeded = []
+    max_effective = 0.0
+    for i, s in enumerate(segments):
+        try:
+            eff = float(s.get("effective_tempo", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            eff = 0.0
+        max_effective = max(max_effective, eff)
+        if eff > hard_max + 1e-6:
+            tempo_exceeded.append(int(s.get("index", i)))
+
+    placed = [
+        float(s.get("placed_audio_duration", 0.0) or 0.0)
+        for s in segments
+        if s.get("placed_audio_duration") is not None
+    ]
+    blocking_codes = []
+    if not segments:
+        blocking_codes.append("missing_narration")
+    if skipped:
+        blocking_codes.append("skipped_segments")
+    if fit_failed:
+        blocking_codes.append("fit_failed")
+    if no_safe:
+        blocking_codes.append("no_safe_fit")
+    if tempo_exceeded:
+        blocking_codes.append("effective_tempo_exceeded")
+    if placed and max(placed) <= 0.0 and not no_safe:
+        blocking_codes.append("empty_narration")
+    visual_rollup = (
+        _visual_qc_rollup(visual_qc)
+        if visual_qc is not None
+        else {"present": False, "verdict": "NOT_RUN", "blocking": False, "blocking_codes": [], "summary": {}}
+    )
+    if visual_rollup.get("blocking"):
+        blocking_codes.append("visual_qc_failed")
+    if source_has_audio is False:
+        # Not blocking: assemble can synthesize a silent original track.
+        source_audio = "synthetic_silence"
+    elif source_has_audio is True:
+        source_audio = "present"
+    else:
+        source_audio = "unknown"
+
+    output = {}
+    if output_path is not None:
+        output_path = Path(output_path)
+        output = {
+            "path": str(output_path),
+            "exists": output_path.exists(),
+            "bytes": output_path.stat().st_size if output_path.exists() else 0,
+        }
+        if output_path.exists() and output["bytes"] <= 0:
+            blocking_codes.append("empty_output")
+
+    render_delivery = render_delivery or delivery_qc or {}
+    qc_payload = {
+        "schema_version": 1,
+        "artifact": ASSEMBLY_QC,
+        "verdict": "FAIL" if blocking_codes else "PASS",
+        "blocking": bool(blocking_codes),
+        "blocking_codes": blocking_codes,
+        "duration": round(float(video_duration or 0.0), 4),
+        "source_audio": source_audio,
+        "loudness_mode": loudness_mode or _loudness_mode(loudnorm_measurement),
+        "loudnorm_measurement": loudnorm_measurement,
+        "release_gate": {
+            "verdict": "FAIL" if blocking_codes else "PASS",
+            "visual_qc": visual_rollup.get("verdict"),
+            "delivery_qc": "PASS",
+            "audio_qc": "FAIL" if any(
+                c in blocking_codes
+                for c in ("missing_narration", "skipped_segments", "fit_failed", "no_safe_fit", "effective_tempo_exceeded", "empty_narration")
+            ) else "PASS",
+        },
+        "visual_qc": visual_rollup,
+        "delivery_qc": {
+            "video_encode_passes": render_delivery.get("video_encode_passes"),
+            "reencode_reason": render_delivery.get("reencode_reason"),
+            "audio_sample_rate": render_delivery.get("audio_sample_rate"),
+            "final_compat_notes": render_delivery.get("final_compat_notes", []),
+        },
+        "summary": {
+            "segments": len(segments),
+            "placed_segments": sum(1 for x in placed if x > 0.0),
+            "skipped_segments": skipped,
+            "fit_failed_segments": fit_failed,
+            "no_safe_fit_segments": no_safe,
+            "tempo_exceeded_segments": tempo_exceeded,
+            "max_effective_tempo": round(max_effective, 4),
+            "truncated_segments": [
+                int(s.get("index", i))
+                for i, s in enumerate(segments)
+                if bool(s.get("truncated", False))
+            ],
+        },
+        "output": output,
+    }
+    qc_payload["visual_rollup"] = visual_rollup
+    qc_payload["delivery_rollup"] = qc_payload["delivery_qc"]
+    return qc_payload
+
+
+def _write_assembly_qc(work_dir, qc):
+    path = Path(work_dir) / ASSEMBLY_QC
+    path.write_text(json.dumps(qc, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def _enforce_assembly_qc(work_dir, qc):
+    _write_assembly_qc(work_dir, qc)
+    if qc.get("blocking"):
+        codes = ", ".join(qc.get("blocking_codes", []))
+        raise RuntimeError(f"声音组装 QC 失败: {codes}；详见 {Path(work_dir) / ASSEMBLY_QC}")
 
 
 def _resolve_final_output(base, stem):
@@ -119,26 +349,142 @@ def _load_cut_timeline_plan(work_dir):
     return raw_plan
 
 
+def _ratio_to_float(value, default=1.0):
+    value = str(value or "").strip()
+    if not value or value in {"0:1", "0/1", "N/A"}:
+        return default
+    try:
+        if ":" in value:
+            num, den = value.split(":", 1)
+        elif "/" in value:
+            num, den = value.split("/", 1)
+        else:
+            return float(value)
+        den_f = float(den or 0)
+        return float(num) / den_f if den_f else default
+    except (TypeError, ValueError, ZeroDivisionError):
+        return default
+
+
+def _fps_from_rate(value, default=30.0):
+    try:
+        if "/" in str(value):
+            num, den = str(value).split("/", 1)
+            den_f = float(den or 0)
+            return round(float(num) / den_f, 3) if den_f else default
+        return round(float(value), 3)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return default
+
+
+def _stream_rotation(stream):
+    """Extract rotation from tags or side_data_list in ffprobe JSON."""
+    if not isinstance(stream, dict):
+        return 0
+    for source in (
+        (stream.get("tags") or {}).get("rotate"),
+        stream.get("rotation"),
+    ):
+        if source not in (None, ""):
+            try:
+                return int(round(float(source))) % 360
+            except (TypeError, ValueError):
+                pass
+    for item in stream.get("side_data_list") or []:
+        if not isinstance(item, dict):
+            continue
+        for key in ("rotation", "displaymatrix"):
+            if item.get(key) not in (None, ""):
+                try:
+                    return int(round(float(item.get(key)))) % 360
+                except (TypeError, ValueError):
+                    pass
+    return 0
+
+
+def _canvas_from_stream(stream, *, default_width=1280, default_height=720, default_fps=30.0):
+    storage_w = int(stream.get("width") or default_width)
+    storage_h = int(stream.get("height") or default_height)
+    fps = _fps_from_rate(stream.get("r_frame_rate") or stream.get("avg_frame_rate"), default_fps)
+    sar_text = stream.get("sample_aspect_ratio") or "1:1"
+    dar_text = stream.get("display_aspect_ratio") or ""
+    sar = _ratio_to_float(sar_text, 1.0)
+    rotation = _stream_rotation(stream)
+
+    display_w = max(1, int(round(storage_w * sar)))
+    display_h = max(1, storage_h)
+    if dar_text and dar_text not in {"0:1", "N/A"}:
+        dar = _ratio_to_float(dar_text, 0.0)
+        # ffprobe sources are not consistent: some report DAR before rotation
+        # (landscape value > 1 for a 90° stream), while simple line mocks and
+        # some containers report the already-rotated portrait DAR (< 1). Only
+        # apply DAR before swapping when it describes the stored orientation.
+        if dar > 0 and not (rotation in {90, 270} and dar < 1.0):
+            # Preserve height and adjust width. This keeps legacy square-pixel landscape
+            # byte-identical while honoring non-square pixel DAR metadata.
+            display_w = max(1, int(round(display_h * dar)))
+    if rotation in {90, 270}:
+        display_w, display_h = display_h, display_w
+
+    return {
+        "width": display_w,
+        "height": display_h,
+        "fps": fps,
+        "storage_width": storage_w,
+        "storage_height": storage_h,
+        "rotation": rotation,
+        "sample_aspect_ratio": sar_text,
+        "display_aspect_ratio": dar_text or f"{display_w}:{display_h}",
+        "sar": sar_text,
+        "dar": dar_text or f"{display_w}:{display_h}",
+        "display_width": display_w,
+        "display_height": display_h,
+    }
+
+
 def _probe_canvas(video_path):
-    """Return {width, height, fps} for a video via ffprobe (best-effort defaults)."""
-    res = run_cmd(["ffprobe", "-v", "error", "-select_streams", "v:0",
-                   "-show_entries", "stream=width,height,r_frame_rate",
-                   "-of", "default=nw=1:nk=0", str(video_path)])
-    width, height, fps = 1280, 720, 30.0
+    """Return rotation/SAR/DAR-aware canvas facts for a video.
+
+    ``width``/``height`` are the display canvas used by subtitle/overlay geometry.
+    For legacy square-pixel landscape sources, these remain the raw storage dimensions.
+    Extra storage/rotation/SAR/DAR fields are visual QC facts and are safe for callers
+    that only consume width/height/fps.
+    """
+    defaults = {"width": 1280, "height": 720, "fps": 30.0}
+    res = run_cmd([
+        "ffprobe", "-v", "error", "-select_streams", "v:0",
+        "-show_entries",
+        "stream=width,height,r_frame_rate,avg_frame_rate,sample_aspect_ratio,display_aspect_ratio:stream_tags=rotate:stream_side_data=rotation",
+        "-of", "json", str(video_path),
+    ])
     if res.returncode == 0:
-        for line in res.stdout.splitlines():
+        try:
+            data = json.loads(res.stdout or "{}")
+            stream = (data.get("streams") or [{}])[0]
+            if isinstance(stream, dict) and stream:
+                return _canvas_from_stream(stream)
+        except (ValueError, TypeError, KeyError):
+            pass
+        # Tests and older mocks may still feed default=nw=1:nk=0 style lines.
+        stream = {}
+        for line in (res.stdout or "").splitlines():
             line = line.strip()
-            if line.startswith("width="):
-                width = int(line.split("=", 1)[1] or width)
-            elif line.startswith("height="):
-                height = int(line.split("=", 1)[1] or height)
-            elif line.startswith("r_frame_rate="):
-                rate = line.split("=", 1)[1]
-                if "/" in rate:
-                    num, den = rate.split("/", 1)
-                    if float(den or 0):
-                        fps = round(float(num) / float(den), 3)
-    return {"width": width, "height": height, "fps": fps}
+            if not line or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            stream[key] = value
+        if stream:
+            return _canvas_from_stream(stream)
+    return {
+        **defaults,
+        "storage_width": defaults["width"],
+        "storage_height": defaults["height"],
+        "rotation": 0,
+        "sample_aspect_ratio": "1:1",
+        "display_aspect_ratio": "16:9",
+        "display_width": defaults["width"],
+        "display_height": defaults["height"],
+    }
 
 
 def _has_audio_stream(video_path):
@@ -374,30 +720,109 @@ def _has_user_subtitles(work_dir):
     )
 
 
+def _source_subtitle_mask_policy(work_dir=None):
+    """Explicit source-subtitle mask policy and trigger facts for visual QC/cache keys.
+
+    Older builds treated ``MASK_SOURCE_SUBTITLES=True`` as an ambient default black
+    band. The visual contract now requires an explicit policy, so a bare truthy
+    legacy flag is represented as ``legacy_implicit`` and blocks the visual gate
+    instead of silently masking picture information.
+    """
+    burn = bool(CONFIG.get("burn_subtitles", False))
+    raw_policy = str(CONFIG.get("source_subtitle_mask_policy", "") or "").strip().lower()
+    legacy_flag = bool(CONFIG.get("mask_source_subtitles", False))
+    allowed = {"off", "opt_in", "safe", "forced"}
+    declared = bool(CONFIG.get("source_subtitle_mask_policy_declared", False)) or raw_policy in {"opt_in", "safe", "forced"}
+    implicit = False
+    if legacy_flag and not declared:
+        raw_policy = "legacy_implicit"
+        implicit = True
+    elif not raw_policy:
+        raw_policy = "off"
+    elif raw_policy not in allowed:
+        implicit = True
+    user_subtitles = _has_user_subtitles(work_dir)
+    active = False
+    trigger = "policy_off"
+    reason = "source subtitle masking disabled by explicit policy"
+    if raw_policy == "off":
+        active = False
+    elif raw_policy in {"opt_in", "forced"}:
+        active = burn and legacy_flag
+        trigger = "burn_subtitles_and_legacy_mask_flag"
+        reason = "explicit policy permits masking only with burned recap subtitles"
+    elif raw_policy == "safe":
+        active = burn and (legacy_flag or user_subtitles)
+        trigger = "safe_policy_with_burned_subtitles"
+        reason = "safe policy masks only when recap subtitles are burned and an original-subtitle source is declared"
+    else:
+        active = False
+        trigger = "implicit_or_invalid_policy"
+        reason = "mask_source_subtitles requires explicit SOURCE_SUBTITLE_MASK_POLICY"
+    if not burn and active:
+        active = False
+        trigger = "burn_subtitles_disabled"
+        reason = "mask-only black band is forbidden without burned recap subtitles"
+    return {
+        "policy": raw_policy,
+        "declared": bool(declared and raw_policy in allowed),
+        "active": bool(active),
+        "scope": "bottom_source_subtitle_band" if active else "none",
+        "trigger": trigger,
+        "reason": reason,
+        "burn_subtitles": burn,
+        "legacy_mask_flag": legacy_flag,
+        "user_subtitles_present": user_subtitles,
+        "blocking": bool(implicit),
+    }
+
+
+def _source_subtitle_mask_policy_qc(canvas=None, work_dir=None):
+    """Compatibility/test helper: return the same explicit policy facts used by visual QC."""
+    return _source_subtitle_mask_policy(work_dir)
+
+
 def assembly_settings_fingerprint(work_dir=None):
     """Settings that affect the rendered video, used by pipeline resume cache. When work_dir is
     given, a user_subtitles presence flag is included so dropping in a user-subtitle file rebuilds
     the cached subtitles."""
     burn_subtitles = bool(CONFIG.get("burn_subtitles", False))
-    mask_source_subtitles = burn_subtitles and bool(CONFIG.get("mask_source_subtitles", False))
+    mask_policy = _source_subtitle_mask_policy(work_dir)
+    mask_source_subtitles = bool(mask_policy["active"])
     user_subtitles = _has_user_subtitles(work_dir)
+    overlay_path = Path(work_dir) / VISUAL_OVERLAYS if work_dir is not None else None
     fingerprint = {
         "version": SUBTITLE_RENDER_VERSION,
         "subtitle_text_normalize": SUBTITLE_TEXT_NORMALIZE_VERSION,
         "user_subtitles": user_subtitles,
         "burn_subtitles": burn_subtitles,
         "force_video_reencode": bool(CONFIG.get("force_video_reencode", False)),
+        "encode": {
+            "output_crf": CONFIG.get("output_crf", 18),
+            "output_preset": CONFIG.get("output_preset", "veryfast"),
+            "output_max_height": CONFIG.get("output_max_height", 0),
+        },
         "video_filters": {
             "mask_source_subtitles": mask_source_subtitles,
+            "source_subtitle_mask_policy": mask_policy["policy"],
+            "source_subtitle_mask_policy_declared": mask_policy["declared"],
+            "source_subtitle_mask_policy_trigger": mask_policy["trigger"],
             "source_subtitle_mask_ratio": (
                 CONFIG.get("source_subtitle_mask_ratio", 0.14) if mask_source_subtitles else None
             ),
+            "visual_overlays": {
+                "artifact": VISUAL_OVERLAYS,
+                "present": bool(overlay_path and overlay_path.exists()),
+                "fingerprint": _artifact_fingerprint(overlay_path) if overlay_path and overlay_path.exists() else None,
+            },
         },
         "narration_timing": {
             "delay_seconds": CONFIG.get("narration_delay_seconds", 1.5),
             "tail_pad_seconds": CONFIG.get("narration_tail_pad_seconds", 0.1),
             "fade_ms": CONFIG.get("fade_ms", 120),
             "narration_speed": CONFIG.get("narration_speed", 1.0),
+            "narration_cumulative_tempo_max": CONFIG.get("narration_cumulative_tempo_max", 1.35),
+            "tts_segment_tempo_max": CONFIG.get("tts_segment_tempo_max", 1.20),
         },
         "audio_mix": {
             "ducking_mode": CONFIG.get("ducking_mode", "fixed"),
@@ -414,7 +839,8 @@ def assembly_settings_fingerprint(work_dir=None):
             "ducking_release": CONFIG.get("ducking_release", 300),
             "ducking_level_sc": CONFIG.get("ducking_level_sc", 2.0),
             "ducking_makeup": CONFIG.get("ducking_makeup", 1.2),
-            "final_loudnorm": final_loudnorm_filter() or "off",
+            "final_loudnorm": final_loudnorm_filter(),
+            "loudness_mode": _loudness_mode(),
             "bgm_path": CONFIG.get("bgm_path", ""),
             "bgm_volume": CONFIG.get("bgm_volume", 0.18),
             "bgm_ducking_volume": CONFIG.get("bgm_ducking_volume", 0.10),
@@ -565,7 +991,7 @@ def _subtitle_entries(narration):
     for seg in narration:
         if not isinstance(seg, dict):
             continue
-        text = str(seg.get("narration", "")).strip()
+        text = str(seg.get("spoken_text") or seg.get("narration", "")).strip()
         if not text:
             continue
         try:
@@ -895,9 +1321,10 @@ def _original_gap_subtitle_entries(tts_segments, work_dir, video_duration):
     # the original dialogue shown, e.g. a clean/foreign source with mask OFF (no burned subs to
     # double). Without a user file we keep the mask requirement so we don't double the source's own
     # visible subs. subtitle_original_in_gaps is the explicit override either way.
+    mask_policy = _source_subtitle_mask_policy(work_dir)
     if not (CONFIG.get("burn_subtitles", False)
             and CONFIG.get("subtitle_original_in_gaps", True)
-            and (CONFIG.get("mask_source_subtitles", False) or _has_user_subtitles(work_dir))):
+            and (mask_policy.get("active") or _has_user_subtitles(work_dir))):
         return []
     gaps = _narration_gap_windows(tts_segments, video_duration)
     if not gaps:
@@ -1124,6 +1551,370 @@ def _generate_ass(narration, work_dir, video_duration=None, canvas=None):
     return ass_path
 
 
+def _visual_text_units(text):
+    """Approximate visual text width in em units for deterministic geometry QC."""
+    units = 0.0
+    for ch in str(text or ""):
+        if ch.isspace():
+            units += 0.35
+        elif ord(ch) < 128:
+            units += 0.56
+        else:
+            units += 1.0
+    return units
+
+
+def _subtitle_layout_qc(entries, canvas=None, style=None, safe_area=None):
+    """Machine-check subtitle safe-area/multiline/overflow facts for visual_qc.json."""
+    canvas = canvas or {}
+    style = style or _subtitle_style_config(canvas)
+    play_x = int(style.get("play_res_x") or canvas.get("width") or 1280)
+    play_y = int(style.get("play_res_y") or canvas.get("height") or 720)
+    margin_l = int(style.get("margin_l") or 0)
+    margin_r = int(style.get("margin_r") or 0)
+    margin_v = int(style.get("margin_v") or 0)
+    font_size = float(style.get("font_size") or 1)
+    max_lines = int(CONFIG.get("subtitle_max_lines", 2) or 2)
+    usable_w = max(1.0, play_x - margin_l - margin_r)
+    if safe_area:
+        safe_area = {
+            "x": int(safe_area.get("x", margin_l) or 0),
+            "y": int(safe_area.get("y", margin_v) or 0),
+            "width": int(safe_area.get("width", safe_area.get("w", play_x - margin_l - margin_r)) or 1),
+            "height": int(safe_area.get("height", safe_area.get("h", play_y - 2 * margin_v)) or 1),
+            "bottom_margin": margin_v,
+        }
+        usable_w = max(1.0, float(safe_area["width"]))
+    else:
+        safe_area = {
+        "x": margin_l,
+        "y": margin_v,
+        "width": max(1, play_x - margin_l - margin_r),
+        "height": max(1, play_y - 2 * margin_v),
+        "bottom_margin": margin_v,
+        }
+    line_h = font_size * 1.25
+    overflow_entries = []
+    violations = []
+    multi_line_entries = []
+    max_observed_lines = 0
+    entry_facts = []
+    for i, entry in enumerate(entries or []):
+        raw_text = _normalize_subtitle_text(entry.get("text", ""))
+        lines = [ln for ln in re.split(r"(?:\\N|\n)+", raw_text) if ln != ""]
+        if not lines:
+            lines = [""]
+        line_count = len(lines)
+        max_observed_lines = max(max_observed_lines, line_count)
+        widths = [_visual_text_units(line) * font_size for line in lines]
+        max_w = max(widths or [0.0])
+        band_h = line_count * line_h + float(style.get("outline", 0)) * 2 + float(style.get("shadow", 0))
+        overflow_reasons = []
+        if line_count > max_lines:
+            overflow_reasons.append("max_lines_exceeded")
+        if max_w > usable_w + 1e-6:
+            overflow_reasons.append("safe_width_exceeded")
+        if band_h > safe_area["height"] + 1e-6:
+            overflow_reasons.append("safe_height_exceeded")
+        fact = {
+            "index": i,
+            "start": round(float(entry.get("start", 0.0) or 0.0), 3),
+            "end": round(float(entry.get("end", 0.0) or 0.0), 3),
+            "line_count": line_count,
+            "max_line_width": round(max_w, 2),
+            "safe_width": round(usable_w, 2),
+            "band_height": round(band_h, 2),
+            "overflow": bool(overflow_reasons),
+            "overflow_reasons": overflow_reasons,
+        }
+        entry_facts.append(fact)
+        if line_count > 1:
+            multi_line_entries.append(i)
+        if overflow_reasons:
+            overflow_entries.append(fact)
+            for reason in overflow_reasons:
+                kind = {
+                    "max_lines_exceeded": "line_count",
+                    "safe_width_exceeded": "line_width",
+                    "safe_height_exceeded": "safe_area",
+                }.get(reason, "safe_area")
+                violations.append({"index": i, "kind": kind, "reason": reason})
+    return {
+        "enabled": bool(CONFIG.get("burn_subtitles", False)),
+        "renderer": "ass" if CONFIG.get("burn_subtitles", False) else "sidecar_srt",
+        "style": {
+            "font_size": int(font_size),
+            "max_chars": int(style.get("max_chars") or 0),
+            "max_lines": max_lines,
+            "play_res_x": play_x,
+            "play_res_y": play_y,
+            "alignment": int(style.get("alignment") or 0),
+            "margin_l": margin_l,
+            "margin_r": margin_r,
+            "margin_v": margin_v,
+        },
+        "safe_area": safe_area,
+        "entries": len(entry_facts),
+        "max_lines": max_observed_lines,
+        "max_observed_lines": max_observed_lines,
+        "multi_line": bool(multi_line_entries),
+        "multi_line_entries": multi_line_entries,
+        "overflow": bool(overflow_entries),
+        "overflow_entries": overflow_entries,
+        "violations": violations,
+        "entry_facts": entry_facts,
+    }
+
+
+def _load_visual_overlays(work_dir, *, with_source=False):
+    path = Path(work_dir) / VISUAL_OVERLAYS
+    if not path.exists():
+        result = ([], {"present": False, "path": str(path), "fingerprint": None})
+        return result if with_source else result[0]
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        result = ([], {
+            "present": True,
+            "path": str(path),
+            "fingerprint": _artifact_fingerprint(path),
+            "load_error": "invalid_json",
+            "load_error_detail": str(exc),
+        })
+        return result if with_source else result[0]
+    source = {
+        "present": True,
+        "path": str(path),
+        "fingerprint": _artifact_fingerprint(path),
+        "schema_version": data.get("schema_version") if isinstance(data, dict) else None,
+    }
+    schema_version = data.get("schema_version") if isinstance(data, dict) else None
+    valid_schema_version = (
+        isinstance(schema_version, int)
+        and not isinstance(schema_version, bool)
+        and schema_version == 1
+    )
+    if isinstance(data, dict) and valid_schema_version and isinstance(data.get("overlays"), list):
+        overlays = data["overlays"]
+    else:
+        overlays = []
+        source["load_error"] = "invalid_schema"
+    return (overlays, source) if with_source else overlays
+
+
+def _escape_drawtext_text(text):
+    return (
+        str(text or "")
+        .replace("\\", "\\\\")
+        .replace(":", "\\:")
+        .replace("'", "\\'")
+        .replace("%", "\\%")
+        .replace("\n", "\\n")
+    )
+
+
+def _overlay_time_window(overlay, video_duration):
+    try:
+        start = float(overlay.get("start", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        start = 0.0
+    try:
+        end = float(overlay.get("end", video_duration) or video_duration)
+    except (TypeError, ValueError):
+        end = float(video_duration or 0.0)
+    end = max(start, end)
+    return start, end
+
+
+def _overlay_bbox(overlay, canvas, *, default_y):
+    width = int((canvas or {}).get("width") or 1280)
+    height = int((canvas or {}).get("height") or 720)
+    text = str(overlay.get("text") or "")
+    font_size = int(overlay.get("font_size") or max(18, round(height * 0.045)))
+    lines = [ln for ln in text.splitlines() if ln.strip()] or [text]
+    max_w = max((_visual_text_units(ln) * font_size for ln in lines), default=0.0)
+    text_h = len(lines) * font_size * 1.25
+    if overlay.get("type") == "top_title":
+        x = max(0.0, (width - max_w) / 2)
+        y = float(overlay.get("y", default_y) or default_y)
+    else:
+        raw_x = overlay.get("x", 0.08)
+        raw_y = overlay.get("y", 0.25)
+        try:
+            x = float(raw_x)
+            if 0.0 <= x <= 1.0:
+                x *= width
+        except (TypeError, ValueError):
+            x = width * 0.08
+        try:
+            y = float(raw_y)
+            if 0.0 <= y <= 1.0:
+                y *= height
+        except (TypeError, ValueError):
+            y = height * 0.25
+    return {
+        "x": round(x, 2),
+        "y": round(y, 2),
+        "width": round(max_w, 2),
+        "height": round(text_h, 2),
+        "font_size": font_size,
+        "line_count": len(lines),
+        "overflow": x < 0 or y < 0 or x + max_w > width or y + text_h > height,
+    }
+
+
+def _visual_overlay_filters(work_dir, canvas, video_duration):
+    """Render the first-release canonical visual_overlays.json contract.
+
+    Only two semantic renderers are supported: top_title and inline_label_or_callout.
+    Unsupported types are QC-blocking and deliberately do not silently render.
+    """
+    overlays, source = _load_visual_overlays(work_dir, with_source=True)
+    width = int((canvas or {}).get("width") or 1280)
+    height = int((canvas or {}).get("height") or 720)
+    default_top_y = max(24, round(height * 0.05))
+    filters = []
+    facts = []
+    unsupported = []
+    overflow = []
+    for idx, overlay in enumerate(overlays):
+        if not isinstance(overlay, dict):
+            unsupported.append({"index": idx, "type": None, "reason": "overlay_not_object"})
+            continue
+        typ = str(overlay.get("type") or "").strip()
+        text = str(overlay.get("text") or "").strip()
+        if typ not in _SUPPORTED_VISUAL_OVERLAY_TYPES:
+            unsupported.append({"index": idx, "type": typ, "reason": "unsupported_overlay_type"})
+            continue
+        if not text:
+            unsupported.append({"index": idx, "type": typ, "reason": "missing_text"})
+            continue
+        start, end = _overlay_time_window(overlay, video_duration)
+        bbox = _overlay_bbox(overlay, canvas, default_y=default_top_y)
+        if bbox["overflow"]:
+            overflow.append({"index": idx, "type": typ, "bbox": bbox})
+        font_size = bbox["font_size"]
+        safe_text = _escape_drawtext_text(text)
+        enable = f"between(t\\,{start:.3f}\\,{end:.3f})"
+        if typ == "top_title":
+            filt = (
+                "drawtext="
+                f"text='{safe_text}':x=(w-text_w)/2:y={int(bbox['y'])}:"
+                f"fontsize={font_size}:fontcolor=white:borderw=2:bordercolor=black@0.85:"
+                f"box=1:boxcolor=black@0.35:boxborderw=12:enable='{enable}'"
+            )
+        else:
+            filt = (
+                "drawtext="
+                f"text='{safe_text}':x={int(bbox['x'])}:y={int(bbox['y'])}:"
+                f"fontsize={font_size}:fontcolor=white:borderw=2:bordercolor=black@0.85:"
+                f"box=1:boxcolor=black@0.45:boxborderw=8:enable='{enable}'"
+            )
+        filters.append(filt)
+        facts.append({
+            "index": idx,
+            "type": typ,
+            "text_chars": len(text),
+            "start": round(start, 3),
+            "end": round(end, 3),
+            "bbox": bbox,
+        })
+    qc = {
+        "source": source,
+        "load_error": source.get("load_error"),
+        "supported_types": sorted(_SUPPORTED_VISUAL_OVERLAY_TYPES),
+        "present": bool(source.get("present")),
+        "count": len(overlays),
+        "rendered": len(facts),
+        "facts": facts,
+        "unsupported": unsupported,
+        "overflow": overflow,
+    }
+    return filters, qc
+
+
+def _visual_qc_has_forbidden_delivery_facts(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in _VISUAL_DELIVERY_FORBIDDEN_KEYS:
+                return True
+            if _visual_qc_has_forbidden_delivery_facts(child):
+                return True
+    elif isinstance(value, list):
+        return any(_visual_qc_has_forbidden_delivery_facts(item) for item in value)
+    return False
+
+
+def _build_visual_qc(tts_segments, work_dir, video_duration, canvas, *, overlay_qc=None, mask_filter=None):
+    entries = _combined_subtitle_entries(tts_segments, work_dir, video_duration)
+    style = _subtitle_style_config(canvas)
+    subtitle_layout = _subtitle_layout_qc(entries, canvas, style)
+    mask = _source_subtitle_mask_policy(work_dir)
+    ratio = None
+    if mask.get("active"):
+        ratio = max(0.0, min(0.5, float(CONFIG.get("source_subtitle_mask_ratio", 0.14) or 0.0)))
+    mask.update({
+        "ratio": ratio,
+        "filter": "drawbox" if mask_filter else None,
+    })
+    overlay_qc = overlay_qc or _visual_overlay_filters(work_dir, canvas, video_duration)[1]
+    blocking_codes = []
+    if mask.get("blocking"):
+        blocking_codes.append("mask_policy_not_explicit")
+    if subtitle_layout.get("overflow"):
+        blocking_codes.append("subtitle_overflow")
+    if overlay_qc.get("load_error"):
+        blocking_codes.append("invalid_visual_overlays_json")
+    if overlay_qc.get("unsupported"):
+        blocking_codes.append("unsupported_visual_overlay")
+    if overlay_qc.get("overflow"):
+        blocking_codes.append("visual_overlay_overflow")
+    qc = {
+        "schema_version": 1,
+        "artifact": VISUAL_QC,
+        "verdict": "FAIL" if blocking_codes else "PASS",
+        "blocking": bool(blocking_codes),
+        "blocking_codes": blocking_codes,
+        "geometry": {
+            "canvas": {
+                "width": int(canvas.get("width", 1280)),
+                "height": int(canvas.get("height", 720)),
+                "fps": float(canvas.get("fps", 30.0)),
+            },
+            "storage": {
+                "width": int(canvas.get("storage_width", canvas.get("width", 1280))),
+                "height": int(canvas.get("storage_height", canvas.get("height", 720))),
+            },
+            "rotation": int(canvas.get("rotation", 0) or 0),
+            "sample_aspect_ratio": canvas.get("sample_aspect_ratio", "1:1"),
+            "display_aspect_ratio": canvas.get("display_aspect_ratio"),
+        },
+        "subtitles": subtitle_layout,
+        "mask": mask,
+        "overlays": overlay_qc,
+        "summary": {
+            "subtitle_entries": subtitle_layout.get("entries", 0),
+            "subtitle_overflow": bool(subtitle_layout.get("overflow")),
+            "subtitle_multi_line": bool(subtitle_layout.get("multi_line")),
+            "mask_policy": mask.get("policy"),
+            "mask_active": bool(mask.get("active")),
+            "overlay_rendered": int(overlay_qc.get("rendered", 0) or 0),
+            "overlay_unsupported": len(overlay_qc.get("unsupported") or []),
+        },
+    }
+    if _visual_qc_has_forbidden_delivery_facts(qc):
+        qc["verdict"] = "FAIL"
+        qc["blocking"] = True
+        qc["blocking_codes"].append("visual_qc_contains_delivery_fact")
+    return qc
+
+
+def _write_visual_qc(work_dir, qc):
+    path = Path(work_dir) / VISUAL_QC
+    path.write_text(json.dumps(qc, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
 def _escape_subtitle_filter_path(path):
     """Escape a path for ffmpeg subtitle/ass video filter arguments."""
     text = str(path).replace("\\", "/")
@@ -1154,19 +1945,103 @@ def _output_downscale_filter(max_h):
     return f"scale=-2:'2*trunc(min(ih,{max_h})/2)':flags=lanczos"
 
 
-def final_loudnorm_filter():
-    """Final-mix loudness normalization filter from CONFIG, or None when disabled.
+def _limiter_filter():
+    peak = float(CONFIG.get("final_limiter_peak", 0.98) or 0.98)
+    return f"alimiter=limit={peak:.2f}:level=false"
+
+
+def _loudness_mode(measured=None):
+    if not CONFIG.get("final_loudnorm", True):
+        return "limiter_only"
+    return "two_pass_linear" if measured else "equivalent"
+
+
+def final_loudnorm_filter(measured=None):
+    """Final-mix loudness normalization/limiter filter from CONFIG.
 
     Ducking branches set only relative balance; this single stage owns the
-    absolute output loudness so the recap is not left too quiet.
+    absolute output loudness so the recap is not left too quiet. When `measured`
+    is supplied from a first loudnorm pass, ffmpeg runs the deterministic second
+    pass; without it we still force the same target and peak limiter as a
+    documented equivalent/fallback path.
     """
     if not CONFIG.get("final_loudnorm", True):
-        return None
+        return _limiter_filter()
+    filt = (
+        f"loudnorm=I={CONFIG.get('target_lufs', -14.0)}"
+        f":TP={CONFIG.get('target_true_peak', -1.0)}"
+        f":LRA={CONFIG.get('target_lra', 11.0)}"
+        f":linear=true"
+    )
+    if measured:
+        for src, dst in (
+            ("input_i", "measured_I"),
+            ("input_tp", "measured_TP"),
+            ("input_lra", "measured_LRA"),
+            ("input_thresh", "measured_thresh"),
+            ("target_offset", "offset"),
+        ):
+            if src in measured:
+                filt += f":{dst}={measured[src]}"
+    filt += ":print_format=summary"
+    return f"{filt},{_limiter_filter()}"
+
+
+def _parse_loudnorm_json(text):
+    """Extract ffmpeg loudnorm JSON from stderr/stdout."""
+    for match in reversed(list(re.finditer(r"\{[\s\S]*?\}", str(text or "")))):
+        try:
+            data = json.loads(match.group(0))
+        except ValueError:
+            continue
+        if isinstance(data, dict) and {"input_i", "input_tp", "input_lra", "input_thresh", "target_offset"} <= set(data):
+            return data
+    return None
+
+
+def _loudnorm_first_pass_filter():
     return (
         f"loudnorm=I={CONFIG.get('target_lufs', -14.0)}"
         f":TP={CONFIG.get('target_true_peak', -1.0)}"
         f":LRA={CONFIG.get('target_lra', 11.0)}"
+        f":print_format=json"
     )
+
+
+def _run_loudnorm_first_pass(input_video, narration_wav, original_audio_input,
+                             bgm_input, filter_complex, work_dir):
+    """Measure the exact mixed audio graph before final render.
+
+    Returns ffmpeg loudnorm JSON, or None when probing fails. The caller then
+    falls back to the documented equivalent single-pass target+limiter filter.
+    """
+    if not CONFIG.get("final_loudnorm", True):
+        return None
+    probe_fc = f"{filter_complex};[aout]{_loudnorm_first_pass_filter()}[lnprobe]"
+    probe_script = Path(work_dir) / ".filter_complex_loudnorm_probe.txt"
+    probe_script.write_text(probe_fc, encoding="utf-8")
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", str(input_video),
+        "-i", str(narration_wav),
+        *original_audio_input,
+        *bgm_input,
+        "-filter_complex_script", str(probe_script),
+        "-map", "[lnprobe]",
+        "-f", "null", "-",
+    ]
+    try:
+        result = run_cmd(cmd)
+    finally:
+        probe_script.unlink(missing_ok=True)
+    if result.returncode != 0:
+        log(f"  ⚠️ loudnorm 首遍测量失败，降级到目标滤镜+limiter: {result.stderr}")
+        return None
+    measured = _parse_loudnorm_json((result.stdout or "") + "\n" + (result.stderr or ""))
+    if not measured:
+        log("  ⚠️ loudnorm 首遍未返回 JSON，降级到目标滤镜+limiter")
+        return None
+    return measured
 
 
 def _apply_narration_speed(tts_segments, work_dir):
@@ -1185,17 +2060,29 @@ def _apply_narration_speed(tts_segments, work_dir):
         src = seg.get("audio_path")
         if not src or not os.path.exists(src):
             continue
+        seg.setdefault("segment_audio_schema_version", SEGMENT_AUDIO_SCHEMA_VERSION)
+        seg.setdefault("narration", str(seg.get("narration") or seg.get("spoken_text") or ""))
+        seg.setdefault("spoken_text", str(seg.get("spoken_text") or seg.get("narration") or ""))
+        seg.setdefault("truncated", False)
+        seg.setdefault("truncate_reason", "none")
+        seg.setdefault("source_audio_duration", seg.get("audio_duration"))
+        seg["global_narration_speed"] = factor
         out = str(Path(work_dir) / f"_spd_{seg.get('index', 0)}.wav")
         res = run_cmd(["ffmpeg", "-y", "-i", src, "-filter:a", f"atempo={factor:.3f}",
                        "-ar", "44100", "-ac", "1", "-acodec", "pcm_s16le", out])
         if res.returncode == 0 and os.path.exists(out):
             seg["audio_path"] = out
             seg["audio_duration"] = get_video_duration(out)
+            seg["effective_tempo"] = (
+                factor
+                * (1.0 + float(seg.get("tts_rate_offset", 0.0) or 0.0))
+                * float(seg.get("segment_tempo_factor", 1.0) or 1.0)
+            )
             done += 1
     log(f"解说整体提速: atempo={factor:.2f} ({done} 段)")
 
 
-def _source_subtitle_mask_filter(canvas=None):
+def _source_subtitle_mask_filter(canvas=None, work_dir=None):
     """ffmpeg drawbox that masks burned-in source subtitles along the bottom, or None.
 
     Many source videos (e.g. 庆余年) ship hardcoded subtitles; without this the recap
@@ -1203,7 +2090,8 @@ def _source_subtitle_mask_filter(canvas=None):
     an opaque box; our subtitles render on top of it. canvas ({"width","height"}) makes the
     single-line band sizing match the canvas-scaled subtitle style.
     """
-    if not (CONFIG.get("burn_subtitles", False) and CONFIG.get("mask_source_subtitles", False)):
+    policy = _source_subtitle_mask_policy(work_dir)
+    if not policy.get("active"):
         return None
     ratio = max(0.0, min(0.5, float(CONFIG.get("source_subtitle_mask_ratio", 0.14) or 0.0)))
     # When we burn our OWN subtitle the band must sit behind it, but our subtitles are split into
@@ -1240,11 +2128,8 @@ def _amix_tail(narr_vol, bgm_chain=""):
 
 
 def _duck_ramp(s, e, fade):
-    """A 0→1 trapezoid over [s,e] with `fade`-second ramps at each edge (no clicks)."""
-    if float(fade or 0) <= 0:
-        return f"between(t,{s:.2f},{e:.2f})"
-    return f"min(1,max(0,min(t-{s:.2f},{e:.2f}-t)/{fade:.2f}))"
-
+    """Compatibility wrapper for the canonical pre-roll/hold/post-roll ramp."""
+    return duck_ramp_expression(s, e, fade)
 
 def _placement_windows(tts_segments, level_for):
     """Collect [(start, end, level)] placement windows for the placed beats, using
@@ -1261,57 +2146,34 @@ def _placement_windows(tts_segments, level_for):
 
 
 def _coalesce_duck_windows(windows, bridge):
-    """Merge placement windows whose gap is smaller than `bridge` into one held span,
-    so the duck stays low across short inter-beat gaps (a continuous bed) instead of the
-    original swelling back to idle between sentences. Each merged span keeps the
-    most-ducked (lowest) level of its members. Genuine gaps >= bridge survive as separate
-    dips, so the original still breathes there. `windows` is [(start, end, level)]."""
-    rel = sorted(([float(s), float(e), float(g)] for s, e, g in windows if e > s),
-                 key=lambda w: w[0])
-    if not rel:
-        return []
-    merged = [rel[0][:]]
-    for s, e, g in rel[1:]:
-        if s - merged[-1][1] < bridge:
-            merged[-1][1] = max(merged[-1][1], e)
-            merged[-1][2] = min(merged[-1][2], g)
-        else:
-            merged.append([s, e, g])
-    return merged
+    """Compatibility wrapper around the canonical audio automation coalescer."""
+    return coalesce_duck_windows(windows, bridge)
 
 
 def _duck_envelope(tts_segments, idle, speech_vol, quiet_vol, fade, bridge=None):
     """Per-beat ducking automation for the ORIGINAL track.
 
-    Ramps the original down under each placed narration window — to speech_vol where the
-    beat overlaps source dialogue, quiet_vol where it sits in a quiet window — and HOLDS
-    that duck across inter-beat gaps shorter than `bridge` so the source dialogue does not
-    pop back up between sentences. Only gaps >= bridge swell back to `idle` (lead-in/out
-    and deliberate long pauses). Returns a volume= expression, or None when no beat carries
-    placement info (caller falls back to a constant)."""
+    Uses the shared ducking contract: [start-fade,start] pre-roll ramp down,
+    [start,end] held at the selected duck level, and [end,end+fade] release.
+    Bridged spans use the most-ducked (lowest) level, matching timeline.json /
+    JianYing keyframes. Returns a volume= expression, or None when no beat carries
+    placement info (caller falls back to a constant).
+    """
     if bridge is None:
         bridge = 2 * float(fade or 0)
     windows = _placement_windows(
         tts_segments, lambda seg: speech_vol if seg.get("overlaps_speech", True) else quiet_vol)
-    merged = _coalesce_duck_windows(windows, bridge)
-    if not merged:
-        return None
-    terms = [f"+({level - idle:.3f})*{_duck_ramp(s, e, fade)}" for s, e, level in merged]
-    return f"max(0,min(1,{idle}{''.join(terms)}))"
+    merged = coalesce_duck_windows(windows, bridge)
+    return ducking_expression(merged, idle, fade)
 
 
 def _bgm_envelope(tts_segments, base, duck, fade, bridge=None):
-    """Per-beat ducking automation for the BGM track: hold the bed at `base`, dip to
-    `duck` under each narration window (held across gaps < `bridge`) so the voice stays
-    clear. None if no beats."""
+    """Per-beat ducking automation for the BGM track using the shared contract."""
     if bridge is None:
         bridge = 2 * float(fade or 0)
     windows = _placement_windows(tts_segments, lambda seg: duck)
-    merged = _coalesce_duck_windows(windows, bridge)
-    if not merged:
-        return None
-    terms = [f"+({lvl - base:.3f})*{_duck_ramp(s, e, fade)}" for s, e, lvl in merged]
-    return f"max(0,min(1,{base}{''.join(terms)}))"
+    merged = coalesce_duck_windows(windows, bridge)
+    return ducking_expression(merged, base, fade)
 
 
 def _build_audio_filter_complex(
@@ -1417,6 +2279,23 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     # 多轨时间线模型（timeline.json）：canonical 渲染仍是 ffmpeg，此模型供检视/可选导出
     _emit_timeline(input_video, tts_segments, work_dir, video_duration, has_bgm)
 
+    overlay_filters, overlay_qc = _visual_overlay_filters(work_dir, canvas, video_duration)
+    mask_filter = _source_subtitle_mask_filter(canvas, work_dir)
+    visual_qc = _build_visual_qc(
+        tts_segments,
+        work_dir,
+        video_duration,
+        canvas,
+        overlay_qc=overlay_qc,
+        mask_filter=mask_filter,
+    )
+    _write_visual_qc(work_dir, visual_qc)
+    assembly_qc_path = Path(work_dir) / ASSEMBLY_QC
+    assembly_qc_path.unlink(missing_ok=True)
+    if visual_qc.get("blocking"):
+        codes = ", ".join(visual_qc.get("blocking_codes", []))
+        raise RuntimeError(f"视觉 QC 失败: {codes}；详见 {Path(work_dir) / VISUAL_QC}")
+
     # 混合原始音频 + 解说音频（+ 可选 BGM）
     source_has_audio = _has_audio_stream(input_video)
     if source_has_audio:
@@ -1438,18 +2317,26 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
         bgm_audio_label=bgm_audio_label,
     )
 
+    # BGM is input [2:a]; -stream_loop -1 loops it to cover the whole timeline (amix
+    # duration=first + -t trim it back to the video length).
+    bgm_input = ["-stream_loop", "-1", "-i", str(bgm_path)] if has_bgm else []
+
     # 对于超长 volume 表达式（多段解说），使用 -filter_complex_script 避免命令行溢出
     # 末端整体响度归一：ducking 只管相对平衡，这一步统一成片绝对响度
     aout_label = "[aout]"
-    final_ln = final_loudnorm_filter()
+    loudnorm_measurement = _run_loudnorm_first_pass(
+        input_video,
+        narration_wav,
+        original_audio_input,
+        bgm_input,
+        filter_complex,
+        work_dir,
+    )
+    final_ln = final_loudnorm_filter(loudnorm_measurement)
     if final_ln:
         filter_complex += f";[aout]{final_ln}[aoutln]"
         aout_label = "[aoutln]"
         log(f"成片响度归一: {final_ln}")
-
-    # BGM is input [2:a]; -stream_loop -1 loops it to cover the whole timeline (amix
-    # duration=first + -t trim it back to the video length).
-    bgm_input = ["-stream_loop", "-1", "-i", str(bgm_path)] if has_bgm else []
 
     filter_complex_bytes = filter_complex.encode('utf-8')
     if len(filter_complex_bytes) > 8000:
@@ -1482,9 +2369,9 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     preset = str(CONFIG.get("output_preset", "veryfast") or "veryfast")
     max_h = int(CONFIG.get("output_max_height", 0) or 0)
     vf_chain = []
-    mask_filter = _source_subtitle_mask_filter(canvas)
     if mask_filter:
         vf_chain.append(mask_filter)
+    vf_chain.extend(overlay_filters)
     if CONFIG.get("burn_subtitles", False):
         vf_chain.append(_subtitle_burn_filter(ass_path))
     # Downscale LAST so the mask + burned subtitles render at native resolution and are then
@@ -1497,23 +2384,26 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
     # needs EVEN width AND height, so normalize odd dims (4:2:2/4:4:4 permit them) before the
     # encode — otherwise libx264 aborts to a 0-byte file. The downscale helper already evens out.
     even = "scale=trunc(iw/2)*2:trunc(ih/2)*2"
+    notes = []
     if vf_chain:
         if max_h <= 0:  # no downscale in the chain to force even dims
             vf_chain.append(even)
         cmd += ["-vf", ",".join(vf_chain), "-c:v", "libx264", "-preset", preset, "-crf", crf,
                 "-pix_fmt", "yuv420p"]
         notes = ((["遮挡原字幕"] if mask_filter else [])
+                 + ([f"视觉叠加×{len(overlay_filters)}"] if overlay_filters else [])
                  + (["压制解说字幕"] if CONFIG.get("burn_subtitles", False) else [])
                  + ([f"缩放≤{max_h}p"] if max_h > 0 else []))
         log(f"视频重编码: {' + '.join(notes)} (crf={crf}, preset={preset})")
     elif CONFIG.get("force_video_reencode", False):
+        notes = ["force_video_reencode"]
         cmd += ["-vf", even, "-c:v", "libx264", "-preset", preset, "-crf", crf, "-pix_fmt", "yuv420p"]
     else:
         cmd += ["-c:v", "copy"]
 
     # +faststart relocates the moov atom to the front so web/social players can start
     # before the full file downloads; valid (and beneficial) on the copy path too.
-    cmd += ["-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart",
+    cmd += ["-c:a", "aac", "-b:a", "192k", "-ar", "48000", "-movflags", "+faststart",
             "-t", str(video_duration), str(output_path)]
     try:
         result = run_cmd(cmd)
@@ -1525,37 +2415,74 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             fc_script.unlink(missing_ok=True)
 
     log(f"最终视频: {output_path} ({output_path.stat().st_size / 1024 / 1024:.1f}MB)")
+    _write_assembly_qc(
+        work_dir,
+        _build_assembly_qc(
+            tts_segments,
+            video_duration,
+            output_path=output_path,
+            source_has_audio=source_has_audio,
+            loudness_mode=_loudness_mode(loudnorm_measurement),
+            loudnorm_measurement=loudnorm_measurement,
+            visual_qc=visual_qc,
+            render_delivery={
+                "video_encode_passes": 1 if (vf_chain or CONFIG.get("force_video_reencode", False)) else 0,
+                "reencode_reason": notes if (vf_chain or CONFIG.get("force_video_reencode", False)) else [],
+                "audio_sample_rate": 48000,
+                "final_compat_notes": ["yuv420p"] if (vf_chain or CONFIG.get("force_video_reencode", False)) else ["video_copy", "aac_48000", "faststart"],
+            },
+        ),
+    )
     return output_path
 
 
-def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0):
-    """如果 TTS 音频超过目标时长，用 ffmpeg atempo 温和加速"""
+def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0, *, return_meta=True):
+    """Fit overlong TTS with bounded atempo; never time-trim speech in assemble.
+
+    Assemble has no word/sentence timestamps, so if bounded atempo cannot make the
+    audio fit, it returns `fit_status=no_safe_fit` and leaves the original audio
+    untouched for QC to block instead of guessing a spoken_text truncation.
+    """
     audio_path = Path(audio_path)
     current_dur = get_video_duration(audio_path)
+    budget = narration_tempo_budget(tts_rate_offset)
+    meta = {
+        "fit_status": "fits",
+        "blocking": False,
+        "tempo_factor": 1.0,
+        "segment_tempo_factor": 1.0,
+        "truncated": False,
+        "truncate_reason": "none",
+        "tts_rate_offset": float(tts_rate_offset or 0.0),
+        "audio_duration": current_dur,
+        "placed_audio_duration": current_dur,
+        "global_narration_speed": budget["global_narration_speed"],
+        "effective_tempo": budget["global_narration_speed"] * budget["tts_rate_factor"],
+        "cumulative_tempo_max": budget["cumulative_tempo_max"],
+        "cumulative_tempo_hard_max": budget["cumulative_tempo_hard_max"],
+    }
     if current_dur <= target_duration or current_dur == 0:
-        return str(audio_path), current_dur
+        return (str(audio_path), current_dur, meta)
 
     ratio = current_dur / target_duration
 
-    # 累积上限：TTS rate × atempo ≤ 1.2x
-    effective_max = 1.2 / (1.0 + tts_rate_offset)
-    effective_max = max(1.0, effective_max)
+    effective_max = budget["segment_tempo_max"]
 
     if ratio > effective_max:
-        # 实际截断到目标时长，加 fade-out 防止爆音
-        truncated_path = audio_path.with_name(f"{audio_path.stem}_cut{audio_path.suffix}")
-        fade_out = min(0.15, target_duration * 0.1)
-        cmd = ["ffmpeg", "-y", "-i", str(audio_path),
-               "-t", f"{target_duration:.3f}",
-               "-af", f"afade=t=out:st={max(0, target_duration - fade_out):.3f}:d={fade_out:.3f}",
-               "-ar", "44100", "-ac", "1", str(truncated_path)]
-        result = run_cmd(cmd)
-        if result.returncode == 0:
-            new_dur = get_video_duration(truncated_path)
-            log(f"  TTS 截断: {current_dur:.1f}s → {new_dur:.1f}s (无法加速到 x{ratio:.2f})")
-            return str(truncated_path), new_dur
-        log(f"  警告: TTS 截断失败，保留原音频 ({current_dur:.1f}s)")
-        return str(audio_path), current_dur
+        meta.update({
+            "fit_status": "no_safe_fit",
+            "blocking": True,
+            "truncate_reason": "no_safe_boundary",
+            "placed_audio_duration": 0.0,
+            "needed_tempo_factor": ratio,
+            "segment_tempo_factor": 1.0,
+            "tempo_factor": 1.0,
+        })
+        log(
+            f"  TTS 无安全放置: {current_dur:.1f}s 需 x{ratio:.2f}，"
+            f"超过段内预算 x{effective_max:.2f}（assemble 不按时间硬切）"
+        )
+        return (str(audio_path), current_dur, meta)
 
     # 温和加速
     tempo = min(ratio, effective_max)
@@ -1566,9 +2493,18 @@ def _adjust_tts_speed(audio_path, target_duration, work_dir, tts_rate_offset=0.0
     result = run_cmd(cmd)
     if result.returncode == 0:
         new_dur = get_video_duration(adjusted_path)
+        meta.update({
+            "fit_status": "tempo_adjusted",
+            "tempo_factor": tempo,
+            "segment_tempo_factor": tempo,
+            "placed_audio_duration": new_dur,
+            "effective_tempo": budget["global_narration_speed"] * budget["tts_rate_factor"] * tempo,
+        })
         log(f"  TTS 温和加速: {current_dur:.1f}s → {new_dur:.1f}s (x{tempo:.2f})")
-        return str(adjusted_path), new_dur
-    return str(audio_path), current_dur
+        return (str(adjusted_path), new_dur, meta)
+    meta["fit_status"] = "speed_adjust_failed"
+    meta["truncate_reason"] = "resample_failed"
+    return (str(audio_path), current_dur, meta)
 
 
 def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
@@ -1580,6 +2516,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
     prev_pause_samples = 0  # 前一段的 pause_after_ms，控制段间间隔
     skipped_count = 0  # 因 WAV 缺失/损坏/重采样失败而被跳过的段数
     placed_count = 0  # 真正写入音频的段数；防止"成功"生成全静音旁白
+    no_safe_fit_count = 0  # 超预算但不能安全截断；交由 QC/manifest 阻断
     prev_authored_end = None  # 上一段作者标注的结束时间，用于判断"段落"边界
     run_gap = float(CONFIG.get("narration_run_gap_seconds", 1.6))   # 作者留白 > 此值 = 新段落
     tighten = bool(CONFIG.get("narration_tighten", True))
@@ -1588,6 +2525,20 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
     max_pull_samples = int(max(0.0, float(CONFIG.get("narration_max_pull_seconds", 2.5))) * sample_rate)
 
     for seg in tts_segments:
+        seg.setdefault("segment_audio_schema_version", SEGMENT_AUDIO_SCHEMA_VERSION)
+        seg.setdefault("narration", str(seg.get("narration") or seg.get("spoken_text") or ""))
+        seg.setdefault("spoken_text", str(seg.get("spoken_text") or seg.get("narration") or ""))
+        seg.setdefault("truncated", False)
+        seg.setdefault("truncate_reason", "none")
+        seg.setdefault("fit_status", "pending_assembly")
+        seg.setdefault("blocking", False)
+        seg.setdefault("segment_tempo_factor", 1.0)
+        seg.setdefault("global_narration_speed", float(CONFIG.get("narration_speed", 1.0) or 1.0))
+        rate_factor = 1.0 + float(seg.get("tts_rate_offset", 0.0) or 0.0)
+        seg.setdefault("effective_tempo", float(seg["global_narration_speed"]) * rate_factor * float(seg.get("segment_tempo_factor", 1.0) or 1.0))
+        seg.setdefault("rms_dbfs_before", None)
+        seg.setdefault("rms_dbfs_after", None)
+        seg.setdefault("peak_after", None)
         wav_path = seg["audio_path"]
         seg_pause_ms = seg.get("pause_after_ms", CONFIG.get("breath_ms", 250))
         # 段落收紧：同一段落内（与上一句作者留白 <= run_gap）把这一句紧贴上一句的实际收尾播放，
@@ -1601,6 +2552,9 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         if not os.path.exists(wav_path):
             seg["actual_place_start"] = seg["start"]
             seg["actual_place_end"] = seg["start"]
+            seg["placed_audio_duration"] = 0.0
+            seg["fit_status"] = "skipped"
+            seg["truncate_reason"] = "missing_wav"
             prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
             skipped_count += 1
             continue
@@ -1616,6 +2570,9 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
                     log(f"  跳过非标准 WAV: {wav_path} (channels={wf_channels}, sampwidth={wf_sampwidth}), 需要 mono 16-bit")
                     seg["actual_place_start"] = seg["start"]
                     seg["actual_place_end"] = seg["start"]
+                    seg["placed_audio_duration"] = 0.0
+                    seg["fit_status"] = "skipped"
+                    seg["truncate_reason"] = "resample_failed"
                     prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
                     skipped_count += 1
                     continue
@@ -1625,6 +2582,9 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
             log(f"  WAV 读取失败: {wav_path}: {e}")
             seg["actual_place_start"] = seg["start"]
             seg["actual_place_end"] = seg["start"]
+            seg["placed_audio_duration"] = 0.0
+            seg["fit_status"] = "skipped"
+            seg["truncate_reason"] = "missing_wav"
             prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
             skipped_count += 1
             continue
@@ -1656,9 +2616,45 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         available_samples = end_boundary - actual_start
         available_duration = max(available_samples / sample_rate, 0)
         if tts_dur > available_duration > 0:
-            wav_path, _actual_dur = _adjust_tts_speed(wav_path, available_duration, work_dir, tts_rate_offset)
+            try:
+                wav_path, _actual_dur, fit_meta = _adjust_tts_speed(
+                    wav_path, available_duration, work_dir, tts_rate_offset, return_meta=True)
+            except TypeError:
+                # Tests/older extensions may monkeypatch the old signature; normalize it.
+                adjusted_result = _adjust_tts_speed(wav_path, available_duration, work_dir, tts_rate_offset)
+                if len(adjusted_result) == 2:
+                    wav_path, _actual_dur = adjusted_result
+                    fit_meta = {
+                        "fit_status": "tempo_adjusted" if wav_path != original_wav_path else "fits",
+                        "segment_tempo_factor": 1.0,
+                        "effective_tempo": narration_tempo_budget(tts_rate_offset)["global_narration_speed"],
+                        "global_narration_speed": narration_tempo_budget(tts_rate_offset)["global_narration_speed"],
+                        "truncate_reason": "none",
+                    }
+                else:
+                    wav_path, _actual_dur, fit_meta = adjusted_result
+            seg.update({
+                "fit_status": fit_meta["fit_status"],
+                "segment_tempo_factor": fit_meta.get("segment_tempo_factor", 1.0),
+                "effective_tempo": fit_meta.get("effective_tempo", seg.get("effective_tempo")),
+                "global_narration_speed": fit_meta.get("global_narration_speed", seg.get("global_narration_speed")),
+                "blocking": bool(fit_meta.get("blocking", False)),
+            })
+            if fit_meta["fit_status"] == "no_safe_fit":
+                seg["actual_place_start"] = actual_start / sample_rate
+                seg["actual_place_end"] = actual_start / sample_rate
+                seg["placed_audio_duration"] = 0.0
+                seg["truncate_reason"] = fit_meta["truncate_reason"]
+                prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+                skipped_count += 1
+                no_safe_fit_count += 1
+                continue
         else:
-            pass  # tts_dur <= available_duration, no speed adjust needed
+            budget = narration_tempo_budget(tts_rate_offset)
+            seg["fit_status"] = "fits"
+            seg["segment_tempo_factor"] = 1.0
+            seg["global_narration_speed"] = budget["global_narration_speed"]
+            seg["effective_tempo"] = budget["global_narration_speed"] * budget["tts_rate_factor"]
 
         # _adjust_tts_speed 输出固定 44100Hz mono 16bit，若文件被替换则无需 resample
         if wav_path != original_wav_path:
@@ -1672,6 +2668,9 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
                 log(f"  重采样失败，跳过本段: {wav_path}: {rs_result.stderr}")
                 seg["actual_place_start"] = seg["start"]
                 seg["actual_place_end"] = seg["start"]
+                seg["placed_audio_duration"] = 0.0
+                seg["fit_status"] = "skipped"
+                seg["truncate_reason"] = "resample_failed"
                 prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
                 skipped_count += 1
                 continue
@@ -1683,17 +2682,35 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         # 按场景边界裁剪
         audio_samples = len(wf_data) // 2
         available = end_boundary - actual_start
-        write_samples = min(audio_samples, max(available, 0))
+        write_samples = audio_samples
 
-        if write_samples <= 0:
+        if write_samples <= 0 or available <= 0:
             log(f"  跳过: {seg['start']:.1f}s-{seg['end']:.1f}s (无空间)")
             seg["actual_place_start"] = seg["start"]
             seg["actual_place_end"] = seg["start"]
+            seg["placed_audio_duration"] = 0.0
+            seg["fit_status"] = "no_safe_fit"
+            seg["blocking"] = True
+            seg["truncate_reason"] = "no_room"
             prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+            no_safe_fit_count += 1
             continue
 
-        # 裁剪到写入长度
-        wf_data = wf_data[:write_samples * 2]
+        if audio_samples > available:
+            # Do not cut spoken audio by time alone. Without upstream boundary
+            # metadata, assemble cannot prove which text would remain spoken.
+            over = (audio_samples - available) / sample_rate
+            log(f"  TTS 无安全放置: 段 {seg.get('index', '?')} 超出可用窗口 {over:.2f}s，跳过并交由 QC 阻断")
+            seg["actual_place_start"] = actual_start / sample_rate
+            seg["actual_place_end"] = actual_start / sample_rate
+            seg["placed_audio_duration"] = 0.0
+            seg["fit_status"] = "no_safe_fit"
+            seg["blocking"] = True
+            seg["truncate_reason"] = "no_safe_boundary"
+            prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+            skipped_count += 1
+            no_safe_fit_count += 1
+            continue
 
         # 重叠检测：跳过与前段重叠的部分（在 fade 之前，避免截断后丢失 fade-in）
         if actual_start < last_written_end:
@@ -1703,16 +2720,30 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
                     f"(与前段重叠 {overlap_ms:.0f}ms)")
                 seg["actual_place_start"] = seg["start"]
                 seg["actual_place_end"] = seg["start"]
+                seg["placed_audio_duration"] = 0.0
+                seg["fit_status"] = "no_safe_fit"
+                seg["blocking"] = True
+                seg["truncate_reason"] = "no_room"
                 prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+                no_safe_fit_count += 1
                 continue
-            log(f"  重叠 {overlap_ms:.0f}ms，截断前部")
-            skip_samples = last_written_end - actual_start
-            wf_data = wf_data[skip_samples * 2:]
-            write_samples -= skip_samples
             actual_start = last_written_end
+            available = end_boundary - actual_start
+            if write_samples > available:
+                log(f"  重叠 {overlap_ms:.0f}ms 后无安全完整窗口，跳过")
+                seg["actual_place_start"] = actual_start / sample_rate
+                seg["actual_place_end"] = actual_start / sample_rate
+                seg["placed_audio_duration"] = 0.0
+                seg["fit_status"] = "no_safe_fit"
+                seg["blocking"] = True
+                seg["truncate_reason"] = "no_safe_boundary"
+                prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+                skipped_count += 1
+                no_safe_fit_count += 1
+                continue
 
         # fade-in / fade-out（在 overlap 裁剪之后应用，确保正确的音频包络）
-        fade_len = min(int(CONFIG.get("fade_ms", 300) * sample_rate / 1000), write_samples // 4)
+        fade_len = min(int(CONFIG.get("fade_ms", 120) * sample_rate / 1000), write_samples // 4)
         for i in range(fade_len):
             gain = i / fade_len
             s = i * 2
@@ -1731,6 +2762,11 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         buffer[actual_start * 2: actual_start * 2 + write_samples * 2] = wf_data
         seg["actual_place_start"] = actual_start / sample_rate
         seg["actual_place_end"] = (actual_start + write_samples) / sample_rate
+        seg["placed_audio_duration"] = write_samples / sample_rate
+        if seg.get("fit_status") == "pending_assembly":
+            seg["fit_status"] = "fits"
+        if seg.get("truncate_reason") in (None, ""):
+            seg["truncate_reason"] = "none"
         last_written_end = actual_start + write_samples
         prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
         placed_count += 1
@@ -1741,7 +2777,7 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
         wf.setframerate(sample_rate)
         wf.writeframes(bytes(buffer))
 
-    if tts_segments and placed_count == 0:
+    if tts_segments and placed_count == 0 and no_safe_fit_count == 0:
         output_wav.unlink(missing_ok=True)
         raise RuntimeError(
             f"全部 {len(tts_segments)} 段解说均被跳过或未能写入"

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -2686,20 +2686,33 @@ def _build_timed_narration(tts_segments, output_wav, video_duration, work_dir):
             continue
 
         if audio_samples > available:
-            # Do not cut spoken audio by time alone. Without upstream boundary
-            # metadata, assemble cannot prove which text would remain spoken.
-            over = (audio_samples - available) / sample_rate
-            log(f"  TTS 无安全放置: 段 {seg.get('index', '?')} 超出可用窗口 {over:.2f}s，跳过并交由 QC 阻断")
-            seg["actual_place_start"] = actual_start / sample_rate
-            seg["actual_place_end"] = actual_start / sample_rate
-            seg["placed_audio_duration"] = 0.0
-            seg["fit_status"] = "no_safe_fit"
-            seg["blocking"] = True
-            seg["truncate_reason"] = "no_safe_boundary"
-            prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
-            skipped_count += 1
-            no_safe_fit_count += 1
-            continue
+            over_samples = audio_samples - available
+            # A rounding-level overrun (a few samples of post-atempo tail decay, far under a
+            # syllable) must NOT discard the whole block: the segment was already speed-fit to
+            # `available_duration`, so the sub-frame tail is release/silence, not dropped words.
+            # Trim that tail instead of dropping + QC-blocking; only a real overrun (> tolerance)
+            # is deferred to QC. Fixes whole blocks lost on a 0.00–0.01s miss.
+            trim_tolerance = int(round(0.05 * sample_rate))  # 50ms
+            if over_samples <= trim_tolerance:
+                audio_samples = available
+                write_samples = available
+                wf_data = wf_data[: write_samples * 2]
+                seg["truncate_reason"] = "tail_trim_tolerance"
+            else:
+                # Do not cut spoken audio by time alone. Without upstream boundary
+                # metadata, assemble cannot prove which text would remain spoken.
+                over = over_samples / sample_rate
+                log(f"  TTS 无安全放置: 段 {seg.get('index', '?')} 超出可用窗口 {over:.2f}s，跳过并交由 QC 阻断")
+                seg["actual_place_start"] = actual_start / sample_rate
+                seg["actual_place_end"] = actual_start / sample_rate
+                seg["placed_audio_duration"] = 0.0
+                seg["fit_status"] = "no_safe_fit"
+                seg["blocking"] = True
+                seg["truncate_reason"] = "no_safe_boundary"
+                prev_pause_samples = int(seg_pause_ms * sample_rate / 1000)
+                skipped_count += 1
+                no_safe_fit_count += 1
+                continue
 
         # 重叠检测：跳过与前段重叠的部分（在 fade 之前，避免截断后丢失 fade-in）
         if actual_start < last_written_end:

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -1770,7 +1770,6 @@ def _visual_overlay_filters(work_dir, canvas, video_duration):
     Unsupported types are QC-blocking and deliberately do not silently render.
     """
     overlays, source = _load_visual_overlays(work_dir, with_source=True)
-    width = int((canvas or {}).get("width") or 1280)
     height = int((canvas or {}).get("height") or 720)
     default_top_y = max(24, round(height * 0.05))
     filters = []

--- a/skills/video-assemble/scripts/audio_automation.py
+++ b/skills/video-assemble/scripts/audio_automation.py
@@ -1,0 +1,140 @@
+"""Shared audio automation semantics for ffmpeg render and editable timelines.
+
+This module is stdlib-only and is the single source for ducking window coalescing,
+pre-roll/hold/post-roll gain shape, timeline keyframes, and ffmpeg volume terms.
+"""
+
+
+def _round_keyframe(t_s, gain):
+    return {"t": round(float(t_s), 4), "gain": round(float(gain), 4)}
+
+
+def default_bridge(fade):
+    return 2 * float(fade or 0)
+
+
+def coalesce_duck_windows(windows, bridge):
+    """Merge [(start, end, gain)] windows separated by gaps below `bridge`.
+
+    A bridged mixed-level span uses the lowest gain across all members so neither
+    ffmpeg nor timeline export swells louder in the bridged gap.
+    """
+    rel = sorted(
+        ([float(s), float(e), float(g)] for s, e, g in windows if float(e) > float(s)),
+        key=lambda w: w[0],
+    )
+    if not rel:
+        return []
+    bridge = float(bridge or 0)
+    merged = [rel[0][:]]
+    for s, e, gain in rel[1:]:
+        if s - merged[-1][1] < bridge:
+            merged[-1][1] = max(merged[-1][1], e)
+            merged[-1][2] = min(merged[-1][2], gain)
+        else:
+            merged.append([s, e, gain])
+    return merged
+
+
+def _t_minus(value):
+    value = float(value)
+    if value < 0:
+        return f"t+{abs(value):.2f}"
+    return f"t-{value:.2f}"
+
+
+def duck_ramp_expression(start, end, fade):
+    """Return ffmpeg expression for the canonical duck shape.
+
+    Semantics: ramp down during [start-fade, start], hold fully ducked on
+    [start, end], and release during [end, end+fade].
+    """
+    start = float(start)
+    end = float(end)
+    fade = float(fade or 0)
+    if fade <= 0:
+        return f"between(t,{start:.2f},{end:.2f})"
+    ramp_start = start - fade
+    ramp_end = end + fade
+    return f"min(1,max(0,min({_t_minus(ramp_start)},{ramp_end:.2f}-t)/{fade:.2f}))"
+
+
+def duck_ramp_gain(start, end, fade, t):
+    """Numeric gain weight (0..1) for the canonical duck shape."""
+    start = float(start)
+    end = float(end)
+    fade = float(fade or 0)
+    t = float(t)
+    if end <= start:
+        return 0.0
+    if fade <= 0:
+        return 1.0 if start <= t <= end else 0.0
+    return max(0.0, min(1.0, min(t - (start - fade), (end + fade) - t) / fade))
+
+
+def ducking_gain_at(windows, idle, fade, t):
+    """Evaluate gain at time `t` for already-coalesced [(s,e,gain)] windows."""
+    idle = float(idle)
+    gain = idle
+    for s, e, level in windows:
+        gain += (float(level) - idle) * duck_ramp_gain(s, e, fade, t)
+    return max(0.0, min(1.0, gain))
+
+
+def ducking_expression(windows, idle, fade):
+    """Build the ffmpeg volume expression for coalesced duck windows."""
+    merged = list(windows or [])
+    if not merged:
+        return None
+    idle = float(idle)
+    terms = [
+        f"+({float(level) - idle:.3f})*{duck_ramp_expression(s, e, fade)}"
+        for s, e, level in merged
+    ]
+    return f"max(0,min(1,{idle}{''.join(terms)}))"
+
+
+def variable_ducking_keyframes(windows, idle, fade, span_start, span_end, bridge=None):
+    """Volume keyframes for per-window duck gains using canonical semantics."""
+    fade = float(fade or 0)
+    if bridge is None:
+        bridge = default_bridge(fade)
+    span_start = float(span_start)
+    span_end = float(span_end)
+    rel = sorted(
+        (max(span_start, float(w[0])), min(span_end, float(w[1])), float(w[2]))
+        for w in windows
+        if float(w[1]) > span_start and float(w[0]) < span_end and float(w[1]) > float(w[0])
+    )
+    merged = coalesce_duck_windows(rel, bridge)
+    if not merged:
+        return []
+
+    pts = [(span_start, float(idle))]
+    for s, e, level in merged:
+        pts.append((max(span_start, s - fade), float(idle)))
+        pts.append((s, level))
+        pts.append((e, level))
+        pts.append((min(span_end, e + fade), float(idle)))
+    pts.append((span_end, float(idle)))
+
+    pts.sort(key=lambda p: p[0])
+    out = []
+    for t, gain in pts:
+        if out and abs(out[-1][0] - t) < 1e-4:
+            out[-1] = (t, min(out[-1][1], gain))
+        else:
+            out.append((t, gain))
+    return [_round_keyframe(t, gain) for t, gain in out]
+
+
+def fixed_ducking_keyframes(windows, idle, duck, fade, span_start, span_end, bridge=None):
+    """Volume keyframes for fixed-gain duck windows using canonical semantics."""
+    return variable_ducking_keyframes(
+        [(float(s), float(e), float(duck)) for s, e in windows],
+        idle,
+        fade,
+        span_start,
+        span_end,
+        bridge=bridge,
+    )

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 
 # ── 配置 ──────────────────────────────────────────────────────────────
+_EXISTING_CONFIG_REF = globals().get("CONFIG")
 
 DEFAULT_MIMO_API_URL = "https://api.xiaomimimo.com/v1"
 DEFAULT_MIMO_TOKEN_PLAN_CLUSTER = "cn"
@@ -231,8 +232,16 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
+    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
+    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
+    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
+    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", False),  # 遮挡原片烧录字幕；必须配合显式 SOURCE_SUBTITLE_MASK_POLICY
+    "source_subtitle_mask_policy_declared": bool(os.environ.get("SOURCE_SUBTITLE_MASK_POLICY", "").strip()),
+    "source_subtitle_mask_policy": (
+        os.environ.get("SOURCE_SUBTITLE_MASK_POLICY", "").strip().lower()
+        or "off"
+    ),  # off | opt_in | safe | forced；MASK_SOURCE_SUBTITLES alone is legacy implicit and QC-blocking
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说（仅用于段落起点）
     "narration_tighten": env_bool("NARRATION_TIGHTEN", True),  # 段落内把句子紧贴上一句实际收尾播放，句间间隔稳定≤tight_pause，杜绝"一句解说一段空白"的卡顿
@@ -267,6 +276,9 @@ CONFIG = {
     "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
     "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
     "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
+    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
+    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
+    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
     "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
@@ -286,6 +298,7 @@ CONFIG = {
     "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
     "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
     "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
+    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
     "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
     "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
     "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
@@ -297,12 +310,42 @@ CONFIG = {
     "subtitle_margin_r": env_int("SUBTITLE_MARGIN_R", 40, minimum=0),
     "subtitle_alignment": env_int("SUBTITLE_ALIGNMENT", 2, minimum=1),
     "subtitle_max_chars": env_int("SUBTITLE_MAX_CHARS", 20, minimum=6),
+    "subtitle_max_lines": env_int("SUBTITLE_MAX_LINES", 2, minimum=1),
     "subtitle_play_res_x": env_int("SUBTITLE_PLAY_RES_X", 1280, minimum=1),
     "subtitle_play_res_y": env_int("SUBTITLE_PLAY_RES_Y", 720, minimum=1),
 }
+if isinstance(_EXISTING_CONFIG_REF, dict):
+    _EXISTING_CONFIG_REF.clear()
+    _EXISTING_CONFIG_REF.update(CONFIG)
+    CONFIG = _EXISTING_CONFIG_REF
 
 SCRIPT_DIR = Path(__file__).parent
 PROMPTS_DIR = SCRIPT_DIR.parent / "references"
+
+def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):
+    """Return the canonical tempo budget shared by voiceover and assemble.
+
+    `effective_tempo` is the user-perceived cumulative compression:
+    TTS rate × global narration atempo × per-segment atempo.  The segment atempo
+    cap is therefore tightened by the configured global speed and TTS rate
+    offset; callers must fail/shorten instead of time-trimming speech when the
+    needed ratio exceeds `segment_tempo_max`.
+    """
+    cfg = config or CONFIG
+    global_speed = max(0.01, float(cfg.get("narration_speed", 1.0) or 1.0))
+    rate_factor = max(0.01, 1.0 + float(tts_rate_offset or 0.0))
+    cumulative_max = max(1.0, float(cfg.get("narration_cumulative_tempo_max", 1.35) or 1.35))
+    hard_max = max(cumulative_max, float(cfg.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40))
+    legacy_segment_cap = max(1.0, float(cfg.get("tts_segment_tempo_max", 1.20) or 1.20))
+    segment_tempo_max = max(1.0, min(legacy_segment_cap, cumulative_max / (global_speed * rate_factor)))
+    return {
+        "global_narration_speed": global_speed,
+        "tts_rate_factor": rate_factor,
+        "cumulative_tempo_max": cumulative_max,
+        "cumulative_tempo_hard_max": hard_max,
+        "segment_tempo_max": segment_tempo_max,
+        "max_raw_duration_factor": global_speed * segment_tempo_max,
+    }
 
 def log(msg):
     print(f"[video-recap] {msg}", flush=True)

--- a/skills/video-assemble/scripts/timeline.py
+++ b/skills/video-assemble/scripts/timeline.py
@@ -11,118 +11,19 @@ set of tracks — exactly like a cut-tool project:
   - an optional **bgm** audio track: a looped music bed with its own ducking;
   - one **subtitle** (text) track: the narration lines.
 
-The canonical renderer is still ffmpeg (`assemble.py`); this model is what it
-emits as `timeline.json` and what the *optional* 剪映 exporter consumes. The
-model itself knows nothing about ffmpeg or 剪映 — times are plain seconds and
-volumes are plain gains, so any backend can read it.
+The canonical ducking semantics live in `audio_automation.py`; ffmpeg
+(`assemble.py`) and this timeline model both derive their automation from that
+shared source. This model is emitted as `timeline.json` and consumed by the
+*optional* 剪映 exporter. The model itself knows nothing about ffmpeg or 剪映 —
+times are plain seconds and volumes are plain gains, so any backend can read it.
 """
 
 import json
 
+from audio_automation import fixed_ducking_keyframes as ducking_keyframes
+from audio_automation import variable_ducking_keyframes
+
 SCHEMA_VERSION = 1
-
-
-def _kf(t_s, gain):
-    return {"t": round(float(t_s), 4), "gain": round(float(gain), 4)}
-
-
-def ducking_keyframes(windows, idle, duck, fade, span_start, span_end, bridge=None):
-    """Volume automation for a track that holds at `idle` and dips to `duck`
-    under each narration window, with `fade`-second linear ramps.
-
-    `windows` is a list of (start_s, end_s) narration spans (timeline-absolute).
-    Returns timeline-absolute [{t, gain}] keyframes clamped to [span_start,
-    span_end]; empty when there is nothing to automate (caller uses a flat gain).
-    """
-    if bridge is None:
-        bridge = 2 * fade
-    rel = sorted((max(span_start, w[0]), min(span_end, w[1]))
-                 for w in windows if w[1] > span_start and w[0] < span_end and w[1] > w[0])
-    if not rel:
-        return []
-    # Coalesce windows whose gap is below `bridge`: with no room to ramp back to idle and
-    # down again between them, the duck must stay held — otherwise the original would pump
-    # up and back down between sentences. Genuine gaps (>= bridge) survive as a plateau, so
-    # the original still swells there.
-    merged = [list(rel[0])]
-    for s, e in rel[1:]:
-        if s - merged[-1][1] < bridge:
-            merged[-1][1] = max(merged[-1][1], e)
-        else:
-            merged.append([s, e])
-    pts = [(span_start, idle)]
-    for s, e in merged:
-        # hold the duck across the merged window; ramp in just before, release just after
-        pts.append((max(span_start, s - fade), idle))
-        pts.append((s, duck))
-        pts.append((e, duck))
-        pts.append((min(span_end, e + fade), idle))
-    pts.append((span_end, idle))
-    # sort by time, collapse points at the same instant (last wins for a clean step)
-    pts.sort(key=lambda p: p[0])
-    out = []
-    for t, g in pts:
-        if out and abs(out[-1][0] - t) < 1e-4:
-            out[-1] = (t, g)
-        else:
-            out.append((t, g))
-    return [_kf(t, g) for t, g in out]
-
-
-def _coalesce_windows(rel, bridge):
-    """Merge sorted (start, end, level) windows whose gap is below `bridge` into one held
-    span at the most-ducked (min) level. This is the SAME coalescing the ffmpeg render path
-    uses (assemble._coalesce_duck_windows), so the exported 剪映 draft matches the rendered
-    mix exactly even when a bridged span mixes speech (louder) and quiet (deeper) beats."""
-    if not rel:
-        return []
-    merged = [list(rel[0])]
-    for s, e, level in rel[1:]:
-        if s - merged[-1][1] < bridge:
-            merged[-1][1] = max(merged[-1][1], e)
-            merged[-1][2] = min(merged[-1][2], level)
-        else:
-            merged.append([s, e, level])
-    return merged
-
-
-def variable_ducking_keyframes(windows, idle, fade, span_start, span_end, bridge=None):
-    """Volume automation with a per-window duck gain.
-
-    `windows` is [(start_s, end_s, duck_gain)]. Windows whose gap is below `bridge` coalesce
-    into one held span at the most-ducked level (matching the renderer), so the original stays
-    ducked across short inter-sentence gaps instead of swelling back to idle; only the
-    lead-in/out and genuine gaps >= bridge return to idle. Defaults bridge to 2*fade.
-    """
-    if bridge is None:
-        bridge = 2 * fade
-    rel = sorted(
-        (max(span_start, float(w[0])), min(span_end, float(w[1])), float(w[2]))
-        for w in windows
-        if float(w[1]) > span_start and float(w[0]) < span_end and float(w[1]) > float(w[0])
-    )
-    merged = _coalesce_windows(rel, bridge)
-    if not merged:
-        return []
-
-    pts = [(span_start, idle)]
-    for s, e, level in merged:
-        # hold the duck across the merged span; ramp in just before, release just after
-        pts.append((max(span_start, s - fade), idle))
-        pts.append((s, level))
-        pts.append((e, level))
-        pts.append((min(span_end, e + fade), idle))
-    pts.append((span_end, idle))
-
-    pts.sort(key=lambda p: p[0])
-    out = []
-    for t, g in pts:
-        if out and abs(out[-1][0] - t) < 1e-4:
-            # coincident points (overlapping ramps): prefer the lower gain, no swell
-            out[-1] = (t, min(out[-1][1], g))
-        else:
-            out.append((t, g))
-    return [_kf(t, g) for t, g in out]
 
 
 def build_timeline(canvas, duration_s, video_clips, narration_segments,

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -1465,9 +1465,15 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
         # segment to one canvas and give every clip an audio segment (real or synthesized
         # silence) so concat always succeeds with a continuous track and no source's audio
         # is dropped just because a sibling source is silent.
-        canvas_w, canvas_h, canvas_fps, geometry_qc = _select_output_geometry(source_paths, clips)
-        qc["output_geometry"] = geometry_qc
-        qc["output_geometry_reason"] = geometry_qc.get("reason")
+        # Reuse the geometry already probed+stored above (guard) or by main() — the
+        # selection is deterministic, so re-probing every source here is wasted ffprobe work.
+        geometry_qc = qc.get("output_geometry")
+        if isinstance(geometry_qc, dict) and all(geometry_qc.get(k) for k in ("width", "height", "fps")):
+            canvas_w, canvas_h, canvas_fps = int(geometry_qc["width"]), int(geometry_qc["height"]), geometry_qc["fps"]
+        else:
+            canvas_w, canvas_h, canvas_fps, geometry_qc = _select_output_geometry(source_paths, clips)
+            qc["output_geometry"] = geometry_qc
+            qc["output_geometry_reason"] = geometry_qc.get("reason")
         vnorm = (f"scale={canvas_w}:{canvas_h}:force_original_aspect_ratio=decrease,"
                  f"pad={canvas_w}:{canvas_h}:(ow-iw)/2:(oh-ih)/2,setsar=1,"
                  f"fps={canvas_fps},format=yuv420p")

--- a/skills/video-cut/scripts/cut.py
+++ b/skills/video-cut/scripts/cut.py
@@ -9,6 +9,10 @@ from pathlib import Path
 from lib import CONFIG, get_video_duration, log, run_cmd
 
 
+EDITED_SOURCE_RENDER_ALGORITHM_VERSION = "edited-source-render-v3"
+GEOMETRY_RENDER_ALGORITHM_VERSION = "geometry-weighted-orientation-area-fps-v2"
+
+
 def parse_duration_seconds(value):
     """Parse seconds, 10m/1h forms, or HH:MM:SS into seconds."""
     if value is None or value == "":
@@ -96,6 +100,8 @@ def cut_plan_fingerprint(validated_plan):
         payload = dict(validated_plan)
         # Provenance for raw-plan freshness is not part of the edited media bytes.
         payload.pop("raw_plan_fingerprint", None)
+        # QC is observability derived from the media plan, not an input range decision.
+        payload.pop("qc", None)
     else:
         payload = validated_plan
     return value_fingerprint(payload)
@@ -139,6 +145,23 @@ def _source_fingerprints_for_plan(validated_plan, input_video=None):
     return fingerprints
 
 
+def edited_source_render_cache_payload():
+    """Render-affecting settings that invalidate edited_source.mp4 cache reuse.
+
+    Keep this payload limited to inputs/algorithms that can change rendered media bytes.
+    Observational QC produced after validation/render is intentionally excluded.
+    """
+    return {
+        "render_algorithm_version": EDITED_SOURCE_RENDER_ALGORITHM_VERSION,
+        "geometry_render_algorithm_version": GEOMETRY_RENDER_ALGORITHM_VERSION,
+        "clip_join_audio_fade_ms": round(max(0.0, float(CONFIG.get("clip_join_audio_fade_ms", 30.0) or 0.0)), 3),
+    }
+
+
+def edited_source_render_fingerprint():
+    return value_fingerprint(edited_source_render_cache_payload())
+
+
 def _write_edited_source_meta(output_path, validated_plan, input_video=None):
     meta_path = _edited_source_meta_path(output_path)
     source_fingerprints = _source_fingerprints_for_plan(validated_plan, input_video)
@@ -154,11 +177,16 @@ def _write_edited_source_meta(output_path, validated_plan, input_video=None):
     meta = {
         "schema_version": 2,
         "clip_plan_fingerprint": cut_plan_fingerprint(validated_plan),
+        "render_fingerprint": edited_source_render_fingerprint(),
+        "render_cache": edited_source_render_cache_payload(),
         "source_fingerprints": source_fingerprints,
         "edited_source_fingerprint": file_fingerprint(output_path),
         "total_duration": validated_plan.get("total_duration"),
         "clip_count": len(validated_plan.get("clips", [])),
     }
+    delivery_qc = (validated_plan.get("qc") or {}).get("delivery_qc")
+    if delivery_qc:
+        meta["delivery_qc"] = delivery_qc
     # Preserve the legacy key for existing single-source callers/tests/metadata readers.
     if legacy_source_fp is not None:
         meta["source_video_fingerprint"] = legacy_source_fp
@@ -172,6 +200,8 @@ def should_reuse_edited_source(output_path, validated_plan, input_video=None):
         return False
     meta = _load_edited_source_meta(output_path)
     if not meta or meta.get("clip_plan_fingerprint") != cut_plan_fingerprint(validated_plan):
+        return False
+    if meta.get("render_fingerprint") != edited_source_render_fingerprint():
         return False
     expected_sources = _source_fingerprints_for_plan(validated_plan, input_video)
     meta_sources = meta.get("source_fingerprints")
@@ -409,6 +439,151 @@ def normalize_clip_plan(raw_plan, video_duration, target_duration=None, clip_pad
     return plan
 
 
+def _valid_silence_windows(silence_periods):
+    """Return sorted well-formed quiet windows as {start,end} floats."""
+    windows = []
+    for w in silence_periods or []:
+        if not isinstance(w, dict):
+            continue
+        try:
+            start = float(w.get("start"))
+            end = float(w.get("end"))
+        except (TypeError, ValueError):
+            continue
+        if end >= start:
+            windows.append({"start": start, "end": end})
+    return sorted(windows, key=lambda w: (w["start"], w["end"]))
+
+
+def _recompute_clip_timeline(clips):
+    cursor = 0.0
+    for clip in clips:
+        duration = round(float(clip["source_end"]) - float(clip["source_start"]), 3)
+        clip["duration"] = duration
+        clip["output_start"] = round(cursor, 3)
+        clip["output_end"] = round(cursor + duration, 3)
+        cursor += duration
+    return round(cursor, 3)
+
+
+def _candidate_overlaps(clips, idx, new_start, new_end):
+    for j, other in enumerate(clips):
+        if j == idx:
+            continue
+        if new_start < float(other["source_end"]) and new_end > float(other["source_start"]):
+            return True
+    return False
+
+
+def snap_clip_starts_to_lines(plan, silence_periods, video_duration, max_prepend,
+                              max_trim=0.35, min_clip_duration=0.3):
+    """Snap clip starts to natural quiet boundaries, preferring safe prepend over trim.
+
+    Policy:
+    - start already inside a quiet window: keep.
+    - speech start: prepend to nearest prior quiet window end if within max_prepend.
+    - no usable prior quiet: keep and warn, except an extremely near next quiet start
+      (<= max_trim) may trim forward if duration/overlap safety holds.
+    - never overlap/collapse when allow_overlap is false; unsafe attempts keep-and-warn.
+    """
+    silence_periods = _valid_silence_windows(silence_periods)
+    if not silence_periods:
+        return plan
+
+    clips = [dict(c) for c in plan["clips"]]
+    video_duration = max(0.0, float(video_duration or 0.0))
+    max_prepend = max(0.0, float(max_prepend or 0.0))
+    max_trim = max(0.0, float(max_trim or 0.0))
+    min_duration = max(0.05, float(min_clip_duration or 0.05))
+    allow_overlap = bool(plan.get("allow_overlap", False))
+    events = []
+
+    for i, clip in enumerate(clips):
+        original_start = float(clip["source_start"])
+        source_end = float(clip["source_end"])
+        event = {
+            "clip_id": clip.get("clip_id", i),
+            "source_id": clip.get("source_id"),
+            "original_start": round(original_start, 3),
+            "action": "kept",
+        }
+
+        if any(w["start"] <= original_start <= w["end"] for w in silence_periods):
+            event["reason"] = "already_quiet"
+            events.append(event)
+            continue
+
+        prior_ends = [w["end"] for w in silence_periods if w["end"] <= original_start]
+        if prior_ends:
+            candidate_start = max(prior_ends)
+            if original_start - candidate_start <= max_prepend:
+                candidate_start = round(max(0.0, candidate_start), 3)
+                safe = candidate_start < source_end - min_duration + 1e-9
+                if safe and not allow_overlap:
+                    safe = not _candidate_overlaps(clips, i, candidate_start, source_end)
+                if safe:
+                    clip["source_start"] = candidate_start
+                    event.update({
+                        "action": "prepended",
+                        "new_start": candidate_start,
+                        "delta": round(original_start - candidate_start, 3),
+                    })
+                    events.append(event)
+                    continue
+                reason = "overlap_or_collapse"
+            else:
+                reason = "prior_quiet_too_far"
+        else:
+            reason = "no_prior_quiet"
+
+        next_starts = [w["start"] for w in silence_periods if w["start"] >= original_start]
+        if next_starts:
+            candidate_start = min(next_starts)
+            trim_delta = candidate_start - original_start
+            if 0 < trim_delta <= max_trim:
+                candidate_start = round(min(video_duration, candidate_start), 3)
+                safe = source_end - candidate_start >= min_duration
+                if safe and not allow_overlap:
+                    safe = not _candidate_overlaps(clips, i, candidate_start, source_end)
+                if safe:
+                    clip["source_start"] = candidate_start
+                    event.update({
+                        "action": "trimmed",
+                        "new_start": candidate_start,
+                        "delta": round(trim_delta, 3),
+                        "fallback_from": reason,
+                    })
+                    events.append(event)
+                    continue
+                reason = "unsafe_forward_trim"
+
+        event["start_unsnapped_reason"] = reason
+        event["warning_code"] = "clip_start_unsnapped"
+        events.append(event)
+
+    total_duration = _recompute_clip_timeline(clips)
+    result = dict(plan)
+    result["clips"] = clips
+    result["total_duration"] = total_duration
+    qc = dict(result.get("qc") or {})
+    boundary = dict(qc.get("boundary_status") or {})
+    boundary["start_snaps"] = events
+    qc["boundary_status"] = boundary
+    warnings = list(qc.get("warnings") or [])
+    for event in events:
+        if event.get("warning_code"):
+            warnings.append({
+                "code": event["warning_code"],
+                "clip_id": event["clip_id"],
+                "source_id": event.get("source_id"),
+                "start_unsnapped_reason": event.get("start_unsnapped_reason"),
+            })
+    if warnings:
+        qc["warnings"] = warnings
+    result["qc"] = qc
+    return result
+
+
 def snap_clip_ends_to_lines(plan, silence_periods, video_duration, max_extend):
     """Extend each clip's source_end forward to the next natural pause, preventing mid-sentence cuts.
 
@@ -421,11 +596,7 @@ def snap_clip_ends_to_lines(plan, silence_periods, video_duration, max_extend):
     """
     # silence_periods is loaded from disk; tolerate a stale/hand-edited row by keeping only
     # well-formed quiet windows so a single bad entry can't KeyError-abort the whole cut.
-    silence_periods = [
-        w for w in (silence_periods or [])
-        if isinstance(w, dict) and isinstance(w.get("start"), (int, float))
-        and isinstance(w.get("end"), (int, float))
-    ]
+    silence_periods = _valid_silence_windows(silence_periods)
     if not silence_periods:
         return plan
 
@@ -433,25 +604,40 @@ def snap_clip_ends_to_lines(plan, silence_periods, video_duration, max_extend):
     video_duration = float(video_duration)
     max_extend = float(max_extend)
     allow_overlap = bool(plan.get("allow_overlap", False))
+    events = []
 
     for i, clip in enumerate(clips):
         source_end = clip["source_end"]
+        event = {
+            "clip_id": clip.get("clip_id", i),
+            "source_id": clip.get("source_id"),
+            "original_end": round(float(source_end), 3),
+            "action": "kept",
+        }
 
         # Already inside a quiet window → already at a natural pause.
         if any(w["start"] <= source_end <= w["end"] for w in silence_periods):
+            event["reason"] = "already_quiet"
+            events.append(event)
             continue
 
         # Find the next quiet window start at or after source_end.
         candidates = [w["start"] for w in silence_periods if w["start"] >= source_end]
         if not candidates:
+            event["end_unsnapped_reason"] = "no_next_quiet"
+            events.append(event)
             continue
         next_quiet_start = min(candidates)
 
         # Only snap if the next pause is within reach (≤ max_extend away).
         if next_quiet_start > source_end + max_extend:
+            event["end_unsnapped_reason"] = "next_quiet_too_far"
+            events.append(event)
             continue
         candidate_end = min(next_quiet_start, video_duration)
         if candidate_end <= source_end:
+            event["end_unsnapped_reason"] = "non_forward_candidate"
+            events.append(event)
             continue
 
         # When overlaps are forbidden, cap against every other clip's source range.
@@ -464,22 +650,29 @@ def snap_clip_ends_to_lines(plan, silence_periods, video_duration, max_extend):
                 nearest_other_start = min(other_starts)
                 candidate_end = min(candidate_end, nearest_other_start)
             if candidate_end <= source_end:
+                event["end_unsnapped_reason"] = "overlap_or_collapse"
+                events.append(event)
                 continue
 
         clip["source_end"] = round(candidate_end, 3)
+        event.update({
+            "action": "extended",
+            "new_end": clip["source_end"],
+            "delta": round(float(clip["source_end"]) - float(source_end), 3),
+        })
+        events.append(event)
 
     # Recompute output timeline cursor-based (same cursor logic as normalize_clip_plan).
-    cursor = 0.0
-    for clip in clips:
-        duration = round(clip["source_end"] - clip["source_start"], 3)
-        clip["duration"] = duration
-        clip["output_start"] = round(cursor, 3)
-        clip["output_end"] = round(cursor + duration, 3)
-        cursor += duration
+    total_duration = _recompute_clip_timeline(clips)
 
     result = dict(plan)
     result["clips"] = clips
-    result["total_duration"] = round(sum(c["duration"] for c in clips), 3)
+    result["total_duration"] = total_duration
+    qc = dict(result.get("qc") or {})
+    boundary = dict(qc.get("boundary_status") or {})
+    boundary["end_snaps"] = events
+    qc["boundary_status"] = boundary
+    result["qc"] = qc
     return result
 
 
@@ -529,10 +722,19 @@ def snap_clips_off_shot_changes(plan, video, video_duration, margin, threshold, 
         return plan
     clips = [dict(c) for c in plan["clips"]]
     n_start = n_end = 0
-    for clip in clips:
+    events = []
+    for i, clip in enumerate(clips):
         s = float(clip["source_start"])
         e = float(clip["source_end"])
         new_s, new_e = s, e
+        event = {
+            "clip_id": clip.get("clip_id", i),
+            "source_id": clip.get("source_id"),
+            "original_start": round(s, 3),
+            "original_end": round(e, 3),
+            "start_action": "kept",
+            "end_action": "kept",
+        }
         # Opening: a shot-change just AFTER source_start leaves an old-shot sliver before it.
         start_changes = [c for c in _detect_shot_changes(video, s, min(e, s + margin), threshold)
                          if c > s + 1e-3]
@@ -540,6 +742,10 @@ def snap_clips_off_shot_changes(plan, video, video_duration, margin, threshold, 
             cand = max(start_changes)          # open after the last rapid cut in the window
             if cand < e - min_keep:
                 new_s = round(cand, 3)
+                event["start_action"] = "moved_forward"
+                event["new_start"] = new_s
+            else:
+                event["start_unsnapped_reason"] = "collapse"
         # Closing: a shot-change just BEFORE source_end leaves a next-shot sliver after it.
         end_changes = [c for c in _detect_shot_changes(video, max(new_s, e - margin), e, threshold)
                        if c < e - 1e-3]
@@ -547,25 +753,29 @@ def snap_clips_off_shot_changes(plan, video, video_duration, margin, threshold, 
             cand = min(end_changes)            # close before the first rapid cut in the window
             if cand > new_s + min_keep:
                 new_e = round(cand, 3)
+                event["end_action"] = "moved_back"
+                event["new_end"] = new_e
+            else:
+                event["end_unsnapped_reason"] = "collapse"
         n_start += new_s != s
         n_end += new_e != e
         clip["source_start"] = new_s
         clip["source_end"] = new_e
+        events.append(event)
 
     # Recompute output timeline cursor-based (same cursor logic as snap_clip_ends_to_lines).
-    cursor = 0.0
-    for clip in clips:
-        duration = round(clip["source_end"] - clip["source_start"], 3)
-        clip["duration"] = duration
-        clip["output_start"] = round(cursor, 3)
-        clip["output_end"] = round(cursor + duration, 3)
-        cursor += duration
+    total_duration = _recompute_clip_timeline(clips)
 
     if n_start or n_end:
         log(f"避让原片切镜头: {n_start} 个起点前移、{n_end} 个终点回收 (margin={margin}s, 阈值={threshold})")
     result = dict(plan)
     result["clips"] = clips
-    result["total_duration"] = round(sum(c["duration"] for c in clips), 3)
+    result["total_duration"] = total_duration
+    qc = dict(result.get("qc") or {})
+    boundary = dict(qc.get("boundary_status") or {})
+    boundary["shot_snaps"] = events
+    qc["boundary_status"] = boundary
+    result["qc"] = qc
     return result
 
 
@@ -586,7 +796,8 @@ def _load_silence_for_source(work_dir, source_id, source_work_dir=None):
 
 
 def snap_multi_source_clips(plan, sources, work_dir, *, line_max_extend, scene_margin,
-                            scene_threshold, do_line_snap=True, do_scene_snap=True):
+                            scene_threshold, do_line_snap=True, do_scene_snap=True,
+                            start_max_prepend=None, start_max_trim=None):
     """Per-source line/shot snapping for a multi-source validated plan.
 
     Each clip is snapped using ITS OWN source's silence windows / shot changes and duration
@@ -601,6 +812,7 @@ def snap_multi_source_clips(plan, sources, work_dir, *, line_max_extend, scene_m
     groups = {}
     for clip in clips:
         groups.setdefault(str(clip.get("source_id")), []).append(clip)
+    boundary_accum = {"start_snaps": [], "end_snaps": [], "shot_snaps": []}
     for sid, group in groups.items():
         source = sources.get(sid, {}) if isinstance(sources, dict) else {}
         duration = float(source.get("duration") or 0.0) or max(
@@ -608,22 +820,40 @@ def snap_multi_source_clips(plan, sources, work_dir, *, line_max_extend, scene_m
         mini = {"clips": [dict(c) for c in group], "allow_overlap": allow_overlap}
         if do_line_snap:
             silence = _load_silence_for_source(work_dir, sid, source.get("source_work_dir"))
+            if start_max_prepend is not None:
+                mini = snap_clip_starts_to_lines(
+                    mini, silence, duration, start_max_prepend,
+                    max_trim=start_max_trim if start_max_trim is not None else 0.35,
+                )
             mini = snap_clip_ends_to_lines(mini, silence, duration, line_max_extend)
         if do_scene_snap and source.get("source_path"):
             mini = snap_clips_off_shot_changes(mini, source["source_path"], duration,
                                                scene_margin, scene_threshold)
+        mini_boundary = ((mini.get("qc") or {}).get("boundary_status") or {})
+        for key in boundary_accum:
+            boundary_accum[key].extend([e for e in mini_boundary.get(key, []) if isinstance(e, dict)])
         for original, snapped in zip(group, mini["clips"]):
             original["source_start"] = snapped["source_start"]
             original["source_end"] = snapped["source_end"]
     # Recompute the global output timeline cursor-based, in plan order (not group order).
-    cursor = 0.0
-    for clip in clips:
-        duration = round(float(clip["source_end"]) - float(clip["source_start"]), 3)
-        clip["duration"] = duration
-        clip["output_start"] = round(cursor, 3)
-        clip["output_end"] = round(cursor + duration, 3)
-        cursor += duration
-    plan["total_duration"] = round(sum(c["duration"] for c in clips), 3)
+    plan["total_duration"] = _recompute_clip_timeline(clips)
+
+    # Preserve per-source boundary QC as the single validated-plan QC source.
+    if any(boundary_accum.values()):
+        qc = plan.setdefault("qc", {})
+        boundary = qc.setdefault("boundary_status", {})
+        for key, events in boundary_accum.items():
+            if events:
+                boundary.setdefault(key, []).extend(events)
+        warnings = qc.setdefault("warnings", [])
+        for event in boundary_accum["start_snaps"]:
+            if event.get("warning_code"):
+                warnings.append({
+                    "code": event["warning_code"],
+                    "clip_id": event.get("clip_id"),
+                    "source_id": event.get("source_id"),
+                    "start_unsnapped_reason": event.get("start_unsnapped_reason"),
+                })
     return plan
 
 
@@ -765,6 +995,69 @@ def lint_mapped_narration(mapped, original_count, output_duration, *, min_spm=6.
     }
 
 
+def update_cut_qc(plan, *, allow_duration_drift=False, duration_drift_allowed_by=None):
+    """Populate clip_plan_validated.json['qc'] as the single cut QC source."""
+    qc = dict(plan.get("qc") or {})
+    warnings = list(qc.get("warnings") or [])
+    blocking = list(qc.get("blocking") or [])
+    total = float(plan.get("total_duration") or 0.0)
+    target = plan.get("target_duration")
+    if target in (None, ""):
+        target_status = "missing"
+        target_qc = {"status": target_status, "target_duration": None, "total_duration": round(total, 3)}
+    else:
+        target = float(target)
+        ratio = total / target if target > 0 else 0.0
+        if ratio < 0.85:
+            target_status = "under"
+        elif ratio > 1.15:
+            target_status = "over"
+        else:
+            target_status = "ok"
+        severity = None
+        if ratio < 0.60 or ratio > 1.40:
+            severity = "blocking"
+        elif target_status in {"under", "over"}:
+            severity = "warning"
+        target_qc = {
+            "status": target_status,
+            "target_duration": round(target, 3),
+            "total_duration": round(total, 3),
+            "ratio": round(ratio, 3),
+            "warning_thresholds": {"under": 0.85, "over": 1.15},
+            "blocking_thresholds": {"under": 0.60, "over": 1.40},
+        }
+        if severity:
+            warning = {
+                "code": "target_duration_drift",
+                "status": target_status,
+                "severity": "warning" if allow_duration_drift else severity,
+                "target_duration": round(target, 3),
+                "total_duration": round(total, 3),
+                "ratio": round(ratio, 3),
+            }
+            if allow_duration_drift:
+                warning["allowed"] = True
+                warning["duration_drift_allowed_by"] = duration_drift_allowed_by or "--allow-duration-drift"
+                target_qc["duration_drift_allowed_by"] = warning["duration_drift_allowed_by"]
+            warnings.append(warning)
+            if severity == "blocking" and not allow_duration_drift:
+                blocking.append(warning)
+    qc["target_duration_status"] = target_status
+    qc["target_duration"] = target_qc
+    qc.setdefault("boundary_status", {})
+    qc["clip_count"] = len(plan.get("clips") or [])
+    qc["total_duration"] = round(total, 3)
+    if warnings:
+        qc["warnings"] = warnings
+    if blocking:
+        qc["blocking"] = blocking
+    elif "blocking" in qc:
+        qc.pop("blocking", None)
+    plan["qc"] = qc
+    return plan
+
+
 def _has_audio_stream(video_path):
     cmd = [
         "ffprobe", "-v", "error", "-select_streams", "a:0",
@@ -774,49 +1067,370 @@ def _has_audio_stream(video_path):
     return result.returncode == 0 and bool(result.stdout.strip())
 
 
-def _probe_video_geometry(video_path):
-    """Best-effort (width, height, fps) for a source; falls back to a safe even-sized canvas.
+class VideoGeometry(tuple):
+    """Tuple-compatible geometry with probe facts attached for QC callers."""
 
-    Used to normalize heterogeneous multi-source segments to one geometry before concat
-    (ffmpeg's concat filter rejects mismatched width/height/SAR/pixel-format/fps).
+    def __new__(cls, width, height, fps, facts=None):
+        obj = super().__new__(cls, (width, height, fps))
+        obj.facts = facts or {}
+        return obj
+
+
+def _parse_ratio(value):
+    if value in (None, "", "0:1", "0/1", "N/A"):
+        return None
+    text = str(value)
+    sep = ":" if ":" in text else "/" if "/" in text else None
+    if not sep:
+        try:
+            ratio = float(text)
+            return ratio if ratio > 0 else None
+        except ValueError:
+            return None
+    left, _, right = text.partition(sep)
+    try:
+        num, den = float(left), float(right)
+    except ValueError:
+        return None
+    return num / den if den > 0 and num > 0 else None
+
+
+def _stream_rotation(stream):
+    candidates = []
+    tags = stream.get("tags") if isinstance(stream.get("tags"), dict) else {}
+    if "rotate" in tags:
+        candidates.append(tags.get("rotate"))
+    for side_data in stream.get("side_data_list") or []:
+        if isinstance(side_data, dict):
+            candidates.append(side_data.get("rotation"))
+    for value in candidates:
+        try:
+            return int(round(float(value))) % 360
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def _fps_from_rate(rate):
+    if not rate or "/" not in str(rate):
+        return 0.0
+    num, _, den = str(rate).partition("/")
+    try:
+        num_f, den_f = float(num), float(den)
+        return num_f / den_f if den_f > 0 else 0.0
+    except ValueError:
+        return 0.0
+
+
+def _geometry_from_stream(stream, *, fallback=False):
+    coded_width = coded_height = 0
+    try:
+        coded_width = int(float(stream.get("width") or 0))
+        coded_height = int(float(stream.get("height") or 0))
+    except (TypeError, ValueError):
+        coded_width = coded_height = 0
+    if coded_width <= 0 or coded_height <= 0:
+        coded_width, coded_height = 1280, 720
+        fallback = True
+
+    parsed_sar = _parse_ratio(stream.get("sample_aspect_ratio"))
+    dar = _parse_ratio(stream.get("display_aspect_ratio"))
+    rotation = _stream_rotation(stream)
+    display_height = float(coded_height)
+    if parsed_sar:
+        sar = parsed_sar
+        display_width = float(coded_width) * sar
+        aspect_source = "sample_aspect_ratio"
+    elif dar:
+        sar = 1.0
+        display_width = display_height * dar
+        aspect_source = "display_aspect_ratio_fallback"
+    else:
+        sar = 1.0
+        display_width = float(coded_width)
+        aspect_source = "square_pixel_fallback"
+    rotation_swaps_axes = rotation in {90, 270}
+    if rotation_swaps_axes:
+        display_width, display_height = display_height, display_width
+
+    width, height = _clamp_even_geometry(round(display_width), round(display_height))
+    fps = _fps_from_rate(stream.get("r_frame_rate")) or _fps_from_rate(stream.get("avg_frame_rate"))
+    if not 0 < fps <= 120:
+        fps = 30.0
+    facts = {
+        "coded_width": coded_width,
+        "coded_height": coded_height,
+        "width": width,
+        "height": height,
+        "fps": round(fps, 3),
+        "sample_aspect_ratio": stream.get("sample_aspect_ratio") or "1:1",
+        "sample_aspect_ratio_float": round(float(sar), 6),
+        "display_aspect_ratio": stream.get("display_aspect_ratio"),
+        "display_aspect_ratio_float": round(float(dar or 0.0), 6),
+        "display_aspect_source": aspect_source,
+        "display_width": width,
+        "display_height": height,
+        "rotation": rotation,
+        "rotation_swaps_axes": rotation_swaps_axes,
+        "fallback": bool(fallback),
+    }
+    return VideoGeometry(width, height, round(fps, 3), facts)
+
+
+def _probe_video_geometry(video_path):
+    """Best-effort iterable (width, height, fps), rotation/SAR/DAR-aware.
+
+    Returned value unpacks like the historical 3-tuple while exposing `.facts`
+    for QC. Used to normalize heterogeneous multi-source segments to one
+    square-pixel geometry before concat (ffmpeg's concat filter rejects
+    mismatched width/height/SAR/pixel-format/fps).
     """
-    width = height = 0
-    fps = 0.0
     cmd = [
         "ffprobe", "-v", "error", "-select_streams", "v:0",
-        "-show_entries", "stream=width,height,r_frame_rate",
-        "-of", "csv=p=0:s=,", str(video_path),
+        "-show_entries",
+        "stream=width,height,r_frame_rate,avg_frame_rate,sample_aspect_ratio,display_aspect_ratio:stream_tags=rotate:stream_side_data=rotation",
+        "-of", "json", str(video_path),
     ]
     try:
         result = run_cmd(cmd)
     except Exception:  # noqa: BLE001 - probing is best-effort; fall back to defaults
         result = None
     if result is not None and getattr(result, "returncode", 1) == 0 and (result.stdout or "").strip():
-        parts = result.stdout.strip().splitlines()[0].split(",")
         try:
-            width, height = int(float(parts[0])), int(float(parts[1]))
-        except (IndexError, ValueError):
-            width = height = 0
-        if len(parts) >= 3 and "/" in parts[2]:
-            num, _, den = parts[2].partition("/")
-            try:
-                num_f, den_f = float(num), float(den)
-                fps = num_f / den_f if den_f > 0 else 0.0
-            except ValueError:
-                fps = 0.0
-    if width <= 0 or height <= 0:
-        width, height = 1280, 720
-    width -= width % 2          # libx264/yuv420p require even dimensions
-    height -= height % 2
-    if not 0 < fps <= 120:
-        fps = 30.0
-    return width, height, round(fps, 3)
+            payload = json.loads(result.stdout)
+            streams = payload.get("streams") or []
+            if streams:
+                return _geometry_from_stream(streams[0])
+        except (AttributeError, TypeError, ValueError):
+            pass
+
+    # Backward-compatible fallback for tests/mocks that still return CSV output.
+    stream = {}
+    if result is not None and (result.stdout or "").strip():
+        parts = result.stdout.strip().splitlines()[0].split(",")
+        if len(parts) >= 2:
+            stream["width"], stream["height"] = parts[0], parts[1]
+        if len(parts) >= 3:
+            stream["r_frame_rate"] = parts[2]
+        if len(parts) >= 4 and parts[3] not in ("", "N/A"):
+            stream["tags"] = {"rotate": parts[3]}
+        if len(parts) >= 5 and parts[4] not in ("", "N/A"):
+            stream["sample_aspect_ratio"] = parts[4]
+        if len(parts) >= 6 and parts[5] not in ("", "N/A"):
+            stream["display_aspect_ratio"] = parts[5]
+    return _geometry_from_stream(stream, fallback=True)
+
+
+def _orientation(width, height):
+    if width > height:
+        return "landscape"
+    if height > width:
+        return "portrait"
+    return "square"
+
+
+def _fps_bucket(fps):
+    if not fps or fps <= 0:
+        return 30.0
+    common = [23.976, 24.0, 25.0, 29.97, 30.0, 50.0, 59.94, 60.0]
+    nearest = min(common, key=lambda x: abs(float(fps) - x))
+    return nearest if abs(float(fps) - nearest) <= 0.15 else round(float(fps))
+
+
+def _clamp_even_geometry(width, height, max_height=None):
+    width = max(2, int(width) - int(width) % 2)
+    height = max(2, int(height) - int(height) % 2)
+    max_height = int(max_height or 0)
+    if max_height > 0 and height > max_height:
+        scale = max_height / height
+        height = max_height - max_height % 2
+        width = max(2, int(width * scale))
+        width -= width % 2
+    return width, height
+
+
+def _select_output_geometry(source_paths, clips, max_height=None):
+    """Deterministically select canvas/fps from all used sources, not just the first."""
+    used = {}
+    for clip in clips or []:
+        path = str(clip.get("source_path") or "")
+        if not path:
+            continue
+        used[path] = used.get(path, 0.0) + max(0.0, float(clip.get("duration") or 0.0))
+    if not used:
+        for path in source_paths or []:
+            used[str(path)] = 0.0
+    rows = []
+    for path in sorted(used):
+        probed = _probe_video_geometry(path)
+        width, height, fps = probed
+        facts = dict(getattr(probed, "facts", {}) or {})
+        facts.setdefault("width", width)
+        facts.setdefault("height", height)
+        facts.setdefault("fps", fps)
+        facts.setdefault("rotation", 0)
+        facts.setdefault("sample_aspect_ratio", "1:1")
+        rows.append({
+            "path": path,
+            "source_id": next((str(c.get("source_id")) for c in clips or []
+                               if str(c.get("source_path") or "") == path and c.get("source_id") is not None), None),
+            "used_duration": round(used[path], 3),
+            "width": width,
+            "height": height,
+            "coded_width": facts.get("coded_width", width),
+            "coded_height": facts.get("coded_height", height),
+            "display_width": facts.get("display_width", width),
+            "display_height": facts.get("display_height", height),
+            "area": width * height,
+            "fps": fps,
+            "fps_bucket": min(60.0, _fps_bucket(fps)),
+            "orientation": _orientation(width, height),
+            "rotation": facts.get("rotation", 0),
+            "sample_aspect_ratio": facts.get("sample_aspect_ratio", "1:1"),
+            "sample_aspect_ratio_float": facts.get("sample_aspect_ratio_float", 1.0),
+            "display_aspect_ratio": facts.get("display_aspect_ratio"),
+            "rotation_swaps_axes": bool(facts.get("rotation_swaps_axes", False)),
+        })
+    if not rows:
+        return 1280, 720, 30.0, {
+            "width": 1280, "height": 720, "fps": 30.0,
+            "reason": "fallback_no_sources", "source_id": None,
+        }
+
+    orientation_duration = {}
+    for row in rows:
+        orientation_duration[row["orientation"]] = orientation_duration.get(row["orientation"], 0.0) + row["used_duration"]
+    chosen_orientation = sorted(
+        orientation_duration.items(),
+        key=lambda kv: (kv[1], max(r["area"] for r in rows if r["orientation"] == kv[0]), kv[0]),
+        reverse=True,
+    )[0][0]
+    eligible = [r for r in rows if r["orientation"] == chosen_orientation] or rows
+    selected = sorted(
+        eligible,
+        key=lambda r: (-r["area"], str(r.get("source_id") or ""), r["path"]),
+    )[0]
+
+    fps_duration = {}
+    for row in rows:
+        fps_duration[row["fps_bucket"]] = fps_duration.get(row["fps_bucket"], 0.0) + row["used_duration"]
+    fps = sorted(fps_duration.items(), key=lambda kv: (kv[1], kv[0]), reverse=True)[0][0]
+    fps = max(1.0, min(60.0, float(fps or 30.0)))
+
+    width, height = _clamp_even_geometry(selected["width"], selected["height"], max_height=max_height)
+    reason = {
+        "width": width,
+        "height": height,
+        "fps": round(fps, 3),
+        "reason": "weighted_orientation_area_fps",
+        "source_id": selected.get("source_id"),
+        "source_path": selected["path"],
+        "orientation": chosen_orientation,
+        "orientation_used_duration": round(orientation_duration.get(chosen_orientation, 0.0), 3),
+        "fps_bucket_used_duration": round(fps_duration.get(fps, 0.0), 3),
+        "rotation": selected.get("rotation", 0),
+        "sample_aspect_ratio": selected.get("sample_aspect_ratio", "1:1"),
+        "display_aspect_ratio": selected.get("display_aspect_ratio"),
+        "coded_width": selected.get("coded_width"),
+        "coded_height": selected.get("coded_height"),
+        "display_width": selected.get("display_width"),
+        "display_height": selected.get("display_height"),
+        "sources": rows,
+    }
+    return width, height, round(fps, 3), reason
+
+
+def _audio_segment_filter(label_in, label_out, start, end, duration, fade_ms, extra_filters=""):
+    fade = max(0.0, min(float(fade_ms or 0.0) / 1000.0, max(0.0, float(duration or 0.0)) / 2))
+    base = f"{label_in}atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS"
+    if fade > 0:
+        base += f",afade=t=in:st=0:d={fade:.3f},afade=t=out:st={max(0.0, duration - fade):.3f}:d={fade:.3f}"
+    if extra_filters:
+        base += f",{extra_filters}"
+    return f"{base}{label_out}"
 
 
 def _write_filter_script(filter_complex, work_dir):
     script_path = Path(work_dir) / "edit_filter_complex.txt"
     script_path.write_text(filter_complex, encoding="utf-8")
     return script_path
+
+
+def _probe_audio_sample_rate(video_path):
+    cmd = [
+        "ffprobe", "-v", "error", "-select_streams", "a:0",
+        "-show_entries", "stream=sample_rate", "-of", "csv=p=0", str(video_path),
+    ]
+    try:
+        result = run_cmd(cmd)
+    except Exception:  # noqa: BLE001 - delivery QC is observational
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(float((result.stdout or "").strip().splitlines()[0]))
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
+def _delivery_reencode_reason(source_paths, clips):
+    reasons = ["trim_concat_filter_requires_reencode"]
+    if len(source_paths or []) > 1:
+        reasons.append("multi_source_geometry_audio_normalization")
+    if any(not clip.get("source_path") for clip in clips or []):
+        reasons.append("single_source_filter_concat_no_stream_copy")
+    return "+".join(reasons)
+
+
+def update_delivery_qc(validated_plan, *, source_paths=None, output_path=None, rendered=False):
+    """Attach cut delivery facts to qc.delivery_qc without writing visual_qc."""
+    qc = validated_plan.setdefault("qc", {})
+    clips = validated_plan.get("clips") or []
+    if source_paths is None:
+        source_paths = sorted({
+            str(clip.get("source_path") or "")
+            for clip in clips
+            if str(clip.get("source_path") or "")
+        })
+    target_sample_rate = 48000
+    probed_sample_rate = _probe_audio_sample_rate(output_path) if output_path and Path(output_path).exists() else None
+    output_geometry = qc.get("output_geometry")
+    delivery_qc = {
+        "schema_version": 1,
+        "video_encode_passes": 1,
+        "reencode_reason": _delivery_reencode_reason(source_paths, clips),
+        "stream_copy_risk": {
+            "status": "avoided",
+            "reason": "cut uses trim/concat/filtergraph with explicit libx264/aac encode; no risky stream-copy path",
+        },
+        "audio_sample_rate": {
+            "target": target_sample_rate,
+            "probed": probed_sample_rate,
+        },
+        "final_compat_notes": [
+            "video encoded with libx264/yuv420p-compatible filter path",
+            "audio encoded as AAC with 48000 Hz target for delivery compatibility",
+            "edited_source.mp4 is an intermediate; downstream assembly may perform another intentional encode",
+        ],
+        "output_geometry": output_geometry,
+        "rendered": bool(rendered),
+        "planned": not bool(rendered),
+    }
+    if probed_sample_rate and probed_sample_rate != target_sample_rate:
+        delivery_qc["final_compat_notes"].append(
+            f"probed audio sample rate {probed_sample_rate} differs from target {target_sample_rate}"
+        )
+    qc["delivery_qc"] = delivery_qc
+    return delivery_qc
+
+
+def write_cut_delivery_qc(work_dir, validated_plan):
+    delivery_qc = (validated_plan.get("qc") or {}).get("delivery_qc")
+    if not delivery_qc or not delivery_qc.get("rendered"):
+        return None
+    path = Path(work_dir) / "cut_delivery_qc.json"
+    path.write_text(json.dumps(delivery_qc, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
 
 
 def build_edited_source_video(input_video, validated_plan, work_dir, output_path=None):
@@ -834,6 +1448,13 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
             source_paths.append(source_path)
     source_index = {path: idx for idx, path in enumerate(source_paths)}
     audio_by_input = {path: _has_audio_stream(path) for path in source_paths}
+    join_fade_ms = max(0.0, float(CONFIG.get("clip_join_audio_fade_ms", 30.0) or 0.0))
+    qc = validated_plan.setdefault("qc", {})
+    qc["join_fade_ms"] = round(join_fade_ms, 3)
+    if not qc.get("output_geometry"):
+        _, _, _, geometry_qc = _select_output_geometry(source_paths, clips)
+        qc["output_geometry"] = geometry_qc
+        qc["output_geometry_reason"] = geometry_qc.get("reason")
 
     parts = []
     concat_inputs = []
@@ -844,7 +1465,9 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
         # segment to one canvas and give every clip an audio segment (real or synthesized
         # silence) so concat always succeeds with a continuous track and no source's audio
         # is dropped just because a sibling source is silent.
-        canvas_w, canvas_h, canvas_fps = _probe_video_geometry(source_paths[0])
+        canvas_w, canvas_h, canvas_fps, geometry_qc = _select_output_geometry(source_paths, clips)
+        qc["output_geometry"] = geometry_qc
+        qc["output_geometry_reason"] = geometry_qc.get("reason")
         vnorm = (f"scale={canvas_w}:{canvas_h}:force_original_aspect_ratio=decrease,"
                  f"pad={canvas_w}:{canvas_h}:(ow-iw)/2:(oh-ih)/2,setsar=1,"
                  f"fps={canvas_fps},format=yuv420p")
@@ -859,10 +1482,10 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
                 f"[{input_idx}:v]trim=start={start:.3f}:end={end:.3f},setpts=PTS-STARTPTS,{vnorm}[v{idx}]"
             )
             if audio_by_input.get(clip_source):
-                parts.append(
-                    f"[{input_idx}:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS,"
-                    f"aresample=48000,aformat=sample_rates=48000:channel_layouts=stereo[a{idx}]"
-                )
+                parts.append(_audio_segment_filter(
+                    f"[{input_idx}:a]", f"[a{idx}]", start, end, dur, join_fade_ms,
+                    extra_filters="aresample=48000,aformat=sample_rates=48000:channel_layouts=stereo",
+                ))
             else:
                 parts.append(
                     f"anullsrc=r=48000:cl=stereo,atrim=duration={dur:.3f},asetpts=PTS-STARTPTS,"
@@ -883,9 +1506,9 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
             )
             concat_inputs.append(f"[v{idx}]")
             if has_audio:
-                parts.append(
-                    f"[{input_idx}:a]atrim=start={start:.3f}:end={end:.3f},asetpts=PTS-STARTPTS[a{idx}]"
-                )
+                parts.append(_audio_segment_filter(
+                    f"[{input_idx}:a]", f"[a{idx}]", start, end, max(0.0, float(end) - float(start)), join_fade_ms
+                ))
                 concat_inputs.append(f"[a{idx}]")
 
         if has_audio:
@@ -908,11 +1531,14 @@ def build_edited_source_video(input_video, validated_plan, work_dir, output_path
     for source_path in source_paths:
         input_args.extend(["-i", str(source_path)])
     cmd = ["ffmpeg", "-y", *input_args, *extra_inputs, *filter_args, *maps,
-           "-c:v", "libx264", "-preset", "veryfast", "-crf", "18", "-c:a", "aac", "-b:a", "192k", str(output_path)]
+           "-c:v", "libx264", "-preset", "veryfast", "-crf", "18", "-pix_fmt", "yuv420p",
+           "-c:a", "aac", "-b:a", "192k", "-ar", "48000", "-movflags", "+faststart", str(output_path)]
     result = run_cmd(cmd)
     if result.returncode != 0:
         raise RuntimeError(f"剪辑源视频失败: {result.stderr}")
 
+    update_delivery_qc(validated_plan, source_paths=source_paths, output_path=output_path, rendered=True)
+    write_cut_delivery_qc(work_dir, validated_plan)
     _write_edited_source_meta(output_path, validated_plan, input_video)
     duration = get_video_duration(output_path)
     log(f"剪辑源视频: {output_path} ({duration:.1f}s, {len(clips)} clips)")
@@ -940,6 +1566,8 @@ def main():
                              "(cut-first/narrate-second: narration is authored in OUTPUT time, no mapping)")
     parser.add_argument("--allow-sparse-cut", action="store_true",
                         help="do not block on heavy narration drop / sparse output (e.g. an intentional montage)")
+    parser.add_argument("--allow-duration-drift", action="store_true",
+                        help="do not block when validated clip duration is far from --target-duration")
     args = parser.parse_args()
 
     work_dir = Path(args.work_dir)
@@ -978,6 +1606,13 @@ def main():
                     silence_periods = []
             except (OSError, ValueError):
                 silence_periods = []
+        validated_plan = snap_clip_starts_to_lines(
+            validated_plan,
+            silence_periods,
+            video_duration,
+            CONFIG.get("clip_start_snap_max_prepend", 1.8),
+            max_trim=CONFIG.get("clip_start_snap_max_trim", 0.35),
+        )
         validated_plan = snap_clip_ends_to_lines(
             validated_plan,
             silence_periods,
@@ -1011,13 +1646,46 @@ def main():
             scene_threshold=CONFIG.get("scene_cut_detect_threshold", 0.4),
             do_line_snap=CONFIG.get("snap_clip_line_end", True),
             do_scene_snap=CONFIG.get("scene_cut_snap", True),
+            start_max_prepend=CONFIG.get("clip_start_snap_max_prepend", 1.8),
+            start_max_trim=CONFIG.get("clip_start_snap_max_trim", 0.35),
         )
 
     if isinstance(validated_plan, dict):
         validated_plan["raw_plan_fingerprint"] = value_fingerprint(raw_plan)
+        validated_plan.setdefault("qc", {})["join_fade_ms"] = round(
+            max(0.0, float(CONFIG.get("clip_join_audio_fade_ms", 30.0) or 0.0)), 3
+        )
+        source_paths = []
+        for clip in validated_plan.get("clips", []):
+            source_path = str(clip.get("source_path") or "")
+            if source_path and source_path not in source_paths:
+                source_paths.append(source_path)
+        if not source_paths:
+            source_paths = [str(args.video)]
+        _, _, _, geometry_qc = _select_output_geometry(source_paths, validated_plan.get("clips", []))
+        validated_plan["qc"]["output_geometry"] = geometry_qc
+        validated_plan["qc"]["output_geometry_reason"] = geometry_qc.get("reason")
+        allow_duration_drift = bool(args.allow_duration_drift or args.allow_sparse_cut)
+        drift_source = "--allow-duration-drift" if args.allow_duration_drift else (
+            "--allow-sparse-cut" if args.allow_sparse_cut else None
+        )
+        update_cut_qc(
+            validated_plan,
+            allow_duration_drift=allow_duration_drift,
+            duration_drift_allowed_by=drift_source,
+        )
+        update_delivery_qc(validated_plan, source_paths=source_paths, output_path=work_dir / "edited_source.mp4")
     (work_dir / "clip_plan_validated.json").write_text(
         json.dumps(validated_plan, ensure_ascii=False, indent=2), encoding="utf-8")
+    if (validated_plan.get("qc") or {}).get("blocking"):
+        raise SystemExit(
+            "clip_plan duration QC blocking: use --allow-duration-drift to accept current target-duration drift. "
+            "See clip_plan_validated.json['qc']."
+        )
     if args.normalize_only:
+        # normalize-only produces planned delivery facts in clip_plan_validated.json, but no
+        # rendered/reused media exists in this run, so remove any stale final delivery artifact.
+        (work_dir / "cut_delivery_qc.json").unlink(missing_ok=True)
         print(json.dumps({"status": "normalized", "clips": len(validated_plan["clips"]),
                           "total_duration": validated_plan["total_duration"]}, ensure_ascii=False))
         return
@@ -1025,8 +1693,15 @@ def main():
     edited_source_path = work_dir / "edited_source.mp4"
     if should_reuse_edited_source(edited_source_path, validated_plan, args.video):
         log(f"复用剪辑源视频: {edited_source_path}")
+        update_delivery_qc(validated_plan, source_paths=source_paths, output_path=edited_source_path, rendered=True)
+        write_cut_delivery_qc(work_dir, validated_plan)
+        _write_edited_source_meta(edited_source_path, validated_plan, args.video)
+        (work_dir / "clip_plan_validated.json").write_text(
+            json.dumps(validated_plan, ensure_ascii=False, indent=2), encoding="utf-8")
     else:
         build_edited_source_video(args.video, validated_plan, work_dir, edited_source_path)
+        (work_dir / "clip_plan_validated.json").write_text(
+            json.dumps(validated_plan, ensure_ascii=False, indent=2), encoding="utf-8")
 
     narration_path = Path(args.narration) if args.narration else work_dir / "narration.json"
     if narration_path.exists() and not args.no_narration_map:

--- a/skills/video-cut/scripts/lib.py
+++ b/skills/video-cut/scripts/lib.py
@@ -32,6 +32,9 @@ def env_float(name, default, min_val=None):
 CONFIG = {
     "snap_clip_line_end": env_bool("SNAP_CLIP_LINE_END", True),
     "clip_snap_max_extend": env_float("CLIP_SNAP_MAX_EXTEND", 2.0, min_val=0.0),
+    "clip_start_snap_max_prepend": env_float("CLIP_START_SNAP_MAX_PREPEND", 1.8, min_val=0.0),
+    "clip_start_snap_max_trim": env_float("CLIP_START_SNAP_MAX_TRIM", 0.35, min_val=0.0),
+    "clip_join_audio_fade_ms": env_float("CLIP_JOIN_AUDIO_FADE_MS", 30.0, min_val=0.0),
     # Keep clip boundaries off the ORIGINAL footage's hard cuts: a clip that opens/closes a few
     # tenths of a second from a source shot-change shows a brief sliver of the adjacent shot that
     # then hard-cuts again — a visible 闪烁/flicker at the edit point. Snap source_start forward

--- a/skills/video-recap/SKILL.md
+++ b/skills/video-recap/SKILL.md
@@ -120,6 +120,8 @@ python3 scripts/recap.py --doctor
 `--skip-asr`, `--mimo-video-overview`, `--consolidate`, `--consolidate-asr`, `--mimo-tts-voice`,
 `--no-burn-subtitles` (burn is on by default), `--output-dir`, `--material-library-dir`, `--use-materials`, `--save-materials`.
 
+`--style` is freeform verbatim guidance for the agent to synthesize with evidence; do not treat it as an option list, preset, switch, or finite style taxonomy.
+
 ## What this skill does NOT do
 - Does NOT write narration.json / clip_plan.json — the agent authors those (see the video-script skill).
 - Does NOT hard-block on the narration review (advisory; validate.py is the hard gate).

--- a/skills/video-recap/references/config-playbook.md
+++ b/skills/video-recap/references/config-playbook.md
@@ -26,7 +26,7 @@ Defaults below are bundle-level defaults unless a note scopes them to a specific
 | Background music | `BGM_PATH` / `BGM_VOLUME` / `BGM_DUCKING_VOLUME` | off / `0.18` / `0.10` | optional looped music bed mixed as its own track; point `BGM_PATH` at any audio file. It ducks to `BGM_DUCKING_VOLUME` under narration |
 | Final loudness | `FINAL_LOUDNORM` / `TARGET_LUFS` | `true` / `-14` | end-of-pipeline normalize |
 | Output compression | `OUTPUT_CRF` / `OUTPUT_PRESET` / `OUTPUT_MAX_HEIGHT` | `18` / `veryfast` / `0` | x264 re-encode controls, applied whenever the final mux re-encodes (burning subtitles / masking / scaling / `FORCE_VIDEO_REENCODE`). Higher `OUTPUT_CRF` = smaller file/lower quality (18≈visually lossless, 23–26 much smaller); `slow`/`slower` preset shrinks more at the same CRF; `OUTPUT_MAX_HEIGHT>0` downscales the final height (keeps aspect, even width), e.g. `720` to halve 1080p pixels. Subtitles/mask render at native res then downscale, so they stay crisp |
-| Style | `--style` | `纪录片` | |
+| Style | `--style` | `纪录片` | freeform verbatim guidance passed into the agent brief. The agent synthesizes voice/pacing from this exact text plus evidence; it is not a fixed option list, preset, switch, or finite style taxonomy |
 | Edit mode | `EDIT_MODE` / `--edit-mode` | `full` | `full` or `cut` |
 | Cut target | `TARGET_DURATION` / `--target-duration` | — | e.g. `10m` (cut mode) |
 | Scene threshold | `--scene-threshold` | `0.1` | scene-cut sensitivity |

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -463,3 +463,8 @@ Dub 模式下，`dub_script.json` 在 voiceclone **之前**先经过 determinist
 ```
 
 > CLI：`dub.py --stage lint|review`（无需 video）、`dub.py --print-schema` 打印以上全部 dub artifact 契约；`--stage render` 会在克隆前自动写 `dub_lint.json` / `dub_review.json`，lint 非 PASS 即中止。
+## shift-left QC artifacts
+
+`preflight_qc.json`、`final_qc.json`、`golden_eval.json`、`mimo_qc.json` 共用最小 QC 契约；stage 仅允许 `pre_cut` / `post_cut` / `pre_tts` / `post_tts` / `pre_assemble` / `post_render` / `golden`，其中 `mimo_qc.json` 是 artifact 而不是 stage。详见 `shift-left-qc-schema.md` 与 `shift-left-qc-rules.json`。
+
+`recap.py` 渲染后会先更新 `preflight_qc.json` 的 `post_render` stage，再写出 `final_qc.json` 和 `golden_eval.json`。`final_qc.json` 汇总最终 mp4、`assembly_manifest.json`、`assembly_qc.json`、`visual_qc.json`、`preflight_qc.json`、`mimo_qc.json` 的本地元数据；缺失/空成片、ffprobe 不可用或失败、以及 assembly/visual QC 的客观 blocker 会进入 deterministic blockers。`golden_eval.json` 默认要求 `final_qc.json.ok=true`，也可用 golden fixture 做简单的时长、codec 和必需 artifact 断言。二者均为 report-only：不接入网络、不调用 MiMo、不自动修复，也不读取或持久化 API key。所有 QC metadata/evidence 写入前都经过 `qc_contract.redact_secrets`：secret-looking key/value 会被替换，URL userinfo/query/fragment 会被移除，仅保留必要 host/path 诊断信息；non-deterministic blocker allow-list 只有在规则表 `schema_version` 与 `qc_contract.SCHEMA_VERSION` 一致时才生效。

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -135,6 +135,90 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 常见 code：`invalid_time`、`empty_narration`、`time_overlap`、`outside_clip_plan`、`over_budget`、`incomplete_sentence`、`slot_too_short`、`under_narrated`、`over_narrated`、`fragmented_beats`、`no_original_blocks`。
 
+## style_card.json（Agent 撰写，可选/按 brief 要求）
+
+`style_card.json` 是表达层契约：由 Agent 根据 `--style`、`--context`、素材证据、ASR 和用户偏好信号综合撰写。`--style` 是 freeform verbatim guidance（原样自由文本指导），不是枚举、preset、switch，也不是一组可穷举风格名；不要把它翻译成固定档位。
+
+这个文件记录声音、节奏、回收意图和证据支撑的表达判断；字段可以随项目增减，下游只把它当 JSON object 读取，不要求固定键名。它不负责标题、封面、首句承诺或卖点包装。
+
+```json
+{
+  "voice": "冷静但有压迫感，少讲大道理，多用人物动作和台词里的证据推进",
+  "pacing": "前 15 秒短句建立冲突，中段留原声喘息，结尾回收开头疑问",
+  "payoff_intent": "让观众先看到误会，再看到人物选择的代价",
+  "subtitle_read_posture": "句子可听、可读，不堆长抽象句",
+  "evidence_intent": ["优先引用画面动作", "关键转折保留原声"]
+}
+```
+
+## packaging_plan.json（Agent 撰写，可选）
+
+`packaging_plan.json` 是包装层契约：标题、封面帧/视觉钩子、首句、观众承诺、卖点和发布包装信息。它帮助 review 判断“包装承诺”和正文前 15 秒是否对齐。
+
+它不是文风策略，不覆盖 `style_card.json` 的声音、节奏或表达规则；如果包装需要某个承诺，正文仍要用素材证据兑现。
+
+```json
+{
+  "title": "一句能对外展示的标题",
+  "cover_frame": {"time": 12.4, "reason": "人物第一次正面做出关键选择"},
+  "first_line": "开场第一句解说",
+  "viewer_promise": "观众看完会明白的冲突/反转/信息增量",
+  "selling_points": ["强冲突", "原声高光"],
+  "packaging_notes": "发布侧备注，不写文风规则"
+}
+```
+
+## deslop_qc_requirements.json（工具/brief 生成的运行契约）
+
+`deslop_qc_requirements.json` 是 tool/brief generated run contract：工具或 brief 生成本次运行的 QC 要求，供 `deslop_qc` 读取，不由 Agent 手写。字段包括 `schema_version`、`owner`、`style_card_required`、`packaging_plan_expected`、`deslop_qc.report_only`、`deslop_qc.aigc_detector`、`deslop_qc.auto_rewrite`。
+
+`deslop_qc` 只根据这个运行契约判断缺少 `style_card.json` 是否是 blocker；它不扫描 `agent_narration_brief.md` 的 prompt wording 来推断 `style_card_required`。如果 requirements 文件缺失或损坏，按 legacy/migration advisory 处理，不作为 hard failure。
+
+该契约不改变 `--style`：`--style` 仍是 freeform verbatim guidance，不增加固定风格档位。它也不改变 `deslop_qc` 边界：仍然是 report-only，不是 AIGC detector，不自动改写。
+
+最小示例：
+
+```json
+{
+  "schema_version": "1.0",
+  "owner": "tool_or_brief",
+  "style_card_required": true,
+  "packaging_plan_expected": true,
+  "deslop_qc": {
+    "report_only": true,
+    "aigc_detector": false,
+    "auto_rewrite": false
+  }
+}
+```
+
+## deslop_qc.json（CLI 生成，报告型 QC）
+
+`deslop_qc.json` 由本地 deterministic scanner 生成，Agent 不手写。它只是 report-only QC：不是 AIGC detector，不判断文本是不是 AI 写的，不会自动改写。修改仍由 Agent/人工根据报告回到 `narration.json`、`style_card.json` 或字幕源里处理。
+
+报告分两层：
+
+- `blockers`：客观阻断项，会并入 `narration_lint.json` 的 error，例如 requirements 要求但缺少/损坏 `style_card.json`、破折号、占位符泄漏、模板化“不是……而是……”转折。
+- `advisories`：建议项，只提示可读性/口语化风险，例如套话密度、抽象总结词、解释链、比喻标记、过长段落；它们不自动阻断，也不自动改写。
+
+```json
+{
+  "ok": false,
+  "contract": "Local readability/QC report only: this is not an AIGC detector, does not claim AI-generation accuracy, and never rewrites text. Corrections remain human/agent rewrite work.",
+  "scanner": "deslop_qc.py",
+  "style_card_required": true,
+  "blocker_count": 1,
+  "advisory_count": 1,
+  "blockers": [
+    {"severity": "blocker", "code": "missing_style_card", "source": "style_card", "index": null, "message": "style_card.json is required by this expression/packaging run but is missing"}
+  ],
+  "advisories": [
+    {"severity": "advisory", "code": "cliche_density", "source": "narration", "index": null, "message": "套话/高频抽象词偏密，建议换成具体行动、选择和后果"}
+  ],
+  "metrics": {"segments_scanned": 12, "text_units": 860, "sentence_count": 38}
+}
+```
+
 ## multi_source_manifest.json（多视频 cut）
 
 多视频剪辑模式下，项目级 `work_dir/multi_source_manifest.json` 是 `recap.py` / `cut.py` / `assemble.py` 的来源契约。`source_id` 默认由源文件 SHA-256 派生为 `src_<fingerprint[:12]>`；同一项目里重复 fingerprint 的不同路径会追加短 path hash 后缀。

--- a/skills/video-recap/references/data-schema.md
+++ b/skills/video-recap/references/data-schema.md
@@ -170,9 +170,9 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 ## deslop_qc_requirements.json（工具/brief 生成的运行契约）
 
-`deslop_qc_requirements.json` 是 tool/brief generated run contract：工具或 brief 生成本次运行的 QC 要求，供 `deslop_qc` 读取，不由 Agent 手写。字段包括 `schema_version`、`owner`、`style_card_required`、`packaging_plan_expected`、`deslop_qc.report_only`、`deslop_qc.aigc_detector`、`deslop_qc.auto_rewrite`。
+`deslop_qc_requirements.json` 是 tool/brief generated run contract：工具或 brief 生成本次运行的 QC 要求，供 `deslop_qc` 读取，不由 Agent 手写。字段为 `schema_version` 与 `style_card_required`。
 
-`deslop_qc` 只根据这个运行契约判断缺少 `style_card.json` 是否是 blocker；它不扫描 `agent_narration_brief.md` 的 prompt wording 来推断 `style_card_required`。如果 requirements 文件缺失或损坏，按 legacy/migration advisory 处理，不作为 hard failure。
+`style_card_required` 默认 `false`（advisory）：缺少 `style_card.json` 只是 warning，不阻断出片。将来的 opt-in 运行可把它设为 `true`，让 `style_card.json` 成为硬性要求——`deslop_qc` 只读这个字段判断缺少 `style_card.json` 是否是 blocker，不扫描 `agent_narration_brief.md` 的 prompt wording 来推断。如果 requirements 文件缺失或损坏，按 legacy/migration advisory 处理，不作为 hard failure。
 
 该契约不改变 `--style`：`--style` 仍是 freeform verbatim guidance，不增加固定风格档位。它也不改变 `deslop_qc` 边界：仍然是 report-only，不是 AIGC detector，不自动改写。
 
@@ -180,15 +180,8 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 ```json
 {
-  "schema_version": "1.0",
-  "owner": "tool_or_brief",
-  "style_card_required": true,
-  "packaging_plan_expected": true,
-  "deslop_qc": {
-    "report_only": true,
-    "aigc_detector": false,
-    "auto_rewrite": false
-  }
+  "schema_version": 1,
+  "style_card_required": false
 }
 ```
 

--- a/skills/video-recap/references/shift-left-qc-rules.json
+++ b/skills/video-recap/references/shift-left-qc-rules.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "stage_values": [
+    "pre_cut",
+    "post_cut",
+    "pre_tts",
+    "post_tts",
+    "pre_assemble",
+    "post_render",
+    "golden"
+  ],
+  "sample_policy_type_values": [
+    "all",
+    "deterministic",
+    "sampled",
+    "semantic",
+    "aesthetic"
+  ],
+  "deterministic_blocking_categories": [
+    "missing_artifact",
+    "stale_fingerprint",
+    "duration",
+    "stream",
+    "subtitle",
+    "tts_placement",
+    "schema_invalid",
+    "placement"
+  ],
+  "non_deterministic_default": {
+    "severity": "advisory",
+    "blocking": false
+  },
+  "non_deterministic_blocking_allow": []
+}

--- a/skills/video-recap/references/shift-left-qc-schema.md
+++ b/skills/video-recap/references/shift-left-qc-schema.md
@@ -1,0 +1,23 @@
+# Shift-left QC schema contract
+
+QC artifacts (`final_qc.json`, `golden_eval.json`, `mimo_qc.json`, `preflight_qc.json`) share one minimal schema, implemented by `skills/video-recap/scripts/qc_contract.py`.
+
+## Contract
+
+- `schema_version`: integer `1`.
+- `artifact`: one of `final_qc.json`, `golden_eval.json`, `mimo_qc.json`, `preflight_qc.json`.
+- `stage`: exactly one of `pre_cut`, `post_cut`, `pre_tts`, `post_tts`, `pre_assemble`, `post_render`, `golden`.
+  - Do not use `pre_voiceover`, `post_voiceover`, `pre_export`, `post_export`, `final`, `golden_eval`, or `mimo_qc` as stage values.
+  - `mimo_qc.json` is an artifact; MiMo findings attach to an actual stage such as `post_tts` or `pre_assemble`.
+- `findings[]`: every finding carries canonical fields `finding_id`, `stage`, `severity`, `blocking`, `deterministic`, `confidence`, `rule_id`, `decision_reason`, `location`, `evidence`, `sample_policy`, `model_used`, `artifact_fingerprints`, and `next_action`.
+- `sample_policy`: object with at least `type`; `type` must be one of `all`, `deterministic`, `sampled`, `semantic`, `aesthetic`.
+- `location.timecode` and `location.source_span` must exist. Pre-cut stages may set either to `null`.
+- Current helpers may also emit `id`, `category`, `code`, `message`, `source`, and `objective_corroboration` for compatibility and blocking-rule evaluation.
+
+## Blocking semantics
+
+Deterministic objective rules may block: missing/stale artifacts, duration or stream errors, subtitle and TTS placement errors, and schema-invalid errors.
+
+MiMo semantic/aesthetic findings are advisory by default and non-blocking. A non-deterministic finding cannot block unless `shift-left-qc-rules.json` has the same `schema_version` as `qc_contract.SCHEMA_VERSION`, explicitly allows its category/code, and the finding includes objective corroboration.
+
+The contract is schema-only: it does not call MiMo, does not connect the pipeline, does not auto-fix, and never reads or persists API keys. All QC report builders must pass metadata/evidence through `qc_contract.redact_secrets` before writing; this redacts secret-looking keys/values and strips URL userinfo/query/fragment while preserving useful host/path context.

--- a/skills/video-recap/scripts/final_qc.py
+++ b/skills/video-recap/scripts/final_qc.py
@@ -204,6 +204,28 @@ def _run_ffprobe(path: Path) -> Mapping[str, Any]:
     return data
 
 
+def _tail_decode_check(path: Path) -> tuple[bool | None, str | None]:
+    """Cheaply verify the final ~2s actually decodes. Returns (ok, detail).
+
+    Header probing (ffprobe -show_format/-show_streams) passes a container-valid but
+    media-truncated/corrupt payload (moov intact + mdat cut — realistic with +faststart on
+    disk-full or partial upload). Decoding the tail catches it. Returns (None, ...) when ffmpeg
+    is unavailable or the probe cannot run, so the caller skips rather than false-blocks.
+    """
+    if shutil.which("ffmpeg") is None:
+        return None, "ffmpeg unavailable"
+    try:
+        res = subprocess.run(
+            ["ffmpeg", "-v", "error", "-xerror", "-sseof", "-2", "-i", str(path), "-f", "null", "-"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"decode probe could not run: {exc}"
+    if res.returncode != 0:
+        return False, (res.stderr or "tail decode failed").strip()[:500]
+    return True, None
+
+
 def _probe_metadata(path: Path, *, probe_fixture: Any = None, probe_runner: ProbeRunner | None = None) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """Return (probe, error). Existing non-empty media gets deterministic error on failure."""
     if probe_fixture is not None:
@@ -475,7 +497,8 @@ def collect_metadata(work_dir: str | Path, *, final_output: str | Path | None = 
 
 
 def build_final_qc(work_dir: str | Path, final_output: str | Path | None = None,
-                   probe_fixture: Any = None, probe_runner: ProbeRunner | None = None) -> dict[str, Any]:
+                   probe_fixture: Any = None, probe_runner: ProbeRunner | None = None,
+                   decode_runner: Callable[[Path], tuple[bool | None, str | None]] | None = None) -> dict[str, Any]:
     root = Path(work_dir)
     selected = _select_final_output(root, final_output)
     metadata = collect_metadata(root, final_output=final_output, probe_fixture=probe_fixture, probe_runner=probe_runner)
@@ -519,11 +542,28 @@ def build_final_qc(work_dir: str | Path, final_output: str | Path | None = None,
             ))
         else:
             probe = metadata.get("probe")
-            findings.extend(_probe_contract_findings(
+            probe_findings = _probe_contract_findings(
                 probe if isinstance(probe, Mapping) else None,
                 final_meta=final_meta,
                 fingerprints=fps,
-            ))
+            )
+            findings.extend(probe_findings)
+            # Header probing cannot see a container-valid but media-truncated/corrupt payload.
+            # A cheap tail decode catches it; skip for offline fixtures and when ffmpeg is absent
+            # (decode_ok is None). Only add on a definite decode failure to avoid false-blocking.
+            if probe_fixture is None and not probe_findings:
+                decode_ok, decode_detail = (decode_runner or _tail_decode_check)(selected)
+                if decode_ok is False:
+                    findings.append(_finding(
+                        finding_id="final-qc-undecodable-stream",
+                        code="undecodable_stream",
+                        message="final output tail failed to decode (truncated or corrupt media payload)",
+                        category="stream",
+                        source={"artifact": final_meta.get("path")},
+                        evidence={"decode_error": decode_detail},
+                        fingerprints=fps,
+                        next_action="rerender_final_output",
+                    ))
     findings.extend(_upstream_blockers(root, "assembly_qc.json"))
     findings.extend(_upstream_blockers(root, "visual_qc.json"))
     report = qc_contract.build_report(

--- a/skills/video-recap/scripts/final_qc.py
+++ b/skills/video-recap/scripts/final_qc.py
@@ -117,7 +117,7 @@ def _file_metadata(path: Path | None, work_dir: Path | None = None) -> dict[str,
     display = str(path)
     if work_dir is not None:
         try:
-            display = str(path.relative_to(work_dir))
+            display = path.relative_to(work_dir).as_posix()
         except ValueError:
             pass
     item: dict[str, Any] = {"path": display}

--- a/skills/video-recap/scripts/final_qc.py
+++ b/skills/video-recap/scripts/final_qc.py
@@ -317,16 +317,10 @@ def _duration_from_probe(probe: Mapping[str, Any] | None) -> float | None:
     return None
 
 
-def _codec_from_probe(probe: Mapping[str, Any] | None, *, stream_type: str = "video") -> str | None:
-    if not isinstance(probe, Mapping):
-        return None
-    streams = probe.get("streams")
-    if not isinstance(streams, list):
-        return None
-    for stream in streams:
-        if isinstance(stream, Mapping) and stream.get("codec_type") == stream_type and stream.get("codec_name"):
-            return str(stream["codec_name"])
-    return None
+def _codec_from_probe(probe: Mapping[str, Any] | None) -> str | None:
+    vs = _first_video_stream(probe)
+    name = vs.get("codec_name") if isinstance(vs, Mapping) else None
+    return str(name) if name else None
 
 
 
@@ -474,9 +468,8 @@ def collect_metadata(work_dir: str | Path, *, final_output: str | Path | None = 
         "artifacts": artifacts,
         "probe": probe,
         "probe_error": probe_error,
-        "mimo_blocking_policy": "mimo_qc.json is advisory metadata only and is not rolled into final blockers",
+        # mimo_qc.json is advisory metadata only and is not rolled into final blockers.
         "auto_repair": False,
-        "network": False,
     }
     return redact_secrets(_json_safe(metadata))
 
@@ -570,7 +563,6 @@ def build_golden_eval(work_dir: str | Path, final_qc_report: Mapping[str, Any] |
         },
         "final_qc_fingerprint": fingerprint_file(root / FINAL_QC_ARTIFACT),
         "auto_repair": False,
-        "network": False,
     }
     findings: list[dict[str, Any]] = []
     expected_ok = fixture.get("expected_final_qc_ok", True)

--- a/skills/video-recap/scripts/final_qc.py
+++ b/skills/video-recap/scripts/final_qc.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""Final post-render QC and golden-eval reports for video-recap.
+
+Local deterministic/report-only checks only: no network, no repair, no secrets.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+import qc_contract
+
+FINAL_QC_ARTIFACT = "final_qc.json"
+GOLDEN_EVAL_ARTIFACT = "golden_eval.json"
+POST_RENDER_STAGE = "post_render"
+GOLDEN_STAGE = "golden"
+_COLLECT_ARTIFACTS = (
+    "assembly_manifest.json",
+    "assembly_qc.json",
+    "visual_qc.json",
+    "preflight_qc.json",
+    "mimo_qc.json",
+)
+ProbeRunner = Callable[[Path], Mapping[str, Any]]
+
+
+def redact_secrets(value: Any) -> Any:
+    """Return a JSON-safe copy with likely credentials removed."""
+    return qc_contract.redact_secrets(value)
+
+
+def safe_load_json(path_or_value: str | Path | Mapping[str, Any] | Sequence[Any] | None) -> Any:
+    """Safely load JSON from a path or return a redacted JSON-like fixture value."""
+    if path_or_value is None:
+        return None
+    if isinstance(path_or_value, (Mapping, list, tuple)):
+        return redact_secrets(path_or_value)
+    path = Path(path_or_value)
+    try:
+        return redact_secrets(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def fingerprint_file(path: str | Path) -> str | None:
+    path = Path(path)
+    try:
+        if path.exists() and path.is_file():
+            return qc_contract.artifact_fingerprint(path)
+    except OSError:
+        return None
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _resolve_in_work_dir(work_dir: Path, path: str | Path | None) -> Path | None:
+    if path is None or str(path) == "":
+        return None
+    p = Path(path)
+    return p if p.is_absolute() else work_dir / p
+
+
+def _candidate_final_outputs(work_dir: Path, final_output: str | Path | None) -> list[Path]:
+    candidates: list[Path] = []
+    explicit = _resolve_in_work_dir(work_dir, final_output)
+    if explicit is not None:
+        candidates.append(explicit)
+    manifest = safe_load_json(work_dir / "assembly_manifest.json")
+    if isinstance(manifest, Mapping):
+        for key in ("final_output", "output", "output_path", "video_path"):
+            if manifest.get(key):
+                p = _resolve_in_work_dir(work_dir, str(manifest[key]))
+                if p is not None:
+                    candidates.append(p)
+    for name in ("output.mp4", "recap.mp4", "final.mp4"):
+        candidates.append(work_dir / name)
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for p in candidates:
+        key = str(p)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(p)
+    return deduped
+
+
+def _select_final_output(work_dir: Path, final_output: str | Path | None) -> Path | None:
+    candidates = _candidate_final_outputs(work_dir, final_output)
+    if final_output is not None:
+        return candidates[0] if candidates else _resolve_in_work_dir(work_dir, final_output)
+    for p in candidates:
+        try:
+            if p.exists() and p.is_file() and p.stat().st_size > 0:
+                return p
+        except OSError:
+            continue
+    return candidates[0] if candidates else None
+
+
+def _file_metadata(path: Path | None, work_dir: Path | None = None) -> dict[str, Any]:
+    if path is None:
+        return {"path": None, "exists": False, "bytes": 0, "fingerprint": None}
+    display = str(path)
+    if work_dir is not None:
+        try:
+            display = str(path.relative_to(work_dir))
+        except ValueError:
+            pass
+    item: dict[str, Any] = {"path": display}
+    try:
+        exists = path.exists() and path.is_file()
+        item["exists"] = exists
+        item["bytes"] = path.stat().st_size if exists else 0
+        item["fingerprint"] = fingerprint_file(path) if exists else None
+    except OSError as exc:
+        item.update({"exists": False, "bytes": 0, "fingerprint": None, "error": str(exc)})
+    return redact_secrets(item)
+
+
+def _artifact_summary(work_dir: Path, name: str) -> dict[str, Any]:
+    path = work_dir / name
+    meta = _file_metadata(path, work_dir)
+    if meta.get("exists") and path.suffix.lower() == ".json":
+        data = safe_load_json(path)
+        if isinstance(data, Mapping):
+            meta["summary"] = {
+                "schema_version": data.get("schema_version"),
+                "artifact": data.get("artifact"),
+                "stage": data.get("stage"),
+                "ok": data.get("ok"),
+                "blocker_count": data.get("blocker_count"),
+                "finding_count": data.get("finding_count"),
+            }
+        elif data is not None:
+            meta["summary"] = {"type": type(data).__name__}
+    return redact_secrets(meta)
+
+
+def _artifact_fingerprints(*paths: Path | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for path in paths:
+        if path is None:
+            continue
+        fp = fingerprint_file(path)
+        if fp:
+            out[path.name] = fp
+    return out
+
+
+def _finding(*, finding_id: str, code: str, message: str, category: str = "schema_invalid",
+             stage: str = POST_RENDER_STAGE, source: Mapping[str, Any] | None = None,
+             evidence: Mapping[str, Any] | None = None, fingerprints: Mapping[str, Any] | None = None,
+             next_action: str = "manual_review") -> dict[str, Any]:
+    return qc_contract.build_finding(
+        finding_id=finding_id,
+        stage=stage,
+        severity="blocker",
+        confidence="objective",
+        sample_policy={"type": "deterministic"},
+        category=category,
+        code=code,
+        message=message,
+        deterministic=True,
+        blocking=True,
+        source=redact_secrets(source or {}),
+        evidence=redact_secrets(evidence or {}),
+        artifact_fingerprints=redact_secrets(fingerprints or {}),
+        next_action=next_action,
+        model_used="local_deterministic_final_qc_v1",
+    )
+
+
+def _run_ffprobe(path: Path) -> Mapping[str, Any]:
+    if shutil.which("ffprobe") is None:
+        raise RuntimeError("ffprobe unavailable")
+    cmd = [
+        "ffprobe", "-v", "error", "-print_format", "json",
+        "-show_format", "-show_streams", str(path),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        detail = (res.stderr or res.stdout or "ffprobe failed").strip()
+        raise RuntimeError(detail)
+    try:
+        data = json.loads(res.stdout or "{}")
+    except ValueError as exc:
+        raise RuntimeError(f"ffprobe returned invalid JSON: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise RuntimeError("ffprobe JSON must be an object")
+    return data
+
+
+def _probe_metadata(path: Path, *, probe_fixture: Any = None, probe_runner: ProbeRunner | None = None) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Return (probe, error). Existing non-empty media gets deterministic error on failure."""
+    if probe_fixture is not None:
+        data = safe_load_json(probe_fixture)
+        if isinstance(data, Mapping):
+            return redact_secrets(dict(data)), None
+        return None, {"code": "probe_failed", "message": "probe_fixture is missing or invalid JSON"}
+    try:
+        runner = probe_runner or _run_ffprobe
+        data = runner(path)
+        if not isinstance(data, Mapping):
+            raise RuntimeError("probe_runner must return an object")
+        return redact_secrets(dict(data)), None
+    except Exception as exc:  # deterministic report-only blocker, no crash
+        return None, {"code": "probe_failed", "message": str(exc) or "ffprobe failed"}
+
+
+def _first_video_stream(probe: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    if not isinstance(probe, Mapping):
+        return None
+    streams = probe.get("streams")
+    if not isinstance(streams, list):
+        return None
+    for stream in streams:
+        if isinstance(stream, Mapping) and stream.get("codec_type") == "video":
+            return stream
+    return None
+
+
+def _parse_positive_finite_number(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        if "/" in value:
+            numerator, denominator = value.split("/", 1)
+            try:
+                den = float(denominator)
+                if den == 0:
+                    return None
+                number = float(numerator) / den
+            except (TypeError, ValueError):
+                return None
+        else:
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                return None
+    else:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+    if math.isfinite(number) and number > 0:
+        return number
+    return None
+
+
+def _probe_duration_status(probe: Mapping[str, Any] | None) -> tuple[float | None, str | None, Any]:
+    if not isinstance(probe, Mapping):
+        return None, "missing_duration", None
+    candidates: list[Any] = []
+    fmt = probe.get("format")
+    if isinstance(fmt, Mapping):
+        candidates.append(fmt.get("duration"))
+    candidates.append(probe.get("duration"))
+    seen = [value for value in candidates if value not in (None, "")]
+    if not seen:
+        return None, "missing_duration", None
+    for value in seen:
+        duration = _parse_positive_finite_number(value)
+        if duration is not None:
+            return duration, None, value
+    return None, "invalid_duration", seen[0]
+
+
+def _probe_fps_status(video_stream: Mapping[str, Any] | None, probe: Mapping[str, Any] | None) -> tuple[float | None, str | None, Any]:
+    candidates: list[Any] = []
+    if isinstance(video_stream, Mapping):
+        for key in ("avg_frame_rate", "r_frame_rate", "fps", "frame_rate"):
+            candidates.append(video_stream.get(key))
+    if isinstance(probe, Mapping):
+        for key in ("fps", "frame_rate"):
+            candidates.append(probe.get(key))
+    seen = [value for value in candidates if value not in (None, "")]
+    if not seen:
+        return None, "missing_fps", None
+    for value in seen:
+        fps = _parse_positive_finite_number(value)
+        if fps is not None:
+            return fps, None, value
+    return None, "invalid_fps", seen[0]
+
+def _duration_from_probe(probe: Mapping[str, Any] | None) -> float | None:
+    if not isinstance(probe, Mapping):
+        return None
+    candidates: list[Any] = []
+    fmt = probe.get("format")
+    if isinstance(fmt, Mapping):
+        candidates.append(fmt.get("duration"))
+    candidates.append(probe.get("duration"))
+    for value in candidates:
+        try:
+            duration = float(value)
+        except (TypeError, ValueError):
+            continue
+        if duration >= 0:
+            return duration
+    return None
+
+
+def _codec_from_probe(probe: Mapping[str, Any] | None, *, stream_type: str = "video") -> str | None:
+    if not isinstance(probe, Mapping):
+        return None
+    streams = probe.get("streams")
+    if not isinstance(streams, list):
+        return None
+    for stream in streams:
+        if isinstance(stream, Mapping) and stream.get("codec_type") == stream_type and stream.get("codec_name"):
+            return str(stream["codec_name"])
+    return None
+
+
+
+def _probe_contract_findings(probe: Mapping[str, Any] | None, *, final_meta: Mapping[str, Any], fingerprints: Mapping[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    video_stream = _first_video_stream(probe)
+    if video_stream is None:
+        findings.append(_finding(
+            finding_id="final-qc-missing-video-stream",
+            code="missing_video_stream",
+            message="final output probe metadata has no video stream",
+            category="stream",
+            source={"artifact": final_meta.get("path")},
+            evidence={"streams": probe.get("streams") if isinstance(probe, Mapping) else None},
+            fingerprints=fingerprints,
+            next_action="rerender_final_output_with_video_stream",
+        ))
+
+    _duration, duration_code, duration_value = _probe_duration_status(probe)
+    if duration_code is not None:
+        findings.append(_finding(
+            finding_id=f"final-qc-{duration_code.replace('_', '-')}",
+            code=duration_code,
+            message="final output probe metadata is missing a positive finite duration" if duration_code == "missing_duration" else "final output probe metadata duration is not positive and finite",
+            category="duration",
+            source={"artifact": final_meta.get("path")},
+            evidence={"duration": duration_value},
+            fingerprints=fingerprints,
+            next_action="rerender_final_output_with_valid_duration",
+        ))
+
+    codec = str(video_stream.get("codec_name")).strip() if isinstance(video_stream, Mapping) and video_stream.get("codec_name") is not None else ""
+    if not codec:
+        findings.append(_finding(
+            finding_id="final-qc-missing-codec",
+            code="missing_codec",
+            message="final output probe metadata is missing a video codec",
+            category="stream",
+            source={"artifact": final_meta.get("path")},
+            evidence={"video_stream": video_stream},
+            fingerprints=fingerprints,
+            next_action="rerender_final_output_with_video_codec",
+        ))
+
+    _fps, fps_code, fps_value = _probe_fps_status(video_stream, probe)
+    if fps_code is not None:
+        findings.append(_finding(
+            finding_id=f"final-qc-{fps_code.replace('_', '-')}",
+            code=fps_code,
+            message="final output probe metadata is missing a positive finite video fps" if fps_code == "missing_fps" else "final output probe metadata video fps is not positive and finite",
+            category="stream",
+            source={"artifact": final_meta.get("path")},
+            evidence={"fps": fps_value, "video_stream": video_stream},
+            fingerprints=fingerprints,
+            next_action="rerender_final_output_with_valid_fps",
+        ))
+    return findings
+
+
+def _blocking_codes(value: Any) -> list[str]:
+    if isinstance(value, str):
+        values: Sequence[Any] = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        values = value
+    else:
+        return []
+    codes: list[str] = []
+    for item in values:
+        code = str(item).strip()
+        if code:
+            codes.append(code)
+    return codes
+
+
+def _failing_verdict(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    verdict = value.strip().lower()
+    return verdict in {"fail", "failed", "failing", "blocker", "blocked", "error", "errored", "reject", "rejected"}
+
+
+def _upstream_blockers(work_dir: Path, artifact_name: str) -> list[dict[str, Any]]:
+    path = work_dir / artifact_name
+    data = safe_load_json(path)
+    if not isinstance(data, Mapping):
+        return []
+    findings = data.get("findings")
+    blocker_count = data.get("blocker_count")
+    ok = data.get("ok")
+    blocked: list[Mapping[str, Any]] = []
+    if isinstance(findings, list):
+        blocked.extend(f for f in findings if isinstance(f, Mapping) and f.get("blocking") is True)
+    elif ok is False or (isinstance(blocker_count, int) and blocker_count > 0):
+        blocked.append({"code": "reported_blocker", "message": f"{artifact_name} reported blockers"})
+
+    blocking_codes = _blocking_codes(data.get("blocking_codes"))
+    if data.get("blocking") is True or _failing_verdict(data.get("verdict")):
+        if not blocking_codes:
+            blocking_codes = ["reported_blocker"]
+        for code in blocking_codes:
+            blocked.append({
+                "code": code,
+                "message": f"{artifact_name} reported {code}",
+                "artifact": data.get("artifact"),
+                "verdict": data.get("verdict"),
+                "blocking": data.get("blocking"),
+            })
+
+    out = []
+    fp = fingerprint_file(path)
+    for idx, item in enumerate(blocked):
+        code = str(item.get("code") or item.get("rule_id") or "reported_blocker")
+        out.append(_finding(
+            finding_id=f"final-qc-upstream-{artifact_name}-{idx}",
+            code=f"upstream_{artifact_name.replace('.', '_')}_{code}",
+            message=f"{artifact_name} has blocking finding: {item.get('message') or item.get('decision_reason') or code}",
+            category="schema_invalid",
+            source={"artifact": artifact_name, "finding_id": item.get("finding_id") or item.get("id")},
+            evidence={
+                "upstream_code": code,
+                "upstream_message": item.get("message") or item.get("decision_reason"),
+                "upstream_artifact": item.get("artifact"),
+                "upstream_verdict": item.get("verdict"),
+                "upstream_blocking": item.get("blocking"),
+            },
+            fingerprints={artifact_name: fp} if fp else {},
+            next_action="fix_upstream_qc_blocker",
+        ))
+    return out
+
+
+def collect_metadata(work_dir: str | Path, *, final_output: str | Path | None = None,
+                     probe_fixture: Any = None, probe_runner: ProbeRunner | None = None) -> dict[str, Any]:
+    root = Path(work_dir)
+    selected = _select_final_output(root, final_output)
+    probe = probe_error = None
+    final_meta = _file_metadata(selected, root)
+    if final_meta.get("exists") and final_meta.get("bytes", 0) > 0:
+        probe, probe_error = _probe_metadata(selected, probe_fixture=probe_fixture, probe_runner=probe_runner)
+    artifacts = {name: _artifact_summary(root, name) for name in _COLLECT_ARTIFACTS}
+    metadata = {
+        "work_dir": str(root),
+        "final_output": final_meta,
+        "final_output_candidates": [_file_metadata(p, root) for p in _candidate_final_outputs(root, final_output)],
+        "artifacts": artifacts,
+        "probe": probe,
+        "probe_error": probe_error,
+        "mimo_blocking_policy": "mimo_qc.json is advisory metadata only and is not rolled into final blockers",
+        "auto_repair": False,
+        "network": False,
+    }
+    return redact_secrets(_json_safe(metadata))
+
+
+def build_final_qc(work_dir: str | Path, final_output: str | Path | None = None,
+                   probe_fixture: Any = None, probe_runner: ProbeRunner | None = None) -> dict[str, Any]:
+    root = Path(work_dir)
+    selected = _select_final_output(root, final_output)
+    metadata = collect_metadata(root, final_output=final_output, probe_fixture=probe_fixture, probe_runner=probe_runner)
+    final_meta = metadata["final_output"]
+    findings: list[dict[str, Any]] = []
+    fps = _artifact_fingerprints(selected)
+    if not final_meta.get("exists"):
+        findings.append(_finding(
+            finding_id="final-qc-missing-final-output",
+            code="missing_final_output",
+            message="final output mp4 is missing",
+            category="missing_artifact",
+            source={"artifact": str(final_output) if final_output else "final_output"},
+            evidence={"final_output": final_meta},
+            fingerprints=fps,
+            next_action="render_final_output",
+        ))
+    elif int(final_meta.get("bytes") or 0) <= 0:
+        findings.append(_finding(
+            finding_id="final-qc-empty-final-output",
+            code="empty_final_output",
+            message="final output mp4 is empty",
+            category="missing_artifact",
+            source={"artifact": final_meta.get("path")},
+            evidence={"final_output": final_meta},
+            fingerprints=fps,
+            next_action="rerender_final_output",
+        ))
+    else:
+        probe_error = metadata.get("probe_error")
+        if isinstance(probe_error, Mapping):
+            findings.append(_finding(
+                finding_id="final-qc-probe-failed",
+                code="probe_failed",
+                message="ffprobe failed or was unavailable for existing non-empty final output",
+                category="stream",
+                source={"artifact": final_meta.get("path")},
+                evidence=probe_error,
+                fingerprints=fps,
+                next_action="inspect_or_rerender_final_output",
+            ))
+        else:
+            probe = metadata.get("probe")
+            findings.extend(_probe_contract_findings(
+                probe if isinstance(probe, Mapping) else None,
+                final_meta=final_meta,
+                fingerprints=fps,
+            ))
+    findings.extend(_upstream_blockers(root, "assembly_qc.json"))
+    findings.extend(_upstream_blockers(root, "visual_qc.json"))
+    report = qc_contract.build_report(
+        artifact=FINAL_QC_ARTIFACT,
+        stage=POST_RENDER_STAGE,
+        findings=findings,
+        metadata=metadata,
+    )
+    qc_contract.validate_report(report)
+    return report
+
+
+def _load_or_build_final_qc(work_dir: Path, final_qc_report: Mapping[str, Any] | None) -> dict[str, Any]:
+    if final_qc_report is not None:
+        report = dict(redact_secrets(final_qc_report))
+    else:
+        existing = safe_load_json(work_dir / FINAL_QC_ARTIFACT)
+        report = dict(existing) if isinstance(existing, Mapping) else build_final_qc(work_dir)
+    qc_contract.validate_report(report)
+    return report
+
+
+def build_golden_eval(work_dir: str | Path, final_qc_report: Mapping[str, Any] | None = None,
+                      golden_fixture: Any = None) -> dict[str, Any]:
+    root = Path(work_dir)
+    final_report = _load_or_build_final_qc(root, final_qc_report)
+    fixture = safe_load_json(golden_fixture)
+    fixture = fixture if isinstance(fixture, Mapping) else {}
+    metadata = {
+        "work_dir": str(root),
+        "fixture": fixture,
+        "final_qc": {
+            "ok": final_report.get("ok"),
+            "blocker_count": final_report.get("blocker_count"),
+            "artifact": final_report.get("artifact"),
+            "stage": final_report.get("stage"),
+        },
+        "final_qc_fingerprint": fingerprint_file(root / FINAL_QC_ARTIFACT),
+        "auto_repair": False,
+        "network": False,
+    }
+    findings: list[dict[str, Any]] = []
+    expected_ok = fixture.get("expected_final_qc_ok", True)
+    if isinstance(expected_ok, bool) and bool(final_report.get("ok")) != expected_ok:
+        findings.append(_finding(
+            finding_id="golden-final-qc-ok-mismatch",
+            stage=GOLDEN_STAGE,
+            code="expected_final_qc_ok_mismatch",
+            message="final_qc ok state does not match golden expectation",
+            category="schema_invalid",
+            source={"artifact": FINAL_QC_ARTIFACT},
+            evidence={"expected": expected_ok, "actual": final_report.get("ok")},
+            fingerprints={FINAL_QC_ARTIFACT: metadata["final_qc_fingerprint"]} if metadata["final_qc_fingerprint"] else {},
+            next_action="fix_final_qc_blockers",
+        ))
+    final_meta = {}
+    probe = None
+    if isinstance(final_report.get("metadata"), Mapping):
+        final_meta = final_report["metadata"].get("final_output") or {}
+        probe = final_report["metadata"].get("probe")
+    duration = _duration_from_probe(probe)
+    codec = _codec_from_probe(probe)
+    if fixture.get("min_duration") is not None and (duration is None or duration < float(fixture["min_duration"])):
+        findings.append(_finding(
+            finding_id="golden-min-duration-mismatch",
+            stage=GOLDEN_STAGE,
+            code="min_duration_mismatch",
+            message="final output duration is below golden minimum",
+            category="duration",
+            source={"artifact": final_meta.get("path")},
+            evidence={"expected_min_duration": fixture.get("min_duration"), "actual_duration": duration},
+            next_action="adjust_render_duration",
+        ))
+    if fixture.get("max_duration") is not None and (duration is None or duration > float(fixture["max_duration"])):
+        findings.append(_finding(
+            finding_id="golden-max-duration-mismatch",
+            stage=GOLDEN_STAGE,
+            code="max_duration_mismatch",
+            message="final output duration is above golden maximum",
+            category="duration",
+            source={"artifact": final_meta.get("path")},
+            evidence={"expected_max_duration": fixture.get("max_duration"), "actual_duration": duration},
+            next_action="adjust_render_duration",
+        ))
+    expected_codec = fixture.get("expected_codec") or fixture.get("expected_video_codec")
+    if expected_codec is not None and codec != str(expected_codec):
+        findings.append(_finding(
+            finding_id="golden-codec-mismatch",
+            stage=GOLDEN_STAGE,
+            code="codec_mismatch",
+            message="final output video codec does not match golden expectation",
+            category="stream",
+            source={"artifact": final_meta.get("path")},
+            evidence={"expected_codec": expected_codec, "actual_codec": codec},
+            next_action="adjust_render_codec",
+        ))
+    required = fixture.get("required_artifacts") or []
+    if isinstance(required, Sequence) and not isinstance(required, (str, bytes)):
+        for idx, name in enumerate(required):
+            artifact_path = root / str(name)
+            if not artifact_path.exists() or not artifact_path.is_file() or artifact_path.stat().st_size <= 0:
+                findings.append(_finding(
+                    finding_id=f"golden-required-artifact-missing-{idx}",
+                    stage=GOLDEN_STAGE,
+                    code="required_artifact_missing",
+                    message="golden fixture requires an artifact that is missing or empty",
+                    category="missing_artifact",
+                    source={"artifact": str(name)},
+                    evidence={"required_artifact": str(name)},
+                    next_action="produce_required_artifact",
+                ))
+    metadata["observed"] = {"duration": duration, "codec": codec, "final_output": final_meta}
+    report = qc_contract.build_report(
+        artifact=GOLDEN_EVAL_ARTIFACT,
+        stage=GOLDEN_STAGE,
+        findings=findings,
+        metadata=redact_secrets(_json_safe(metadata)),
+    )
+    qc_contract.validate_report(report)
+    return report
+
+
+def _write_report(path: Path, report: Mapping[str, Any]) -> None:
+    qc_contract.validate_report(report)
+    path.write_text(json.dumps(redact_secrets(report), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    qc_contract.validate_report(json.loads(path.read_text(encoding="utf-8")))
+
+
+def run(work_dir: str | Path, final_output: str | Path | None = None,
+        probe_fixture: Any = None, golden_fixture: Any = None,
+        probe_runner: ProbeRunner | None = None, only: str | None = None) -> dict[str, Any]:
+    root = Path(work_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    mode = {"final": "final_qc", "golden": "golden_eval"}.get(only or "all", only or "all")
+    if mode not in {"all", "final_qc", "golden_eval"}:
+        raise ValueError("only must be one of all, final_qc, golden_eval, final, golden")
+    result: dict[str, Any] = {"work_dir": str(root), "written": []}
+    final_report: dict[str, Any] | None = None
+    if mode in {"all", "final_qc"}:
+        final_report = build_final_qc(root, final_output=final_output, probe_fixture=probe_fixture, probe_runner=probe_runner)
+        _write_report(root / FINAL_QC_ARTIFACT, final_report)
+        result.update({"final_qc": {"ok": final_report["ok"], "blocker_count": final_report["blocker_count"]}})
+        result["written"].append(FINAL_QC_ARTIFACT)
+    if mode in {"all", "golden_eval"}:
+        golden_report = build_golden_eval(root, final_qc_report=final_report, golden_fixture=golden_fixture)
+        _write_report(root / GOLDEN_EVAL_ARTIFACT, golden_report)
+        result.update({"golden_eval": {"ok": golden_report["ok"], "blocker_count": golden_report["blocker_count"]}})
+        result["written"].append(GOLDEN_EVAL_ARTIFACT)
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Write final_qc.json and golden_eval.json for a video-recap work_dir.")
+    ap.add_argument("--work-dir", required=True)
+    ap.add_argument("--final-output", default=None)
+    ap.add_argument("--probe-fixture", default=None)
+    ap.add_argument("--golden-fixture", default=None)
+    ap.add_argument("--only", choices=["all", "final_qc", "golden_eval", "final", "golden"], default="all")
+    args = ap.parse_args(argv)
+    summary = run(
+        args.work_dir,
+        final_output=args.final_output,
+        probe_fixture=args.probe_fixture,
+        golden_fixture=args.golden_fixture,
+        only=args.only,
+    )
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -193,7 +193,7 @@ CONFIG = {
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
     "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 300,  # TTS fade-in/fade-out 时长(ms)
+    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
     # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
     "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
@@ -219,7 +219,10 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
+    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
+    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
+    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
@@ -250,6 +253,9 @@ CONFIG = {
     "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
     "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
     "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
+    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
+    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
+    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
     "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
@@ -264,6 +270,7 @@ CONFIG = {
     "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
     "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
     "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
+    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
     "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
     "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
     "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
@@ -281,6 +288,24 @@ CONFIG = {
 
 SCRIPT_DIR = Path(__file__).parent
 PROMPTS_DIR = SCRIPT_DIR.parent / "references"
+
+def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):
+    """Return the canonical tempo budget shared by voiceover and assemble."""
+    cfg = config or CONFIG
+    global_speed = max(0.01, float(cfg.get("narration_speed", 1.0) or 1.0))
+    rate_factor = max(0.01, 1.0 + float(tts_rate_offset or 0.0))
+    cumulative_max = max(1.0, float(cfg.get("narration_cumulative_tempo_max", 1.35) or 1.35))
+    hard_max = max(cumulative_max, float(cfg.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40))
+    legacy_segment_cap = max(1.0, float(cfg.get("tts_segment_tempo_max", 1.20) or 1.20))
+    segment_tempo_max = max(1.0, min(legacy_segment_cap, cumulative_max / (global_speed * rate_factor)))
+    return {
+        "global_narration_speed": global_speed,
+        "tts_rate_factor": rate_factor,
+        "cumulative_tempo_max": cumulative_max,
+        "cumulative_tempo_hard_max": hard_max,
+        "segment_tempo_max": segment_tempo_max,
+        "max_raw_duration_factor": global_speed * segment_tempo_max,
+    }
 
 def log(msg):
     print(f"[video-recap] {msg}", flush=True)

--- a/skills/video-recap/scripts/mimo_qc.py
+++ b/skills/video-recap/scripts/mimo_qc.py
@@ -229,10 +229,14 @@ def safe_mimo_config(config: Mapping[str, Any] | None = None) -> dict[str, Any]:
     safe = {key: source[key] for key in keep if key in source}
     model = source.get("mimo_video_model") or source.get("mimo_model") or source.get("vlm_model") or "mimo-v2.5"
     safe.setdefault("model", model)
-    safe["api_key_configured"] = bool(
+    key_present = bool(
         source.get("mimo_video_api_key") or source.get("mimo_api_key") or source.get("api_key")
     )
-    return _redact(safe)
+    safe = _redact(safe)
+    # Set AFTER redaction and under a non-secret-matching key so the boolean signal
+    # survives: redact_secrets() would blank any key containing "api_key"/"token"/etc.
+    safe["key_present"] = key_present
+    return safe
 
 
 def build_payload(evidence: Mapping[str, Any], *, stage: str = DEFAULT_STAGE,

--- a/skills/video-recap/scripts/mimo_qc.py
+++ b/skills/video-recap/scripts/mimo_qc.py
@@ -1,0 +1,446 @@
+"""Thin MiMo multimodal evidence QC adapter for video-recap.
+
+This module is report-only by design: it gathers lightweight local evidence,
+builds a compact judge payload, optionally normalizes an offline fixture/model
+response, and writes a qc_contract-compliant ``mimo_qc.json`` advisory report.
+It never repairs artifacts, never blocks the pipeline, and never persists API
+keys or secrets.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+import qc_contract
+
+try:  # Reuse existing MiMo config defaults without requiring callers to import lib.
+    from lib import CONFIG as DEFAULT_CONFIG
+except Exception:  # pragma: no cover - only for unusual standalone imports
+    DEFAULT_CONFIG = {}
+
+ARTIFACT_NAME = "mimo_qc.json"
+DEFAULT_STAGE = "pre_assemble"
+_JSON_ARTIFACTS = (
+    "narration.json",
+    "visual_overlays.json",
+    "clip_plan_validated.json",
+    "clip_plan.json",
+    "assembly_manifest.json",
+    "tts_meta.json",
+)
+_ASR_OR_SUBTITLE_ARTIFACTS = (
+    "asr.json",
+    "asr_result.json",
+    "asr_segments.json",
+    "subtitles.json",
+    "subtitle.json",
+    "subtitles.srt",
+    "subtitle.srt",
+    "subtitles.vtt",
+    "subtitle.vtt",
+    "output.srt",
+    "output.vtt",
+)
+_OPTIONAL_VISUAL_METADATA = (
+    "sampled_frames.json",
+    "frame_samples.json",
+    "storyboard.json",
+    "storyboard_meta.json",
+    "frames_manifest.json",
+)
+
+JudgeCallable = Callable[[Mapping[str, Any]], Mapping[str, Any] | Sequence[Mapping[str, Any]]]
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _fingerprint_value(value: Any) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _redact(value: Any) -> Any:
+    """Return a JSON-safe copy with likely credentials removed."""
+    return qc_contract.redact_secrets(value)
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return _redact(json.load(f))
+
+
+def _read_text_sample(path: Path, *, max_chars: int = 4000) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return {
+        "kind": "text",
+        "bytes": path.stat().st_size,
+        "truncated": len(text) > max_chars,
+        "sample": _redact(text[:max_chars]),
+    }
+
+
+def _summarize(value: Any, *, max_items: int = 8, max_string: int = 700, depth: int = 0) -> Any:
+    """Keep payloads small while preserving semantically useful structure."""
+    value = _redact(value)
+    if depth >= 4:
+        return {"type": type(value).__name__, "fingerprint": _fingerprint_value(value)}
+    if isinstance(value, Mapping):
+        out: dict[str, Any] = {}
+        for key in list(value)[:max_items]:
+            out[str(key)] = _summarize(value[key], max_items=max_items, max_string=max_string, depth=depth + 1)
+        if len(value) > max_items:
+            out["_omitted_keys"] = len(value) - max_items
+        return out
+    if isinstance(value, list):
+        return {
+            "count": len(value),
+            "items": [_summarize(item, max_items=max_items, max_string=max_string, depth=depth + 1)
+                      for item in value[:max_items]],
+            "omitted": max(0, len(value) - max_items),
+        }
+    if isinstance(value, str) and len(value) > max_string:
+        return {"text": value[:max_string], "truncated": True, "chars": len(value)}
+    return value
+
+
+def _collect_file(work_dir: Path, name: str) -> dict[str, Any] | None:
+    path = work_dir / name
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        fingerprint = qc_contract.artifact_fingerprint(path)
+        if path.suffix.lower() == ".json":
+            raw = _load_json(path)
+            summary = _summarize(raw)
+            kind = "json"
+        else:
+            raw = _read_text_sample(path)
+            summary = _summarize(raw)
+            kind = raw.get("kind", "file")
+        return {
+            "path": name,
+            "kind": kind,
+            "bytes": path.stat().st_size,
+            "fingerprint": fingerprint,
+            "summary": summary,
+        }
+    except Exception as exc:  # keep adapter report-only and resilient
+        return {"path": name, "kind": "unreadable", "error": str(exc)}
+
+
+def _first_existing(work_dir: Path, names: Sequence[str]) -> str | None:
+    for name in names:
+        if (work_dir / name).exists():
+            return name
+    return None
+
+
+def _final_output_metadata(work_dir: Path, final_output: str | Path | None = None) -> dict[str, Any]:
+    candidates: list[Path] = []
+    if final_output:
+        candidates.append(Path(final_output))
+    manifest_path = work_dir / "assembly_manifest.json"
+    if manifest_path.exists():
+        try:
+            manifest = _load_json(manifest_path)
+            for key in ("final_output", "output", "output_path", "video_path"):
+                if isinstance(manifest, Mapping) and manifest.get(key):
+                    candidates.append(Path(str(manifest[key])))
+        except Exception:
+            pass
+    for name in ("output.mp4", "recap.mp4", "final.mp4"):
+        candidates.append(work_dir / name)
+
+    seen: set[str] = set()
+    outputs = []
+    for candidate in candidates:
+        path = candidate if candidate.is_absolute() else work_dir / candidate
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        item: dict[str, Any] = {"path": str(candidate)}
+        if path.exists() and path.is_file():
+            item.update({
+                "exists": True,
+                "bytes": path.stat().st_size,
+                "fingerprint": qc_contract.artifact_fingerprint(path),
+            })
+        else:
+            item["exists"] = False
+        outputs.append(item)
+    return {"candidates": _redact(outputs)}
+
+
+def collect_evidence(work_dir: str | Path, *, final_output: str | Path | None = None) -> dict[str, Any]:
+    """Collect lightweight, secret-scrubbed evidence from a video-recap work_dir."""
+    root = Path(work_dir)
+    artifacts: dict[str, Any] = {}
+
+    # Prefer validated clip plan when present; include clip_plan only as fallback.
+    preferred_clip_plan = _first_existing(root, ("clip_plan_validated.json", "clip_plan.json"))
+    for name in _JSON_ARTIFACTS:
+        if name in {"clip_plan_validated.json", "clip_plan.json"} and name != preferred_clip_plan:
+            continue
+        item = _collect_file(root, name)
+        if item is not None:
+            artifacts[name] = item
+
+    asr_subtitles = {name: item for name in _ASR_OR_SUBTITLE_ARTIFACTS if (item := _collect_file(root, name))}
+    visual_metadata = {name: item for name in _OPTIONAL_VISUAL_METADATA if (item := _collect_file(root, name))}
+
+    evidence = {
+        "work_dir": str(root),
+        "artifacts": artifacts,
+        "asr_subtitles": asr_subtitles,
+        "visual_metadata": visual_metadata,
+        "final_output": _final_output_metadata(root, final_output),
+    }
+    evidence["fingerprint"] = _fingerprint_value(evidence)
+    return _redact(evidence)
+
+
+def safe_mimo_config(config: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Return non-secret MiMo judge configuration suitable for report metadata."""
+    source = dict(DEFAULT_CONFIG)
+    if config:
+        source.update(dict(config))
+    keep = (
+        "api_provider",
+        "mimo_api_url",
+        "mimo_api_url_source",
+        "mimo_video_api_url",
+        "mimo_video_api_url_source",
+        "mimo_model",
+        "mimo_model_source",
+        "mimo_video_model",
+        "mimo_video_model_source",
+        "vlm_model",
+        "vlm_model_source",
+        "mimo_disable_thinking",
+        "mimo_disable_thinking_source",
+        "mimo_media_resolution",
+        "mimo_media_resolution_source",
+    )
+    safe = {key: source[key] for key in keep if key in source}
+    model = source.get("mimo_video_model") or source.get("mimo_model") or source.get("vlm_model") or "mimo-v2.5"
+    safe.setdefault("model", model)
+    safe["api_key_configured"] = bool(
+        source.get("mimo_video_api_key") or source.get("mimo_api_key") or source.get("api_key")
+    )
+    return _redact(safe)
+
+
+def build_payload(evidence: Mapping[str, Any], *, stage: str = DEFAULT_STAGE,
+                  config: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Build a concise, mockable payload for a multimodal evidence judge."""
+    cfg = safe_mimo_config(config)
+    instructions = (
+        "You are a report-only video-recap QC judge. Review narration, overlays, clip plan, "
+        "assembly/TTS metadata, subtitles/ASR, final output metadata, and optional frames/storyboard. "
+        "Return concise subjective observations only; do not propose auto-repair or blocking decisions. "
+        "Each observation should include code, message, category (semantic/aesthetic), confidence "
+        "(low/medium/high), sample_policy (semantic/aesthetic/sampled), and evidence."
+    )
+    payload = {
+        "stage": stage,
+        "artifact": ARTIFACT_NAME,
+        "model": cfg.get("model"),
+        "config": cfg,
+        "instructions": instructions,
+        "evidence": _summarize(evidence, max_items=12),
+        "evidence_fingerprint": evidence.get("fingerprint") or _fingerprint_value(evidence),
+    }
+    payload["payload_fingerprint"] = _fingerprint_value(payload)
+    return _redact(payload)
+
+
+def _extract_observations(model_output: Any) -> list[Mapping[str, Any]]:
+    model_output = _redact(model_output)
+    if isinstance(model_output, str):
+        try:
+            model_output = json.loads(model_output)
+        except json.JSONDecodeError:
+            return [{"code": "freeform_observation", "message": model_output, "confidence": "low"}]
+    if isinstance(model_output, list):
+        return [item for item in model_output if isinstance(item, Mapping)]
+    if not isinstance(model_output, Mapping):
+        return []
+    if isinstance(model_output.get("observations"), list):
+        return [item for item in model_output["observations"] if isinstance(item, Mapping)]
+    if isinstance(model_output.get("findings"), list):
+        return [item for item in model_output["findings"] if isinstance(item, Mapping)]
+    # OpenAI-compatible fixture convenience.
+    try:
+        content = model_output["choices"][0]["message"]["content"]
+        return _extract_observations(content)
+    except Exception:
+        return [model_output] if model_output else []
+
+
+def _norm_choice(raw: Any, allowed: set[str], default: str) -> str:
+    value = str(raw or "").strip().lower()
+    return value if value in allowed else default
+
+
+def normalize_observations(model_output: Any, *, stage: str = DEFAULT_STAGE,
+                           payload: Mapping[str, Any] | None = None,
+                           model_config: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Normalize model/fixture observations into advisory qc_contract findings."""
+    payload = _redact(payload or {})
+    cfg = safe_mimo_config(model_config)
+    model_used = str(cfg.get("model") or "mimo-qc-offline-fixture")
+    findings: list[dict[str, Any]] = []
+    for idx, obs in enumerate(_extract_observations(model_output), start=1):
+        category_hint = str(obs.get("category") or obs.get("type") or "semantic").lower()
+        category = "mimo_aesthetic" if "aesthetic" in category_hint else "mimo_semantic"
+        code = str(obs.get("code") or obs.get("rule_id") or f"mimo_observation_{idx}").strip() or f"mimo_observation_{idx}"
+        message = str(obs.get("message") or obs.get("summary") or obs.get("text") or "MiMo QC observation").strip()
+        confidence = _norm_choice(obs.get("confidence"), {"low", "medium", "high"}, "low")
+        sample_policy_type = _norm_choice(
+            obs.get("sample_policy") or obs.get("sample_policy_type"),
+            {"semantic", "aesthetic", "sampled"},
+            "aesthetic" if category == "mimo_aesthetic" else "semantic",
+        )
+        location = obs.get("location") if isinstance(obs.get("location"), Mapping) else {}
+        evidence = obs.get("evidence") if isinstance(obs.get("evidence"), Mapping) else {}
+        evidence = {
+            **dict(evidence),
+            "model": model_used,
+            "config": cfg,
+            "cache": {
+                "mode": "fixture_or_dry_run",
+                "payload_fingerprint": payload.get("payload_fingerprint"),
+            },
+            "fingerprint": {
+                "evidence": payload.get("evidence_fingerprint"),
+                "observation": _fingerprint_value(obs),
+            },
+        }
+        findings.append(qc_contract.build_finding(
+            finding_id=str(obs.get("finding_id") or obs.get("id") or f"mimo-{idx:03d}"),
+            stage=stage,
+            severity="advisory",
+            confidence=confidence,
+            sample_policy={"type": sample_policy_type},
+            category=category,
+            code=code,
+            message=message,
+            deterministic=False,
+            blocking=False,
+            source={"artifact": ARTIFACT_NAME, "adapter": "mimo_qc.py"},
+            location=location,
+            evidence=_redact(evidence),
+            model_used=model_used,
+            artifact_fingerprints={
+                "payload": str(payload.get("payload_fingerprint") or "fixture"),
+                "evidence": str(payload.get("evidence_fingerprint") or "fixture"),
+            },
+            next_action="human_review",
+            decision_reason=message,
+        ))
+    return findings
+
+
+def build_report(work_dir: str | Path, *, stage: str = DEFAULT_STAGE, fixture: Any | None = None,
+                 dry_run: bool = False, judge: JudgeCallable | None = None,
+                 config: Mapping[str, Any] | None = None,
+                 final_output: str | Path | None = None) -> dict[str, Any]:
+    """Build a validated mimo_qc report without writing it."""
+    evidence = collect_evidence(work_dir, final_output=final_output)
+    payload = build_payload(evidence, stage=stage, config=config)
+    cfg = safe_mimo_config(config)
+    if fixture is not None:
+        model_output = fixture
+        mode = "fixture"
+    elif judge is not None and not dry_run:
+        model_output = judge(payload)
+        mode = "injected_judge"
+    else:
+        model_output = {"observations": []}
+        mode = "dry_run"
+
+    findings = normalize_observations(model_output, stage=stage, payload=payload, model_config=cfg)
+    report = qc_contract.build_report(
+        artifact=ARTIFACT_NAME,
+        stage=stage,
+        findings=findings,
+        metadata={
+            "mode": mode,
+            "report_only": True,
+            "auto_repair": False,
+            "pipeline_blocking": False,
+            "deterministic": False,
+            "evidence": evidence,
+            "payload": payload,
+            "config": cfg,
+        },
+    )
+    qc_contract.validate_report(report)
+    return _redact(report)
+
+
+def write_report(work_dir: str | Path, report: Mapping[str, Any], *, output: str | Path | None = None) -> Path:
+    path = Path(output) if output else Path(work_dir) / ARTIFACT_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    safe_report = _redact(dict(report))
+    qc_contract.validate_report(safe_report)
+    path.write_text(json.dumps(safe_report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    qc_contract.validate_report(json.loads(path.read_text(encoding="utf-8")))
+    return path
+
+
+def run(work_dir: str | Path, *, stage: str = DEFAULT_STAGE, fixture: Any | None = None,
+        dry_run: bool = False, judge: JudgeCallable | None = None,
+        config: Mapping[str, Any] | None = None,
+        final_output: str | Path | None = None,
+        output: str | Path | None = None) -> dict[str, Any]:
+    report = build_report(
+        work_dir,
+        stage=stage,
+        fixture=fixture,
+        dry_run=dry_run,
+        judge=judge,
+        config=config,
+        final_output=final_output,
+    )
+    path = write_report(work_dir, report, output=output)
+    return {"path": str(path), "report": report}
+
+
+def _load_fixture(path: str | Path | None) -> Any | None:
+    if not path:
+        return None
+    with Path(path).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Write advisory MiMo QC report from local video-recap evidence.")
+    parser.add_argument("--work-dir", required=True, help="video-recap work directory")
+    parser.add_argument("--stage", default=DEFAULT_STAGE, choices=sorted(qc_contract.STAGES))
+    parser.add_argument("--fixture", help="offline model-response fixture JSON")
+    parser.add_argument("--dry-run", action="store_true", help="write evidence-only report with no model observations")
+    parser.add_argument("--final-output", help="optional final video path metadata")
+    parser.add_argument("--output", help="optional output path; defaults to work_dir/mimo_qc.json")
+    args = parser.parse_args(argv)
+
+    fixture = _load_fixture(args.fixture)
+    result = run(
+        args.work_dir,
+        stage=args.stage,
+        fixture=fixture,
+        dry_run=args.dry_run or fixture is None,
+        final_output=args.final_output,
+        output=args.output,
+    )
+    print(json.dumps({"ok": result["report"]["ok"], "path": result["path"]}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skills/video-recap/scripts/qc_contract.py
+++ b/skills/video-recap/scripts/qc_contract.py
@@ -1,0 +1,388 @@
+"""Shared shift-left QC report contract for video-recap artifacts.
+
+This module is intentionally standalone: it defines a small schema and local
+validation helpers only. It does not call MiMo, read credentials, connect the
+pipeline, or attempt automatic fixes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+
+SCHEMA_VERSION = 1
+schema_version = SCHEMA_VERSION
+
+STAGES = frozenset({
+    "pre_cut",
+    "post_cut",
+    "pre_tts",
+    "post_tts",
+    "pre_assemble",
+    "post_render",
+    "golden",
+})
+SEVERITIES = frozenset({"info", "advisory", "warning", "blocker"})
+CONFIDENCES = frozenset({"low", "medium", "high", "objective"})
+SAMPLE_POLICIES = frozenset({"all", "deterministic", "sampled", "semantic", "aesthetic"})
+ARTIFACTS = frozenset({"final_qc.json", "golden_eval.json", "mimo_qc.json", "preflight_qc.json"})
+SUPPORTED_ARTIFACTS = ARTIFACTS
+stage_values = STAGES
+severity_values = SEVERITIES
+confidence_values = CONFIDENCES
+sample_policy_values = SAMPLE_POLICIES
+supported_artifacts = SUPPORTED_ARTIFACTS
+
+DETERMINISTIC_CATEGORIES = frozenset({
+    "missing_artifact",
+    "stale_fingerprint",
+    "duration",
+    "stream",
+    "subtitle",
+    "tts_placement",
+    "schema_invalid",
+    "placement",
+})
+NON_DETERMINISTIC_CATEGORIES = frozenset({"semantic", "aesthetic", "mimo_semantic", "mimo_aesthetic"})
+BLOCKING_SEVERITIES = frozenset({"blocker"})
+_SECRET_KEY_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization|credential)")
+_SECRET_VALUE_RE = re.compile(r"\b(?:sk|tp)-[A-Za-z0-9_-]{6,}\b")
+_URL_SCHEMES_TO_SCRUB = frozenset({"http", "https", "ws", "wss"})
+REDACTED = "<redacted>"
+
+
+def _redact_url(value: str) -> str:
+    """Strip URL credentials, query, and fragment while preserving useful host/path."""
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return value
+    if parts.scheme.lower() not in _URL_SCHEMES_TO_SCRUB or not parts.netloc:
+        return value
+    host = parts.hostname or ""
+    if not host:
+        return value
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    try:
+        port = parts.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def redact_secrets(value: Any) -> Any:
+    """Return a JSON-safe copy with likely credentials removed.
+
+    Centralized for all video-recap QC reports: redacts secret-looking keys,
+    common synthetic key/token values, and URL userinfo/query/fragment fields.
+    """
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_s = str(key)
+            redacted[key_s] = REDACTED if _SECRET_KEY_RE.search(key_s) else redact_secrets(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_secrets(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, str):
+        return _SECRET_VALUE_RE.sub(REDACTED, _redact_url(value))
+    return value
+
+
+_REQUIRED_FINDING_FIELDS = frozenset({
+    "finding_id",
+    "stage",
+    "severity",
+    "blocking",
+    "deterministic",
+    "confidence",
+    "rule_id",
+    "decision_reason",
+    "location",
+    "evidence",
+    "sample_policy",
+    "model_used",
+    "artifact_fingerprints",
+    "next_action",
+    # Helper fields kept for current rule semantics and compatibility.
+    "category",
+    "code",
+    "message",
+    "source",
+    "objective_corroboration",
+})
+_REQUIRED_LOCATION_FIELDS = frozenset({"timecode", "source_span"})
+_REQUIRED_REPORT_FIELDS = frozenset({
+    "schema_version",
+    "artifact",
+    "stage",
+    "ok",
+    "blocker_count",
+    "finding_count",
+    "findings",
+})
+
+
+class QCContractError(ValueError):
+    """Raised when a QC report or finding violates the shared contract."""
+
+
+def artifact_fingerprint(path: str | Path) -> str:
+    """Return a stable sha256 hex digest for an artifact file."""
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_rule_table(path: str | Path | None = None) -> dict[str, Any]:
+    """Load the optional blocking-allowance table.
+
+    The table contains no credentials and is never resolved from environment
+    variables. With no path, the skill reference table is loaded if present.
+    """
+    if path is None:
+        path = Path(__file__).resolve().parents[1] / "references" / "shift-left-qc-rules.json"
+    p = Path(path)
+    if not p.exists():
+        return {"schema_version": SCHEMA_VERSION, "non_deterministic_blocking_allow": []}
+    with p.open("r", encoding="utf-8") as f:
+        table = json.load(f)
+    if not isinstance(table, dict):
+        raise QCContractError("rule table must be a JSON object")
+    return table
+
+
+def _allowed_non_deterministic_blocking(rule_table: Mapping[str, Any] | None, category: str, code: str) -> bool:
+    if not rule_table or rule_table.get("schema_version") != SCHEMA_VERSION:
+        return False
+    for item in rule_table.get("non_deterministic_blocking_allow", []):
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("category") in (category, "*") and item.get("code") in (code, "*"):
+            return True
+    return False
+
+
+def _objective_corroboration_present(value: Any) -> bool:
+    return isinstance(value, Mapping) and bool(value.get("type")) and bool(value.get("evidence"))
+
+
+def build_finding(
+    *,
+    stage: str,
+    severity: str,
+    confidence: str,
+    sample_policy: str | Mapping[str, Any],
+    category: str,
+    code: str,
+    message: str,
+    finding_id: str | None = None,
+    id: str | None = None,
+    rule_id: str | None = None,
+    decision_reason: str | None = None,
+    model_used: str | None = None,
+    artifact_fingerprints: Mapping[str, Any] | None = None,
+    next_action: str | None = None,
+    deterministic: bool | None = None,
+    blocking: bool | None = None,
+    source: Mapping[str, Any] | None = None,
+    location: Mapping[str, Any] | None = None,
+    evidence: Mapping[str, Any] | None = None,
+    objective_corroboration: Mapping[str, Any] | None = None,
+    rule_table: Mapping[str, Any] | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build and validate one normalized QC finding.
+
+    Deterministic objective findings may block. MiMo semantic/aesthetic findings
+    default to advisory, non-blocking. Non-deterministic findings may not block
+    unless the rule table explicitly allows the category/code and objective
+    corroboration is supplied.
+    """
+    if finding_id is None:
+        finding_id = id
+    if finding_id is None:
+        raise QCContractError("finding_id is required")
+    if rule_id is None:
+        rule_id = code
+    if decision_reason is None:
+        decision_reason = message
+    if model_used is None:
+        model_used = "local_deterministic"
+    if artifact_fingerprints is None:
+        artifact_fingerprints = {}
+    if next_action is None:
+        next_action = "manual_review"
+    if isinstance(sample_policy, str):
+        sample_policy = {"type": sample_policy}
+
+    if deterministic is None:
+        deterministic = category in DETERMINISTIC_CATEGORIES
+    if source is None:
+        source = {}
+    source = redact_secrets(source)
+    if location is None:
+        location = {"timecode": None, "source_span": None}
+    else:
+        location = {"timecode": location.get("timecode"), "source_span": location.get("source_span")}
+    if evidence is None:
+        evidence = {}
+    evidence = redact_secrets(evidence)
+    artifact_fingerprints = redact_secrets(artifact_fingerprints)
+    objective_corroboration = redact_secrets(objective_corroboration or {})
+
+    is_non_deterministic = (not deterministic) or category in NON_DETERMINISTIC_CATEGORIES
+    if is_non_deterministic and blocking is None:
+        blocking = False
+    elif blocking is None:
+        blocking = severity in BLOCKING_SEVERITIES
+
+    if is_non_deterministic and blocking:
+        if not _allowed_non_deterministic_blocking(rule_table, category, code):
+            raise QCContractError(f"non-deterministic blocking finding is not allowed: {category}/{code}")
+        if not _objective_corroboration_present(objective_corroboration):
+            raise QCContractError("non-deterministic blocking finding requires objective_corroboration")
+
+    finding = {
+        "finding_id": finding_id,
+        "id": finding_id,
+        "stage": stage,
+        "severity": severity,
+        "blocking": bool(blocking),
+        "deterministic": bool(deterministic),
+        "confidence": confidence,
+        "rule_id": rule_id,
+        "decision_reason": decision_reason,
+        "location": dict(location),
+        "evidence": dict(evidence),
+        "sample_policy": dict(sample_policy),
+        "model_used": model_used,
+        "artifact_fingerprints": dict(artifact_fingerprints),
+        "next_action": next_action,
+        "category": category,
+        "code": code,
+        "message": message,
+        "source": dict(source),
+        "objective_corroboration": dict(objective_corroboration),
+    }
+    finding.update(redact_secrets(extra))
+    _validate_finding(finding, rule_table=rule_table)
+    return finding
+
+
+def build_report(
+    *,
+    artifact: str,
+    stage: str,
+    findings: list[Mapping[str, Any]] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    rule_table: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate a minimal report for a supported QC artifact."""
+    normalized_findings = [redact_secrets(dict(f)) for f in (findings or [])]
+    blocker_count = sum(1 for f in normalized_findings if f.get("blocking") is True)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact": artifact,
+        "stage": stage,
+        "ok": blocker_count == 0,
+        "blocker_count": blocker_count,
+        "finding_count": len(normalized_findings),
+        "findings": normalized_findings,
+        "metadata": redact_secrets(dict(metadata or {})),
+    }
+    validate_report(report, rule_table=rule_table)
+    return report
+
+
+def validate_report(report: Mapping[str, Any], rule_table: Mapping[str, Any] | None = None) -> bool:
+    """Validate report shape, value domains, and blocking semantics."""
+    if not isinstance(report, Mapping):
+        raise QCContractError("report must be an object")
+    missing = _REQUIRED_REPORT_FIELDS - set(report)
+    if missing:
+        raise QCContractError(f"report missing required fields: {sorted(missing)}")
+    if report["schema_version"] != SCHEMA_VERSION:
+        raise QCContractError(f"unsupported schema_version: {report['schema_version']!r}")
+    if report["artifact"] not in ARTIFACTS:
+        raise QCContractError(f"unsupported artifact: {report['artifact']!r}")
+    if report["stage"] not in STAGES:
+        raise QCContractError(f"unsupported stage: {report['stage']!r}")
+    if not isinstance(report["findings"], list):
+        raise QCContractError("findings must be a list")
+    for finding in report["findings"]:
+        _validate_finding(finding, rule_table=rule_table)
+    blocker_count = sum(1 for f in report["findings"] if f.get("blocking") is True)
+    if report["blocker_count"] != blocker_count:
+        raise QCContractError("blocker_count does not match findings")
+    if report["finding_count"] != len(report["findings"]):
+        raise QCContractError("finding_count does not match findings")
+    if report["ok"] != (blocker_count == 0):
+        raise QCContractError("ok must be true exactly when blocker_count is zero")
+    return True
+
+
+def _validate_finding(finding: Mapping[str, Any], rule_table: Mapping[str, Any] | None = None) -> None:
+    if not isinstance(finding, Mapping):
+        raise QCContractError("finding must be an object")
+    missing = _REQUIRED_FINDING_FIELDS - set(finding)
+    if missing:
+        raise QCContractError(f"finding missing required fields: {sorted(missing)}")
+    if finding["stage"] not in STAGES:
+        raise QCContractError(f"unsupported finding stage: {finding['stage']!r}")
+    if finding["severity"] not in SEVERITIES:
+        raise QCContractError(f"unsupported severity: {finding['severity']!r}")
+    if finding["confidence"] not in CONFIDENCES:
+        raise QCContractError(f"unsupported confidence: {finding['confidence']!r}")
+    sample_policy = finding["sample_policy"]
+    if not isinstance(sample_policy, Mapping):
+        raise QCContractError("sample_policy must be an object")
+    sample_policy_type = sample_policy.get("type")
+    if sample_policy_type not in SAMPLE_POLICIES:
+        raise QCContractError(f"unsupported sample_policy.type: {sample_policy_type!r}")
+    if not isinstance(finding["deterministic"], bool):
+        raise QCContractError("deterministic must be boolean")
+    if not isinstance(finding["blocking"], bool):
+        raise QCContractError("blocking must be boolean")
+    if finding["blocking"] and finding["severity"] != "blocker":
+        raise QCContractError("blocking findings must use severity='blocker'")
+    location = finding["location"]
+    if not isinstance(location, Mapping):
+        raise QCContractError("location must be an object")
+    missing_location = _REQUIRED_LOCATION_FIELDS - set(location)
+    if missing_location:
+        raise QCContractError(f"location missing required fields: {sorted(missing_location)}")
+    if finding["source"] is None or not isinstance(finding["source"], Mapping):
+        raise QCContractError("source must be an object")
+    if finding["evidence"] is None or not isinstance(finding["evidence"], Mapping):
+        raise QCContractError("evidence must be an object")
+    if finding["artifact_fingerprints"] is None or not isinstance(finding["artifact_fingerprints"], Mapping):
+        raise QCContractError("artifact_fingerprints must be an object")
+    if finding["objective_corroboration"] is None or not isinstance(finding["objective_corroboration"], Mapping):
+        raise QCContractError("objective_corroboration must be an object")
+    for field in ("finding_id", "rule_id", "decision_reason", "model_used", "next_action"):
+        if not isinstance(finding[field], str) or not finding[field]:
+            raise QCContractError(f"{field} must be a non-empty string")
+
+    is_non_deterministic = (not finding["deterministic"]) or finding["category"] in NON_DETERMINISTIC_CATEGORIES
+    if is_non_deterministic and finding["blocking"]:
+        if not _allowed_non_deterministic_blocking(rule_table, finding["category"], finding["code"]):
+            raise QCContractError(
+                f"non-deterministic blocking finding is not allowed: {finding['category']}/{finding['code']}"
+            )
+        if not _objective_corroboration_present(finding["objective_corroboration"]):
+            raise QCContractError("non-deterministic blocking finding requires objective_corroboration")

--- a/skills/video-recap/scripts/qc_contract.py
+++ b/skills/video-recap/scripts/qc_contract.py
@@ -15,7 +15,6 @@ from urllib.parse import urlsplit, urlunsplit
 
 
 SCHEMA_VERSION = 1
-schema_version = SCHEMA_VERSION
 
 STAGES = frozenset({
     "pre_cut",
@@ -31,11 +30,6 @@ CONFIDENCES = frozenset({"low", "medium", "high", "objective"})
 SAMPLE_POLICIES = frozenset({"all", "deterministic", "sampled", "semantic", "aesthetic"})
 ARTIFACTS = frozenset({"final_qc.json", "golden_eval.json", "mimo_qc.json", "preflight_qc.json"})
 SUPPORTED_ARTIFACTS = ARTIFACTS
-stage_values = STAGES
-severity_values = SEVERITIES
-confidence_values = CONFIDENCES
-sample_policy_values = SAMPLE_POLICIES
-supported_artifacts = SUPPORTED_ARTIFACTS
 
 DETERMINISTIC_CATEGORIES = frozenset({
     "missing_artifact",

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -21,6 +21,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import qc_contract
+# Same-skill local QC helper exception: final_qc is imported directly so recap can
+# write report-only post-render QC without subprocess overhead or credential/env
+# expansion. Sibling skills still communicate through subprocess artifacts.
+import final_qc
 from doctor import ffmpeg_has_subtitles_filter
 import materials as material_lib
 
@@ -44,6 +49,113 @@ MULTI_SOURCE_NARRATION_CRAFT_BULLETS = [
     "- Leave deliberate original-audio gaps between blocks for strong source moments; tee up the gap before it plays and react to it after it plays.",
     "- Use the kept-clip map and each source work_dir to retrieve source facts, names, ASR, and per-source brief context when a beat is unclear.",
 ]
+
+
+
+
+def _json_safe(value):
+    """Return a JSON-serializable, secret-redacted copy for local QC metadata."""
+    def convert(item):
+        if isinstance(item, Path):
+            return str(item)
+        if isinstance(item, dict):
+            return {str(k): convert(v) for k, v in item.items()}
+        if isinstance(item, (list, tuple)):
+            return [convert(v) for v in item]
+        return item
+
+    return qc_contract.redact_secrets(convert(value))
+
+
+def _load_preflight_stage_reports(work_dir):
+    path = Path(work_dir) / "preflight_qc.json"
+    if not path.exists():
+        return {}
+    data = _load_json(path)
+    if not isinstance(data, dict):
+        raise qc_contract.QCContractError("preflight_qc.json must be a JSON object")
+    qc_contract.validate_report(data)
+    stages = None
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("stages"), dict):
+        stages = metadata.get("stages")
+    elif isinstance(data.get("stages"), dict):
+        stages = data.get("stages")
+    if stages is None:
+        return {data["stage"]: data}
+    stage_reports = {}
+    for stage, report in stages.items():
+        if not isinstance(report, dict):
+            raise qc_contract.QCContractError(f"preflight stage report must be an object: {stage}")
+        qc_contract.validate_report(report)
+        if report.get("stage") != stage:
+            raise qc_contract.QCContractError(f"preflight stage key does not match report stage: {stage}")
+        stage_reports[stage] = report
+    return stage_reports
+
+
+def _write_shift_left_stage_qc(work_dir, stage, metadata=None, findings=None):
+    """Write/roll up local shift-left QC for one pipeline stage.
+
+    This is a local contract artifact only: no MiMo/deep eval calls, no repair, and
+    no credential persistence. Any validation/write failure is allowed to raise.
+    """
+    work_dir = Path(work_dir)
+    path = work_dir / "preflight_qc.json"
+    stage_report = qc_contract.build_report(
+        artifact="preflight_qc.json",
+        stage=stage,
+        findings=findings or [],
+        metadata=_json_safe(metadata or {}),
+    )
+    stage_reports = _load_preflight_stage_reports(work_dir)
+    stage_reports[stage] = stage_report
+    aggregate_findings = []
+    for report in stage_reports.values():
+        aggregate_findings.extend(dict(f) for f in report.get("findings", []))
+    top_metadata = dict(stage_report.get("metadata") or {})
+    top_metadata["latest_stage"] = stage
+    top_metadata["stages"] = stage_reports
+    top_report = qc_contract.build_report(
+        artifact="preflight_qc.json",
+        stage=stage,
+        findings=aggregate_findings,
+        metadata=_json_safe(top_metadata),
+    )
+    qc_contract.validate_report(top_report)
+    path.write_text(json.dumps(top_report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    qc_contract.validate_report(_load_json(path))
+    return top_report
+
+
+def _tts_qc_metadata(work_dir):
+    work_dir = Path(work_dir)
+    metadata = {}
+    tts_meta = _load_json(work_dir / "tts_meta.json")
+    if tts_meta is not None:
+        metadata["tts_meta"] = tts_meta
+    tts_dir = work_dir / "tts_segments"
+    if tts_dir.exists() and tts_dir.is_dir():
+        metadata["tts_segments"] = [str(p.relative_to(work_dir)) for p in sorted(tts_dir.iterdir()) if p.is_file()]
+    return metadata
+
+
+def _post_render_qc_metadata(work_dir, final_output):
+    work_dir = Path(work_dir)
+    metadata = {"final_output": str(final_output) if final_output is not None else None}
+    assembly_manifest = _load_json(work_dir / ASSEMBLY_MANIFEST)
+    if assembly_manifest is not None:
+        metadata["assembly_manifest"] = assembly_manifest
+    return metadata
+
+
+def _write_final_qc_reports(work_dir, final_output):
+    """Write report-only final QC artifacts after render.
+
+    final_qc.run converts ffprobe unavailability/failure into deterministic
+    blockers; only unexpected schema/write errors propagate.
+    """
+    return final_qc.run(work_dir, final_output=final_output)
 
 
 def _entry(skill, script):
@@ -919,7 +1031,8 @@ def _run_multi_cut(videos, work_dir, args):
     if getattr(args, "allow_sparse_cut", False):
         crender.append("--allow-sparse-cut")
     _run("video-cut", "cut.py", *crender)
-    _surface_cut_qc(work_dir)
+    cut_qc = _surface_cut_qc(work_dir)
+    _write_shift_left_stage_qc(work_dir, "post_cut", metadata={"cut_qc": cut_qc})
     if not narration_json.exists():
         _write_multi_source_output_brief(work_dir, source_records, work_dir / "clip_plan_validated.json")
         _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp, edited_source_rendered=True, multi_source=True)
@@ -941,13 +1054,16 @@ def _run_multi_cut(videos, work_dir, args):
     _run("video-script", "validate.py", "--work-dir", work_dir, "--mode", "cut_output",
          "--output-duration", f"{output_duration:.3f}")
     review_ran = _run_narration_review(work_dir, args, timeline="cut_output")
+    _write_shift_left_stage_qc(work_dir, "pre_tts", metadata={"review_ran": review_ran, "timeline": "cut_output"})
     vargs = ["--work-dir", str(work_dir), "--narration", str(narration_json)]
     if args.mimo_tts_voice:
         vargs += ["--mimo-voice", args.mimo_tts_voice]
     if args.allow_partial_tts:
         vargs.append("--allow-partial-tts")
     _run("video-voiceover", "voiceover.py", *vargs)
-    _write_canonical_visual_overlays(work_dir, narration_json)
+    _write_shift_left_stage_qc(work_dir, "post_tts", metadata=_tts_qc_metadata(work_dir))
+    overlays_path = _write_canonical_visual_overlays(work_dir, narration_json)
+    _write_shift_left_stage_qc(work_dir, "pre_assemble", metadata={"visual_overlays": str(overlays_path)})
 
     recap_stem = f"multi_{videos[0].stem}"
     aargs = [str(edited_source), "--work-dir", str(work_dir), "--recap-stem", recap_stem]
@@ -965,6 +1081,8 @@ def _run_multi_cut(videos, work_dir, args):
 
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
     final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + recap_stem + ".mp4"))
+    _write_shift_left_stage_qc(work_dir, "post_render", metadata=_post_render_qc_metadata(work_dir, final_output))
+    _write_final_qc_reports(work_dir, final_output)
     print(f"[video-recap] ✅ 完成: {final_output}")
     _print_narration_review_pointer(work_dir, review_ran=review_ran)
 
@@ -1150,7 +1268,8 @@ def main():
         if getattr(args, "allow_sparse_cut", False):
             crender.append("--allow-sparse-cut")
         _run("video-cut", "cut.py", *crender)
-        _surface_cut_qc(work_dir)
+        cut_qc = _surface_cut_qc(work_dir)
+        _write_shift_left_stage_qc(work_dir, "post_cut", metadata={"cut_qc": cut_qc})
         if not narration_json.exists():
             # PASS 2: rebuild the brief (now an OUTPUT-timeline variant) and pause for narration.
             _rebuild_output_brief()
@@ -1171,13 +1290,20 @@ def main():
         narration_for_tts = narration_json
         assemble_video_path = edited_source
     review_ran = _run_narration_review(work_dir, args, timeline="cut_output" if cut else "source")
+    _write_shift_left_stage_qc(
+        work_dir,
+        "pre_tts",
+        metadata={"review_ran": review_ran, "timeline": "cut_output" if cut else "source"},
+    )
     vargs = ["--work-dir", str(work_dir), "--narration", str(narration_for_tts)]
     if args.mimo_tts_voice:
         vargs += ["--mimo-voice", args.mimo_tts_voice]
     if args.allow_partial_tts:
         vargs.append("--allow-partial-tts")
     _run("video-voiceover", "voiceover.py", *vargs)
-    _write_canonical_visual_overlays(work_dir, narration_for_tts)
+    _write_shift_left_stage_qc(work_dir, "post_tts", metadata=_tts_qc_metadata(work_dir))
+    overlays_path = _write_canonical_visual_overlays(work_dir, narration_for_tts)
+    _write_shift_left_stage_qc(work_dir, "pre_assemble", metadata={"visual_overlays": str(overlays_path)})
 
     aargs = [str(assemble_video_path), "--work-dir", str(work_dir), "--recap-stem", video.stem]
     if args.output_dir:
@@ -1199,6 +1325,8 @@ def main():
 
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
     final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + video.stem + ".mp4"))
+    _write_shift_left_stage_qc(work_dir, "post_render", metadata=_post_render_qc_metadata(work_dir, final_output))
+    _write_final_qc_reports(work_dir, final_output)
     print(f"[video-recap] ✅ 完成: {final_output}")
     _print_narration_review_pointer(work_dir, review_ran=review_ran)
 

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -31,6 +31,21 @@ PHASE_LEDGER = "recap_phase.json"
 MULTI_SOURCE_MANIFEST = "multi_source_manifest.json"
 
 
+CUT_TIMELINE_CRAFT_BULLETS = [
+    "- Build one story spine, not unordered highlights: 0–1 optional cold-open/high-impact clip may come first, then return to setup → turn → payoff in a coherent arc.",
+    "- Use clip `reason` as craft intent where useful: `cold_open`, `setup`, `turn`, or `payoff` plus a concrete why.",
+    "- Prefer causal/reveal/decision/emotional beats; skip credits, ads, repeated static filler, and watermark/无法描述 stretches.",
+    "- End clips on complete spoken lines or quiet windows so original audio does not enter/exit mid-sentence.",
+]
+
+MULTI_SOURCE_NARRATION_CRAFT_BULLETS = [
+    "- Write against the OUTPUT timeline of edited_source.mp4 only; do not use original source timestamps for narration.json.",
+    "- Recap in BLOCKS of 2–4 complete sentences, not isolated caption fragments; each block should advance the same story spine.",
+    "- Leave deliberate original-audio gaps between blocks for strong source moments; tee up the gap before it plays and react to it after it plays.",
+    "- Use the kept-clip map and each source work_dir to retrieve source facts, names, ASR, and per-source brief context when a beat is unclear.",
+]
+
+
 def _entry(skill, script):
     return BUNDLE / skill / "scripts" / script
 
@@ -131,6 +146,8 @@ def _run_narration_review(work_dir, args, *, timeline="source"):
         # through to review.py's auto-detect (which could flip on stale cut artifacts left in a
         # reused full-mode work_dir).
         rargs = ["--work-dir", work_dir, "--timeline", timeline]
+        if strict and timeline == "cut_output":
+            rargs.append("--strict-evidence")
         _run("video-script", "review.py", *rargs)
     except SystemExit as exc:
         if strict:
@@ -315,12 +332,121 @@ def _preflight_burn_subtitles(args):
             f"  自检：python3 {shlex.quote(str(_entry('video-recap', 'doctor.py')))}")
 
 
+
+
+_ALLOWED_VISUAL_OVERLAY_TYPES = {"top_title", "inline_label_or_callout"}
+_VISUAL_OVERLAYS = "visual_overlays.json"
+
+
+def _finite_number(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _iter_narration_segments(narration_data):
+    if isinstance(narration_data, list):
+        yield from (item for item in narration_data if isinstance(item, dict))
+        return
+    if not isinstance(narration_data, dict):
+        return
+    for key in ("segments", "narration", "items"):
+        value = narration_data.get(key)
+        if isinstance(value, list):
+            yield from (item for item in value if isinstance(item, dict))
+            return
+
+
+def _canonical_visual_overlay(overlay, segment=None):
+    """Return the first-release assemble overlay contract, or None.
+
+    Recap owns the handoff artifact but does not invent richer overlay semantics. Only the
+    two overlay types implemented by assemble are allowed through; all unknown platform or
+    future types stay out of the canonical first-release file.
+    """
+    if not isinstance(overlay, dict):
+        return None
+    typ = overlay.get("type")
+    if typ not in _ALLOWED_VISUAL_OVERLAY_TYPES:
+        return None
+    text = overlay.get("text")
+    if text is None or str(text) == "":
+        return None
+    seg = segment if isinstance(segment, dict) else {}
+    start = _finite_number(overlay.get("start"))
+    end = _finite_number(overlay.get("end"))
+    if start is None:
+        start = _finite_number(seg.get("start"))
+    if end is None:
+        end = _finite_number(seg.get("end"))
+    if start is None or end is None or end <= start:
+        return None
+
+    item = {"type": typ, "text": str(text), "start": start, "end": end}
+    # Preserve renderer-supported placement hints supplied by upstream facts; do not add new
+    # semantic overlay kinds or infer platform-specific cards/chapters.
+    for key in ("anchor", "x", "y", "max_width", "style"):
+        if key in overlay:
+            item[key] = overlay[key]
+    return item
+
+
+def _extract_visual_overlays_from_narration(narration_path):
+    data = _load_json(narration_path)
+    overlays = []
+    for segment in _iter_narration_segments(data):
+        raw = segment.get("visual_overlays")
+        if not isinstance(raw, list):
+            continue
+        for overlay in raw:
+            item = _canonical_visual_overlay(overlay, segment)
+            if item is not None:
+                overlays.append(item)
+    return overlays
+
+
+def _write_canonical_visual_overlays(work_dir, narration_path):
+    """Write assemble's canonical work_dir/visual_overlays.json recap handoff.
+
+    Direct assemble still supports user-authored/manual visual_overlays.json files. Once
+    recap owns the handoff for a narration, however, the canonical artifact must be a
+    deterministic reflection of the current narration so reused work_dirs cannot render
+    stale overlays from a previous run. Unsupported/future overlay types are filtered out
+    and represented as an explicit empty overlay list.
+    """
+    work_dir = Path(work_dir)
+    path = work_dir / _VISUAL_OVERLAYS
+    overlays = _extract_visual_overlays_from_narration(narration_path)
+    payload = {"schema_version": 1, "overlays": overlays}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"[video-recap] 🧩 visual overlays: {len(overlays)} → {path}", flush=True)
+    return path
+
+
+def _print_grounding_qc_pointer(work_dir):
+    qc_path = Path(work_dir) / "grounding_qc.json"
+    if not qc_path.exists():
+        return
+    data = _load_json(qc_path)
+    if isinstance(data, dict):
+        verdict = data.get("verdict", "unknown")
+        ranges = (data.get("review_coverage") or {}).get("time_ranges") or []
+        warnings = data.get("warnings") or []
+        suffix = f" · warnings {len(warnings)}" if warnings else ""
+        print(f"[video-recap] 🧭 Grounding QC: {verdict} · ranges {len(ranges)}{suffix} → {qc_path}", flush=True)
+    else:
+        print(f"[video-recap] 🧭 Grounding QC → {qc_path}", flush=True)
+
+
 def _print_narration_review_pointer(work_dir, *, review_ran=True):
     """Surface the advisory narration review produced by this run, if any.
 
     Review is optional/fail-open. Avoid surfacing a stale narration_review.md from an
     older run when review was disabled or failed before producing fresh artifacts.
     """
+    _print_grounding_qc_pointer(work_dir)
     if not review_ran:
         return
     review_md = Path(work_dir) / "narration_review.md"
@@ -451,6 +577,8 @@ def _continuation_command(video, work_dir, args):
         parts += ["--edit-mode", args.edit_mode]
     if args.target_duration:
         parts += ["--target-duration", args.target_duration]
+    if getattr(args, "allow_duration_drift", False):
+        parts.append("--allow-duration-drift")
     if getattr(args, "allow_sparse_cut", False):
         parts.append("--allow-sparse-cut")
     if args.skip_asr:
@@ -536,6 +664,11 @@ def _write_multi_source_clip_brief(work_dir, source_records, args):
         "- `start`/`end` 是对应 source 原视频时间（秒）。",
         "- 不同 `source_id` 的相同时间段不算重叠；同一 `source_id` 内不要重复/重叠，除非你明确接受稀疏/重复剪辑风险。",
         "- 素材库是文件系统 JSON/MD/JSONL；需要找历史素材时直接 `grep -R \"关键词\" <material-library-dir>`。",
+        "",
+        "## Cut craft",
+        *CUT_TIMELINE_CRAFT_BULLETS,
+        "- For multi-source, choose clips across sources to serve the shared story spine; do not let one source become a disconnected mini-recap unless that is the intended setup/turn/payoff.",
+        "- Use each source work_dir below (`sources/<source_id>`) to retrieve scenes.json, ASR, indexes, and per-source brief context before selecting clips.",
     ]
     if args.target_duration:
         lines.append(f"- 目标时长：`{args.target_duration}`。")
@@ -572,6 +705,10 @@ def _write_multi_source_output_brief(work_dir, source_records, validated_plan_pa
         "",
         "注意：`start`/`end` 是剪后成片时间，不是原视频时间。",
         "",
+        "## Output narration craft",
+        *MULTI_SOURCE_NARRATION_CRAFT_BULLETS,
+        "- Use BLOCK recap style: explain intent, stakes, subtext, relationships, and consequences; do not merely describe pixels.",
+        "",
         "## Kept clips (output → source)",
     ]
     for c in clips:
@@ -587,6 +724,62 @@ def _write_multi_source_output_brief(work_dir, source_records, validated_plan_pa
     for s in source_records:
         lines.append(f"- {s['source_id']}: `{_source_work_dir(work_dir, s)}`")
     (Path(work_dir) / "agent_narration_brief.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _qc_status_is_blocking(value):
+    if isinstance(value, str):
+        return value.strip().lower() in {"blocking", "blocked", "fail", "failed", "error"}
+    return bool(value) if isinstance(value, bool) else False
+
+
+def _cut_qc_blocking_reasons(qc):
+    if not isinstance(qc, dict):
+        return []
+    reasons = []
+    for key in ("status", "target_duration_status", "duration_status", "boundary_status"):
+        if _qc_status_is_blocking(qc.get(key)):
+            reasons.append(f"{key}={qc.get(key)}")
+    for key in ("blocking", "blocked", "failed", "fail", "errors"):
+        value = qc.get(key)
+        if value:
+            reasons.append(f"{key}={value}")
+    checks = qc.get("checks") if isinstance(qc.get("checks"), list) else []
+    for item in checks:
+        if isinstance(item, dict) and _qc_status_is_blocking(item.get("status")):
+            reasons.append(f"{item.get('name', 'check')}={item.get('status')}")
+    return reasons
+
+
+def _cut_qc_summary_lines(qc):
+    if not isinstance(qc, dict) or not qc:
+        return []
+    parts = []
+    for key in ("status", "target_duration_status", "total_duration", "clip_count", "join_fade_ms"):
+        if key in qc:
+            parts.append(f"{key}={qc.get(key)}")
+    geometry = qc.get("output_geometry")
+    if isinstance(geometry, dict):
+        dims = "x".join(str(geometry.get(k)) for k in ("width", "height") if geometry.get(k) is not None)
+        fps = geometry.get("fps")
+        reason = geometry.get("reason") or qc.get("output_geometry_reason")
+        fps_suffix = f"@{fps}fps" if fps else ""
+        reason_suffix = f" reason={reason}" if reason else ""
+        parts.append(f"output_geometry={dims or geometry}{fps_suffix}{reason_suffix}")
+    warnings = qc.get("warnings")
+    if warnings:
+        parts.append(f"warnings={len(warnings) if isinstance(warnings, list) else warnings}")
+    return ["[video-recap] cut QC: " + "; ".join(parts)] if parts else []
+
+
+def _surface_cut_qc(work_dir):
+    plan = _load_json(Path(work_dir) / "clip_plan_validated.json")
+    qc = plan.get("qc") if isinstance(plan, dict) else None
+    for line in _cut_qc_summary_lines(qc):
+        print(line, flush=True)
+    blocking = _cut_qc_blocking_reasons(qc)
+    if blocking:
+        raise SystemExit("video-cut QC blocking/fail status: " + "; ".join(blocking))
+    return qc
 
 
 def _fmt_range(start, end):
@@ -721,9 +914,12 @@ def _run_multi_cut(videos, work_dir, args):
     crender = [str(videos[0]), "--work-dir", str(work_dir), "--sources-manifest", str(manifest_path), "--no-narration-map"]
     if args.target_duration:
         crender += ["--target-duration", args.target_duration]
+    if getattr(args, "allow_duration_drift", False):
+        crender.append("--allow-duration-drift")
     if getattr(args, "allow_sparse_cut", False):
         crender.append("--allow-sparse-cut")
     _run("video-cut", "cut.py", *crender)
+    _surface_cut_qc(work_dir)
     if not narration_json.exists():
         _write_multi_source_output_brief(work_dir, source_records, work_dir / "clip_plan_validated.json")
         _write_phase_ledger(work_dir, clip_plan_fingerprint=cp_fp, edited_source_rendered=True, multi_source=True)
@@ -751,6 +947,7 @@ def _run_multi_cut(videos, work_dir, args):
     if args.allow_partial_tts:
         vargs.append("--allow-partial-tts")
     _run("video-voiceover", "voiceover.py", *vargs)
+    _write_canonical_visual_overlays(work_dir, narration_json)
 
     recap_stem = f"multi_{videos[0].stem}"
     aargs = [str(edited_source), "--work-dir", str(work_dir), "--recap-stem", recap_stem]
@@ -781,8 +978,10 @@ def main():
     ap.add_argument("--style", default="纪录片")
     ap.add_argument("--edit-mode", default=os.environ.get("EDIT_MODE", "full"), choices=["full", "cut", "dub"])
     ap.add_argument("--target-duration", default=os.environ.get("TARGET_DURATION") or None)
+    ap.add_argument("--allow-duration-drift", action="store_true",
+                    help="cut mode: accept clip duration drift from --target-duration (primary override)")
     ap.add_argument("--allow-sparse-cut", action="store_true",
-                    help="cut mode: accept a sparse/heavily-dropped narration mapping instead of failing the cut preflight")
+                    help="compatibility: accept sparse cut mapping and legacy duration drift override")
     ap.add_argument("--skip-asr", action="store_true")
     ap.add_argument("--mimo-video-overview", action="store_true")
     ap.add_argument("--consolidate", action=argparse.BooleanOptionalAction, default=True,
@@ -946,7 +1145,12 @@ def main():
         crender = [str(video), "--work-dir", str(work_dir), "--no-narration-map"]
         if args.target_duration:
             crender += ["--target-duration", args.target_duration]
+        if getattr(args, "allow_duration_drift", False):
+            crender.append("--allow-duration-drift")
+        if getattr(args, "allow_sparse_cut", False):
+            crender.append("--allow-sparse-cut")
         _run("video-cut", "cut.py", *crender)
+        _surface_cut_qc(work_dir)
         if not narration_json.exists():
             # PASS 2: rebuild the brief (now an OUTPUT-timeline variant) and pause for narration.
             _rebuild_output_brief()
@@ -973,6 +1177,7 @@ def main():
     if args.allow_partial_tts:
         vargs.append("--allow-partial-tts")
     _run("video-voiceover", "voiceover.py", *vargs)
+    _write_canonical_visual_overlays(work_dir, narration_for_tts)
 
     aargs = [str(assemble_video_path), "--work-dir", str(work_dir), "--recap-stem", video.stem]
     if args.output_dir:

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -136,7 +136,7 @@ def _tts_qc_metadata(work_dir):
         metadata["tts_meta"] = tts_meta
     tts_dir = work_dir / "tts_segments"
     if tts_dir.exists() and tts_dir.is_dir():
-        metadata["tts_segments"] = [str(p.relative_to(work_dir)) for p in sorted(tts_dir.iterdir()) if p.is_file()]
+        metadata["tts_segments"] = [p.relative_to(work_dir).as_posix() for p in sorted(tts_dir.iterdir()) if p.is_file()]
     return metadata
 
 

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -884,7 +884,7 @@ def _cut_qc_summary_lines(qc):
     if not isinstance(qc, dict) or not qc:
         return []
     parts = []
-    for key in ("status", "target_duration_status", "total_duration", "clip_count", "join_fade_ms"):
+    for key in ("target_duration_status", "total_duration", "clip_count", "join_fade_ms"):
         if key in qc:
             parts.append(f"{key}={qc.get(key)}")
     geometry = qc.get("output_geometry")

--- a/skills/video-recap/scripts/recap.py
+++ b/skills/video-recap/scripts/recap.py
@@ -158,6 +158,24 @@ def _write_final_qc_reports(work_dir, final_output):
     return final_qc.run(work_dir, final_output=final_output)
 
 
+def _print_final_qc_pointer(result):
+    """Surface a report-only final_qc/golden_eval FAIL so the shift-left QC is
+    not a silent no-op. Advisory only: it never changes the exit status."""
+    if not isinstance(result, dict):
+        return
+    problems = []
+    for key in ("final_qc", "golden_eval"):
+        section = result.get(key)
+        if isinstance(section, dict) and section.get("ok") is False:
+            problems.append(f"{key} blocker_count={section.get('blocker_count', '?')}")
+    if problems:
+        print(
+            "[video-recap] ⚠️  最终 QC 未通过（仅报告，不阻断）: "
+            + "; ".join(problems)
+            + "；详见 final_qc.json / golden_eval.json"
+        )
+
+
 def _entry(skill, script):
     return BUNDLE / skill / "scripts" / script
 
@@ -1082,8 +1100,9 @@ def _run_multi_cut(videos, work_dir, args):
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
     final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + recap_stem + ".mp4"))
     _write_shift_left_stage_qc(work_dir, "post_render", metadata=_post_render_qc_metadata(work_dir, final_output))
-    _write_final_qc_reports(work_dir, final_output)
+    final_qc_result = _write_final_qc_reports(work_dir, final_output)
     print(f"[video-recap] ✅ 完成: {final_output}")
+    _print_final_qc_pointer(final_qc_result)
     _print_narration_review_pointer(work_dir, review_ran=review_ran)
 
 
@@ -1326,8 +1345,9 @@ def main():
     final_dir = Path(args.output_dir) if args.output_dir else work_dir.parent
     final_output = _read_assembly_output(work_dir) or (final_dir / ("recap_" + video.stem + ".mp4"))
     _write_shift_left_stage_qc(work_dir, "post_render", metadata=_post_render_qc_metadata(work_dir, final_output))
-    _write_final_qc_reports(work_dir, final_output)
+    final_qc_result = _write_final_qc_reports(work_dir, final_output)
     print(f"[video-recap] ✅ 完成: {final_output}")
+    _print_final_qc_pointer(final_qc_result)
     _print_narration_review_pointer(work_dir, review_ran=review_ran)
 
 

--- a/skills/video-script/scripts/deslop_qc.py
+++ b/skills/video-script/scripts/deslop_qc.py
@@ -20,7 +20,7 @@ CONTRACT = (
 
 EM_DASH_RE = re.compile(r"——|—")
 NEGATIVE_FLIP_RE = re.compile(r"并?不是[^。！？!?；;\.]{0,40}而是")
-PLACEHOLDER_RE = re.compile(r"【主角】|TA要|旧案真相")
+PLACEHOLDER_RE = re.compile(r"【主角】|TA要")
 
 CLICHE_TERMS = [
     "命运的齿轮", "殊不知", "与此同时", "一场阴谋", "背后真相", "不为人知",
@@ -179,7 +179,7 @@ def analyze_deslop_qc(narration: Any, *, work_dir: str | Path | None = None, ori
         if EM_DASH_RE.search(text):
             _add_issue(blockers, "blocker", "em_dash", seg["source"], seg["index"], "破折号（—/——）不得出现在 narration/original_subtitles 中", matches=EM_DASH_RE.findall(text))
         if PLACEHOLDER_RE.search(text):
-            _add_issue(blockers, "blocker", "placeholder_leakage", seg["source"], seg["index"], "示例占位内容泄漏到成稿中（如【主角】/TA要/旧案真相）", matches=PLACEHOLDER_RE.findall(text))
+            _add_issue(blockers, "blocker", "placeholder_leakage", seg["source"], seg["index"], "示例占位内容泄漏到成稿中（如【主角】/TA要）", matches=PLACEHOLDER_RE.findall(text))
         for sentence in _sentence_pieces(text):
             sentences.append(sentence)
             if NEGATIVE_FLIP_RE.search(sentence):

--- a/skills/video-script/scripts/deslop_qc.py
+++ b/skills/video-script/scripts/deslop_qc.py
@@ -20,7 +20,11 @@ CONTRACT = (
 
 EM_DASH_RE = re.compile(r"——|—")
 NEGATIVE_FLIP_RE = re.compile(r"并?不是[^。！？!?；;\.]{0,40}而是")
-PLACEHOLDER_RE = re.compile(r"【主角】|TA要")
+# Catch verbatim copy of the brief's example scaffolding without over-matching real text.
+# The bracketed role token 【主角】 is the placeholder; anchor the pronoun signal to the
+# example's exact phrase "TA要赌上" so the legitimate gender-neutral pronoun "TA" (他/她) +
+# 要 (idiomatic 解说 suspense device "凶手就在其中，TA要做的下一件事…") is NOT hard-blocked.
+PLACEHOLDER_RE = re.compile(r"【主角】|TA要赌上")
 
 CLICHE_TERMS = [
     "命运的齿轮", "殊不知", "与此同时", "一场阴谋", "背后真相", "不为人知",
@@ -174,7 +178,7 @@ def analyze_deslop_qc(narration: Any, *, work_dir: str | Path | None = None, ori
         if EM_DASH_RE.search(text):
             _add_issue(blockers, "blocker", "em_dash", seg["source"], seg["index"], "破折号（—/——）不得出现在 narration/original_subtitles 中", matches=EM_DASH_RE.findall(text))
         if PLACEHOLDER_RE.search(text):
-            _add_issue(blockers, "blocker", "placeholder_leakage", seg["source"], seg["index"], "示例占位内容泄漏到成稿中（如【主角】/TA要）", matches=PLACEHOLDER_RE.findall(text))
+            _add_issue(blockers, "blocker", "placeholder_leakage", seg["source"], seg["index"], "示例占位内容泄漏到成稿中（如【主角】/TA要赌上）", matches=PLACEHOLDER_RE.findall(text))
         for sentence in _sentence_pieces(text):
             sentences.append(sentence)
             if NEGATIVE_FLIP_RE.search(sentence):

--- a/skills/video-script/scripts/deslop_qc.py
+++ b/skills/video-script/scripts/deslop_qc.py
@@ -1,0 +1,238 @@
+"""Deterministic narration readability/QC scanner.
+
+This module is intentionally report-only. It flags local readability and
+packaging hygiene risks for video narration; it is not an AIGC detector and it
+never rewrites text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+CONTRACT = (
+    "Local readability/QC report only: this is not an AIGC detector, does not "
+    "claim AI-generation accuracy, and never rewrites text. Corrections remain "
+    "human/agent rewrite work."
+)
+
+EM_DASH_RE = re.compile(r"——|—")
+NEGATIVE_FLIP_RE = re.compile(r"并?不是[^。！？!?；;\.]{0,40}而是")
+PLACEHOLDER_RE = re.compile(r"【主角】|TA要|旧案真相")
+
+CLICHE_TERMS = [
+    "命运的齿轮", "殊不知", "与此同时", "一场阴谋", "背后真相", "不为人知",
+    "故事就此展开", "命运", "真相", "秘密", "危机", "反转", "救赎",
+]
+ABSTRACT_TERMS = ["人性", "成长", "救赎", "命运", "时代", "宿命", "选择", "意义", "价值", "情感"]
+REASONING_MARKERS = ["因为", "所以", "因此", "也就是说", "换句话说", "这意味着", "原因是", "可见"]
+METAPHOR_MARKERS = ["像", "仿佛", "好似", "犹如", "如同", "一把", "一场", "一张", "棋局", "风暴"]
+CONNECTIVE_MARKERS = ["但", "却", "而", "于是", "随后", "直到", "结果", "因为", "所以", "这时", "最后"]
+
+
+def _sentence_pieces(text: str) -> list[str]:
+    text = re.sub(r"\s+", " ", str(text or "")).strip()
+    if not text:
+        return []
+    parts = re.split(r"([。！？!?；;\.])", text)
+    out: list[str] = []
+    for idx in range(0, len(parts), 2):
+        body = parts[idx].strip()
+        punct = parts[idx + 1] if idx + 1 < len(parts) else ""
+        if body or punct:
+            out.append((body + punct).strip())
+    return out or [text]
+
+
+def _text_units(text: str) -> int:
+    text = str(text or "")
+    if re.search(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]", text):
+        return len(re.sub(r"\s+", "", text))
+    return len(re.findall(r"\b\w+\b", text))
+
+
+def _normalise_segments(payload: Any, *, source: str) -> list[dict[str, Any]]:
+    if isinstance(payload, str):
+        return [{"source": source, "index": None, "text": payload}]
+    if not isinstance(payload, list):
+        return []
+    segments: list[dict[str, Any]] = []
+    for idx, item in enumerate(payload):
+        if isinstance(item, dict):
+            key = "narration" if source == "narration" else "text"
+            text = str(item.get(key, item.get("text", item.get("narration", ""))) or "").strip()
+        else:
+            text = str(item or "").strip()
+        if text:
+            segments.append({"source": source, "index": idx, "text": text})
+    return segments
+
+
+def _load_json(path: Path) -> tuple[Any, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except Exception as exc:  # intentionally broad: malformed artifacts are QC findings
+        return None, str(exc)
+
+
+def _load_original_subtitles(work_dir: Path | None) -> list[dict[str, Any]]:
+    if work_dir is None:
+        return []
+    path = work_dir / "original_subtitles.json"
+    if not path.exists():
+        return []
+    data, err = _load_json(path)
+    if err:
+        return []
+    return _normalise_segments(data, source="original_subtitles")
+
+
+def _style_card_requirement(work_dir: Path | None) -> tuple[bool, str]:
+    """Read the explicit stable requirements contract.
+
+    Legacy/migration workspaces that do not have a valid requirements file are
+    advisory-only: they must not be hard-gated by prompt text in
+    agent_narration_brief.md.
+    """
+    if work_dir is None:
+        return False, "legacy_default"
+    path = work_dir / "deslop_qc_requirements.json"
+    if not path.exists():
+        return False, "legacy_default"
+    data, err = _load_json(path)
+    if err is not None or not isinstance(data, dict):
+        return False, "legacy_default"
+    required = data.get("style_card_required")
+    if not isinstance(required, bool):
+        return False, "legacy_default"
+    return required, "deslop_qc_requirements.json"
+
+
+def _style_card_required(work_dir: Path | None) -> bool:
+    required, _source = _style_card_requirement(work_dir)
+    return required
+
+
+def _style_card_issue(work_dir: Path | None, required: bool) -> dict[str, Any] | None:
+    if work_dir is None:
+        return None
+    path = work_dir / "style_card.json"
+    if not path.exists():
+        return {
+            "severity": "blocker" if required else "advisory",
+            "code": "missing_style_card",
+            "source": "style_card",
+            "index": None,
+            "message": (
+                "style_card.json is required by this expression/packaging run but is missing"
+                if required else
+                "style_card.json is absent; legacy/migration workspaces may continue, but new expression-special runs should author it"
+            ),
+        }
+    data, err = _load_json(path)
+    if err is not None or not isinstance(data, dict) or not data:
+        return {
+            "severity": "blocker" if required else "advisory",
+            "code": "malformed_style_card",
+            "source": "style_card",
+            "index": None,
+            "message": (
+                "style_card.json is required but missing, malformed, empty, or not a JSON object"
+                if required else
+                "style_card.json is present but malformed/empty; treat as migration warning unless the run requires it"
+            ),
+            "detail": err,
+        }
+    return None
+
+
+def _add_issue(bucket: list[dict[str, Any]], severity: str, code: str, source: str, index: int | None, message: str, **extra: Any) -> None:
+    issue = {"severity": severity, "code": code, "source": source, "index": index, "message": message}
+    issue.update({k: v for k, v in extra.items() if v is not None})
+    bucket.append(issue)
+
+
+def analyze_deslop_qc(narration: Any, *, work_dir: str | Path | None = None, original_subtitles: Any = None) -> dict[str, Any]:
+    """Return a structured report; never mutates or rewrites input text."""
+    work_path = Path(work_dir) if work_dir is not None else None
+    segments = _normalise_segments(narration, source="narration")
+    if original_subtitles is None:
+        segments.extend(_load_original_subtitles(work_path))
+    else:
+        segments.extend(_normalise_segments(original_subtitles, source="original_subtitles"))
+
+    blockers: list[dict[str, Any]] = []
+    advisories: list[dict[str, Any]] = []
+
+    required, requirement_source = _style_card_requirement(work_path)
+    style_issue = _style_card_issue(work_path, required)
+    if style_issue:
+        (blockers if style_issue["severity"] == "blocker" else advisories).append(style_issue)
+
+    all_text = "\n".join(seg["text"] for seg in segments)
+    total_units = max(1, _text_units(all_text))
+    sentences: list[str] = []
+    for seg in segments:
+        text = seg["text"]
+        if EM_DASH_RE.search(text):
+            _add_issue(blockers, "blocker", "em_dash", seg["source"], seg["index"], "破折号（—/——）不得出现在 narration/original_subtitles 中", matches=EM_DASH_RE.findall(text))
+        if PLACEHOLDER_RE.search(text):
+            _add_issue(blockers, "blocker", "placeholder_leakage", seg["source"], seg["index"], "示例占位内容泄漏到成稿中（如【主角】/TA要/旧案真相）", matches=PLACEHOLDER_RE.findall(text))
+        for sentence in _sentence_pieces(text):
+            sentences.append(sentence)
+            if NEGATIVE_FLIP_RE.search(sentence):
+                _add_issue(blockers, "blocker", "negative_positive_flip", seg["source"], seg["index"], "同一句中出现“不是…而是…”模板化转折，请改成更具体的因果/行动表达", sentence=sentence[:120])
+
+    def term_count(terms: list[str]) -> int:
+        return sum(all_text.count(term) for term in terms)
+
+    cliche_count = term_count(CLICHE_TERMS)
+    abstract_count = term_count(ABSTRACT_TERMS)
+    reasoning_count = term_count(REASONING_MARKERS)
+    metaphor_count = term_count(METAPHOR_MARKERS)
+    connective_count = term_count(CONNECTIVE_MARKERS)
+
+    if cliche_count >= 4 or (cliche_count / total_units) > 0.025:
+        _add_issue(advisories, "advisory", "cliche_density", "narration", None, "套话/高频抽象词偏密，建议换成具体行动、选择和后果", count=cliche_count)
+    if abstract_count >= 5 or (abstract_count / total_units) > 0.03:
+        _add_issue(advisories, "advisory", "abstract_summary", "narration", None, "抽象总结词偏多，容易像概括论文；补足画面证据和具体抉择", count=abstract_count)
+    if reasoning_count >= 4:
+        _add_issue(advisories, "advisory", "reasoning_chain", "narration", None, "解释链标记偏多，建议减少“因为/所以/这意味着”等讲理口吻", count=reasoning_count)
+    if metaphor_count >= 4:
+        _add_issue(advisories, "advisory", "metaphor_markers", "narration", None, "比喻/包装化标记偏多，确认没有遮住剧情事实", count=metaphor_count)
+    if total_units >= 180 and connective_count <= 1:
+        _add_issue(advisories, "advisory", "low_connective_density", "narration", None, "长文本缺少转折/因果连接，可能像平铺摘要", connective_count=connective_count)
+
+    long_segments = [seg for seg in segments if seg["source"] == "narration" and _text_units(seg["text"]) > 180]
+    if long_segments:
+        _add_issue(advisories, "advisory", "overlong_narration_block", "narration", long_segments[0].get("index"), "单个解说块过长，建议拆成更可听的段落", max_units=max(_text_units(seg["text"]) for seg in long_segments))
+    long_sentences = [s for s in sentences if _text_units(s) > 90]
+    if long_sentences:
+        _add_issue(advisories, "advisory", "long_paragraph", "narration", None, "长句/长段落偏多，字幕阅读压力较大", max_units=max(_text_units(s) for s in long_sentences))
+
+    return {
+        "ok": not blockers,
+        "contract": CONTRACT,
+        "scanner": "deslop_qc.py",
+        "style_card_required": required,
+        "style_card_requirement_source": requirement_source,
+        "blocker_count": len(blockers),
+        "advisory_count": len(advisories),
+        "blockers": blockers,
+        "advisories": advisories,
+        "metrics": {
+            "segments_scanned": len(segments),
+            "text_units": total_units if all_text else 0,
+            "sentence_count": len(sentences),
+            "cliche_count": cliche_count,
+            "abstract_count": abstract_count,
+            "reasoning_marker_count": reasoning_count,
+            "metaphor_marker_count": metaphor_count,
+            "connective_count": connective_count,
+        },
+    }
+
+
+__all__ = ["CONTRACT", "analyze_deslop_qc"]

--- a/skills/video-script/scripts/deslop_qc.py
+++ b/skills/video-script/scripts/deslop_qc.py
@@ -110,11 +110,6 @@ def _style_card_requirement(work_dir: Path | None) -> tuple[bool, str]:
     return required, "deslop_qc_requirements.json"
 
 
-def _style_card_required(work_dir: Path | None) -> bool:
-    required, _source = _style_card_requirement(work_dir)
-    return required
-
-
 def _style_card_issue(work_dir: Path | None, required: bool) -> dict[str, Any] | None:
     if work_dir is None:
         return None
@@ -183,7 +178,7 @@ def analyze_deslop_qc(narration: Any, *, work_dir: str | Path | None = None, ori
         for sentence in _sentence_pieces(text):
             sentences.append(sentence)
             if NEGATIVE_FLIP_RE.search(sentence):
-                _add_issue(blockers, "blocker", "negative_positive_flip", seg["source"], seg["index"], "同一句中出现“不是…而是…”模板化转折，请改成更具体的因果/行动表达", sentence=sentence[:120])
+                _add_issue(advisories, "advisory", "negative_positive_flip", seg["source"], seg["index"], "“不是…而是…”模板化转折偏多，建议改成更具体的因果/行动表达", sentence=sentence[:120])
 
     def term_count(terms: list[str]) -> int:
         return sum(all_text.count(term) for term in terms)

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -203,7 +203,7 @@ CONFIG = {
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
     "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 300,  # TTS fade-in/fade-out 时长(ms)
+    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
     # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
     "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
@@ -229,7 +229,10 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
+    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
+    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
+    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
@@ -260,6 +263,9 @@ CONFIG = {
     "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
     "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
     "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
+    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
+    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
+    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
     "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
@@ -274,6 +280,7 @@ CONFIG = {
     "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
     "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
     "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
+    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
     "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
     "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
     "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
@@ -291,6 +298,24 @@ CONFIG = {
 
 SCRIPT_DIR = Path(__file__).parent
 PROMPTS_DIR = SCRIPT_DIR.parent / "references"
+
+def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):
+    """Return the canonical tempo budget shared by voiceover and assemble."""
+    cfg = config or CONFIG
+    global_speed = max(0.01, float(cfg.get("narration_speed", 1.0) or 1.0))
+    rate_factor = max(0.01, 1.0 + float(tts_rate_offset or 0.0))
+    cumulative_max = max(1.0, float(cfg.get("narration_cumulative_tempo_max", 1.35) or 1.35))
+    hard_max = max(cumulative_max, float(cfg.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40))
+    legacy_segment_cap = max(1.0, float(cfg.get("tts_segment_tempo_max", 1.20) or 1.20))
+    segment_tempo_max = max(1.0, min(legacy_segment_cap, cumulative_max / (global_speed * rate_factor)))
+    return {
+        "global_narration_speed": global_speed,
+        "tts_rate_factor": rate_factor,
+        "cumulative_tempo_max": cumulative_max,
+        "cumulative_tempo_hard_max": hard_max,
+        "segment_tempo_max": segment_tempo_max,
+        "max_raw_duration_factor": global_speed * segment_tempo_max,
+    }
 
 def log(msg):
     print(f"[video-recap] {msg}", flush=True)

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib.util
 import json
 import math
 import re
@@ -7,6 +8,17 @@ from pathlib import Path
 
 from lib import CONFIG, file_fingerprint, stable_hash
 from lib import log
+
+try:
+    from deslop_qc import analyze_deslop_qc
+except ModuleNotFoundError:
+    _deslop_qc_path = Path(__file__).resolve().parents[1].parent / "video-script" / "scripts" / "deslop_qc.py"
+    _deslop_qc_spec = importlib.util.spec_from_file_location("deslop_qc", _deslop_qc_path)
+    if _deslop_qc_spec is None or _deslop_qc_spec.loader is None:
+        raise
+    _deslop_qc_module = importlib.util.module_from_spec(_deslop_qc_spec)
+    _deslop_qc_spec.loader.exec_module(_deslop_qc_module)
+    analyze_deslop_qc = _deslop_qc_module.analyze_deslop_qc
 
 
 # ── Agent narration preparation and validation helpers ────────────────
@@ -617,15 +629,28 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                 avg_block_chars=round(avg_chars, 1), block_min_chars=block_min_chars,
             ))
 
+    deslop_qc = analyze_deslop_qc(narration, work_dir=work_dir)
+    for blocker in deslop_qc.get("blockers", []):
+        errors.append(_lint_issue(
+            "error", blocker.get("index"), blocker.get("code", "deslop_qc_blocker"),
+            blocker.get("message", "deslop QC objective blocker"),
+            source=blocker.get("source"), matches=blocker.get("matches"),
+            sentence=blocker.get("sentence"),
+        ))
+
     report = {
         "ok": not errors,
         "error_count": len(errors),
         "warning_count": len(warnings),
         "metrics": metrics,
+        "deslop_qc": deslop_qc,
         "errors": errors,
         "warnings": warnings,
     }
     if work_dir is not None:
+        Path(work_dir, "deslop_qc.json").write_text(
+            json.dumps(deslop_qc, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
         Path(work_dir, "narration_lint.json").write_text(
             json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
         )
@@ -710,7 +735,7 @@ def _align_narration_to_quiet(narration, scenes_analysis, silence_periods):
             n["overlaps_speech"] = True
         return _validate_narration_budget(narration, scenes_analysis)
 
-    quiet_windows = [qp for qp in silence_periods if not qp.get("has_speech", False)]
+    quiet_windows = [qp for qp in silence_periods if _silence_window_is_usable_quiet(qp)]
     quiet_ratio_min = float(CONFIG.get("quiet_overlap_min_ratio", 0.8) or 0.8)
 
     # Run budget/dedup FIRST, then set the flag on the final (possibly merged) spans,
@@ -749,7 +774,7 @@ def _scene_asr_lines(asr_result, scene):
 def _quiet_windows_for_scene(silence_periods, scene):
     windows = []
     for qp in silence_periods or []:
-        if qp.get("has_speech", False):
+        if not _silence_window_is_usable_quiet(qp):
             continue
         if qp["start"] < scene["end"] and qp["end"] > scene["start"]:
             start = max(qp["start"], scene["start"])
@@ -757,6 +782,18 @@ def _quiet_windows_for_scene(silence_periods, scene):
             if end > start:
                 windows.append((start, end))
     return windows
+
+
+def _silence_window_is_usable_quiet(qp):
+    if not isinstance(qp, dict):
+        return False
+    reason = str(qp.get("has_speech_reason", "")).lower()
+    granularity = str(qp.get("asr_granularity", "")).lower()
+    if reason in {"coarse_asr_overlap_ignored", "asr_overlap_low_confidence_quiet", "coarse_asr_no_overlap"}:
+        return True
+    if granularity == "coarse_grid" and qp.get("has_speech") is True:
+        return True
+    return not qp.get("has_speech", False)
 
 
 def _quiet_overlap_seconds(start, end, quiet_windows):
@@ -783,7 +820,7 @@ def _overlap_seconds(start, end, other_start, other_end):
 def _build_timeline_fusion(scenes, asr_segments, silence_periods):
     """Fuse VLM scenes, ASR dialogue and quiet narration slots on one timeline."""
     fusion = []
-    quiet_windows = [w for w in silence_periods or [] if not w.get("has_speech", False)]
+    quiet_windows = [w for w in silence_periods or [] if _silence_window_is_usable_quiet(w)]
     for scene in scenes or []:
         try:
             start = float(scene.get("start", 0))
@@ -872,7 +909,7 @@ def _format_background_research(research, limit=1800):
     """Render background_research.json into a bounded Story-context brief section."""
     if not isinstance(research, dict) or not research:
         return []
-    lines = ["## Story context (from background_research.json)", ""]
+    lines = ["## Story context (from background_research.json)", "", "Research is context_only: use it for aliases/names/world terms and weak background only; do NOT reveal future plot or upgrade research-only relationships/causes into current on-screen facts without visual/ASR support.", ""]
     for key, label in (
         ("synopsis", "Synopsis"),
         ("worldbuilding", "Worldbuilding"),
@@ -1670,9 +1707,35 @@ def _format_output_clip_list(work_dir):
         except (TypeError, ValueError):
             continue
         reason = str(c.get("reason", "")).strip()
-        out.append(f"- output {os_:.1f}–{oe:.1f}s ← source {ss:.1f}–{se:.1f}s" + (f" — {reason}" if reason else ""))
+        source_id = c.get("source_id", c.get("source", "0"))
+        clip_id = c.get("id", c.get("clip_id", "?"))
+        out.append(f"- OUTPUT {os_:.1f}–{oe:.1f}s ← SOURCE[{source_id}] {ss:.1f}–{se:.1f}s (clip_id={clip_id})" + (f" — {reason}" if reason else ""))
     out.append("")
     return out if len(out) > 2 else []
+
+
+def _deslop_qc_owner():
+    skill_name = Path(__file__).resolve().parents[1].name
+    script_name = Path(__file__).stem
+    return f"{skill_name}.{script_name}"
+
+
+def _write_deslop_qc_requirements(work_dir, *, owner):
+    """Write the stable deslop QC contract consumed by deslop_qc.py."""
+    payload = {
+        "schema_version": 1,
+        "owner": owner,
+        "style_card_required": True,
+        "packaging_plan_expected": True,
+        "deslop_qc": {
+            "report_only": True,
+            "aigc_detector": False,
+            "auto_rewrite": False,
+        },
+    }
+    path = Path(work_dir) / "deslop_qc_requirements.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
 
 
 def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
@@ -1717,7 +1780,8 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "Write the required JSON artifact(s) manually from the analysis files in this work directory.",
         "The CLI will not generate final narration text; it will only validate timing, run TTS, and assemble the video.",
         "",
-        f"- Style: {style}",
+        f"- Style (--style, freeform verbatim guidance): {style}",
+        "- Do not translate `--style` into a preset, enum, switch, or fallback ladder; synthesize the voice from this freeform text plus evidence.",
         f"- Edit mode: {edit_mode}",
         f"- Source video duration: {video_duration:.1f}s",
         f"- Target duration (cut mode): {target_duration}",
@@ -1754,6 +1818,13 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     lines.extend([
         f"- Default pause between beats: {target_pause_ms}ms",
         f"- Context: {CONFIG.get('context_info') or '(none)'}",
+        "",
+        "## Shared expression / packaging artifacts",
+        "",
+        "Before final narration, author `style_card.json` and `packaging_plan.json` from `--style`, `--context`, source materials, ASR, scene evidence, and user preference signals.",
+        "- `style_card.json` owns freeform voice, pacing, payoff shape, subtitle/read posture, and evidence-backed expression intent. It is not a preset enum, fixed taxonomy, title plan, cover plan, or packaging promise.",
+        "- `packaging_plan.json` owns title, cover-frame/visual hook, first-line, viewer promise, packaging metadata, and packaging-to-story alignment. It must not override `style_card.json` voice or pacing policy.",
+        "- `deslop_qc.json` is deterministic report-only tool QC: do not hand-author it, do not treat it as an AIGC detector, and do not auto-rewrite from it. Corrections remain human/agent rewrite work guided by objective blockers and advisory readability signals.",
         "",
     ])
 
@@ -1812,7 +1883,9 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
                 "- Keep clips that carry causality, a reveal, a decision, or a strong emotional beat; cut establishing/transition/repeated/static shots.",
                 "- SKIP non-story footage: 片头/片尾 credits, 演职员表, 广告/赞助, 台标/水印 stretches, and any scene the analysis marks rejected/无法描述 (often a watermark) — they look bad on screen and add nothing.",
                 "- Prefer scenes that have a real visual description in the guide; favor faces, action and dialogue over scenery.",
-                "- Clip length ~3–15s; vary the pace; order clips in story order so the cut reads as a coherent story.",
+                "- Clip order is the story spine, not unordered highlights: you may use 0–1 optional cold-open/high-impact clip first, then return to the coherent main arc (setup → turn → payoff) and escalate to the ending.",
+                "- Use the `reason` field as craft intent where useful: `cold_open`, `setup`, `turn`, or `payoff` plus a short concrete why. Example: `cold_open: trial explosion reveals the stakes`.",
+                "- Clip length ~3–15s; vary the pace; after any cold-open, order clips by causality so the cut reads as one coherent story, not a flat highlights reel.",
                 "- End a clip on a COMPLETE spoken line — set the clip end at or just after an ASR line-end (or inside the quiet window that follows it), never mid-sentence, so the original dialogue is never chopped off. Use the ASR [start–end] times + Quiet windows below as safe cut points; the CLI also snaps clip ends to the nearest line-end as a safety net.",
                 "",
                 "### clip_plan.json shape (original source timestamps)",
@@ -1843,7 +1916,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
                 "block's text, then leave a few-second gap before the next block for an original-audio moment.",
                 "```json",
                 "[",
-                "  {\"start\": 2.0, \"end\": 13.0, \"narration\": \"范闲表面是个闲散少爷，背地里却握着监察院的暗线。这一次，他要赌上身家去查母亲的死。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"紧张\"}",
+                "  {\"start\": 2.0, \"end\": 13.0, \"narration\": \"【主角】表面只是旁观者，暗中却握着关键线索。这一次，TA要赌上全部去查清旧案真相。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"紧张\"}",
                 "]",
                 "```",
             ])
@@ -1855,7 +1928,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
             "block's text, then leave a few-second gap before the next block for an original-audio moment.",
             "```json",
             "[",
-            "  {\"start\": 5.0, \"end\": 16.0, \"narration\": \"范闲表面是个闲散少爷，背地里却握着监察院的暗线。这一次，他要赌上身家去查母亲的死。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"平静\"}",
+            "  {\"start\": 5.0, \"end\": 16.0, \"narration\": \"【主角】表面只是旁观者，暗中却握着关键线索。这一次，TA要赌上全部去查清旧案真相。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"平静\"}",
             "]",
             "```",
         ])
@@ -1907,7 +1980,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "",
         "看图说话 (bad) vs recap (good) — same shot:",
         "- ✗ \"一个蒙眼的男人抱着一个篮子走在雨里。\"  (just describes the frame)",
-        "- ✓ \"杀手五竹本可以一走了之，却为了一个不是自己孩子的婴儿，把整座京都的追兵引向自己。\"  (who, why, stakes)",
+        "- ✓ \"护送者本可以独自离开，却为了保护那个孩子，主动把追兵引向自己。\"  (who, why, stakes)",
         "",
         "## Scene timing guide",
         "",
@@ -1937,5 +2010,6 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
 
     brief_path = Path(work_dir) / "agent_narration_brief.md"
     brief_path.write_text("\n".join(lines), encoding="utf-8")
+    _write_deslop_qc_requirements(work_dir, owner=_deslop_qc_owner())
     log(f"已写入 Agent 解说写作 brief: {brief_path}")
     return brief_path

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1137,13 +1137,17 @@ def _clean_asr_prompt_fingerprint():
 
 
 def _index_prompt_fingerprint():
-    prompt = """你在根据逐场景画面分析，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
-只依据给到的画面证据（场景描述 + 帧实动作），不要脑补画面之外的剧情。
+    prompt = """你在根据逐场景画面分析、ASR对白、background_research术语表，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
+规则：
+- visual/asr 是当前视频事实证据；每个人物、关系、剧情节点、物件尽量给 evidence_ids。
+- background_research 只能用于人名/别名/术语/身份消歧，默认 support=context_only；不能把后续剧情或未出现关系升级为当前画面事实。
+- ASR 中出现但画面描述未命名的人名，应进入 characters[*].asr_mentions。
 只返回 JSON：
-{"characters":[{"name":"角色名或外观指代","description":"身份/特征"}],
- "relationships":[{"a":"角色","b":"角色","relation":"关系"}],
- "plot_points":["按时间顺序的关键剧情节点"],
- "entities":["重要物件/地点/线索"]}"""
+{"characters":[{"name":"角色名或外观指代","description":"身份/特征","aliases":[],"visual_descriptions":[],"asr_mentions":[],"research_role":"","evidence_ids":[],"confidence":"high|medium|low"}],
+ "relationships":[{"a":"角色","b":"角色","relation":"关系","evidence_ids":[],"support":"direct|indirect|context_only"}],
+ "plot_points":[{"time":"00:00","text":"按时间顺序的关键剧情节点","evidence_ids":[]}],
+ "entities":[{"name":"重要物件/地点/线索","evidence_ids":[]}],
+ "research_glossary":[{"name":"名字/术语","aliases":[],"role":"说明","support":"context_only"}]}"""
     return hashlib.md5(prompt.encode("utf-8")).hexdigest()
 
 
@@ -1202,10 +1206,14 @@ def _format_consolidation(index):
     plot = index.get("plot_points") or []
     if plot:
         lines.append("- Plot spine:")
-        lines.extend(f"    {i + 1}. {p}" for i, p in enumerate(plot))
+        lines.extend(
+            f"    {i + 1}. {p.get('text', p) if isinstance(p, dict) else p}"
+            for i, p in enumerate(plot)
+        )
     ents = index.get("entities") or []
     if ents:
-        lines.append(f"- Entities: {', '.join(str(e) for e in ents)}")
+        ent_names = [str(e.get("name", e) if isinstance(e, dict) else e) for e in ents]
+        lines.append(f"- Entities: {', '.join(ent_names)}")
     lines.append("")
     return lines
 

--- a/skills/video-script/scripts/narration.py
+++ b/skills/video-script/scripts/narration.py
@@ -1722,24 +1722,16 @@ def _format_output_clip_list(work_dir):
     return out if len(out) > 2 else []
 
 
-def _deslop_qc_owner():
-    skill_name = Path(__file__).resolve().parents[1].name
-    script_name = Path(__file__).stem
-    return f"{skill_name}.{script_name}"
+def _write_deslop_qc_requirements(work_dir):
+    """Write the stable deslop QC contract consumed by deslop_qc.py.
 
-
-def _write_deslop_qc_requirements(work_dir, *, owner):
-    """Write the stable deslop QC contract consumed by deslop_qc.py."""
+    style_card_required defaults to False (advisory): a missing style_card.json is a
+    warning, not a render-blocking error. A future opt-in run can set it True to make
+    style_card.json a hard requirement — deslop_qc.py reads that field.
+    """
     payload = {
         "schema_version": 1,
-        "owner": owner,
-        "style_card_required": True,
-        "packaging_plan_expected": True,
-        "deslop_qc": {
-            "report_only": True,
-            "aigc_detector": False,
-            "auto_rewrite": False,
-        },
+        "style_card_required": False,
     }
     path = Path(work_dir) / "deslop_qc_requirements.json"
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -2018,6 +2010,6 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
 
     brief_path = Path(work_dir) / "agent_narration_brief.md"
     brief_path.write_text("\n".join(lines), encoding="utf-8")
-    _write_deslop_qc_requirements(work_dir, owner=_deslop_qc_owner())
+    _write_deslop_qc_requirements(work_dir)
     log(f"已写入 Agent 解说写作 brief: {brief_path}")
     return brief_path

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -22,22 +22,28 @@ CATEGORIES = [
     "hallucination", "weak_hook", "no_throughline", "narrating_picture",
     "density", "pacing", "cliche", "incomplete", "disjoint_handoff",
     "promise_mismatch", "low_information_gain", "not_write_for_ear",
-    "grounding_risk", "original_audio_conflict", "subtitle_readability", "other",
+    "grounding_risk", "original_audio_conflict", "subtitle_readability",
+    "ai_flavor", "weak_payoff", "style_mismatch", "packaging_mismatch",
+    "example_entity_leak", "other",
 ]
 
 SCORECARD_KEYS = [
     "promise_match", "hook_3s", "first_15s_delivery", "spine_clarity",
     "stakes_escalation", "information_gain", "spoken_language",
     "sentence_brevity", "tts_pacing", "grounding", "original_audio_use",
-    "subtitle_readability",
+    "subtitle_readability", "ending_payoff", "style_consistency", "ai_flavor",
+    "packaging_consistency",
 ]
 
 # Categories whose findings are allowed to keep severity=error and thus gate strict
 # mode. Everything else is craft/subjective and is clamped to at most "warning".
 FACTUAL_CATEGORIES = {"hallucination", "incomplete"}
 
+EVIDENCE_CONTRACT_VERSION = 1
+COVERAGE_POLICY_VERSION = "coverage_policy_v1"
+
 RUBRIC = """你是中文视频解说稿的严格评审。依据以下规则审阅草稿，只指出真实问题，宁缺毋滥：
-1. 反幻觉（最重要）：解说里的人物、动作、因果、关系只要能由「画面证据」(frame_facts/描述) 或「对白」(ASR) 或「背景资料」(background_research) 任一支撑，即不算幻觉。只有与全部可得证据都矛盾的论断才是 severity=error, category=hallucination，并指出与哪条证据冲突。若与背景资料一致但画面/对白里看不到（合理推断、非矛盾），最多 severity=suggestion，不要判 error。
+1. 反幻觉（最重要）：解说里的人物、动作、因果、关系必须由带标签的 evidence 支撑。画面/对白是 timeline evidence（clock=SOURCE 或 OUTPUT）；背景资料/user_context 只能作为 context-only（clock=null）辅助识别/消歧。research-only 不能升级成当前画面强事实；若与 research 一致但画面/对白里看不到，最多 severity=suggestion/category=grounding_risk，不要判 error；只有与全部可得证据矛盾才是 severity=error, category=hallucination，并指出冲突证据。
 2. 钩子：开头 1-2 段要制造悬念/利害，不是交代场景。弱钩子 → weak_hook。
 3. 主线：应有一条贯穿主线（目标/关系/悬念），每段推进它，不要每个场景从头讲。缺主线 → no_throughline。
 4. 给信息而非念画面：观众看得见动作表情；解说要讲动机/关系/潜台词/剧情意义。复述画面 → narrating_picture。
@@ -45,10 +51,13 @@ RUBRIC = """你是中文视频解说稿的严格评审。依据以下规则审�
 6. 去废词：删空泛形容（"危机四伏""震撼人心"）→ cliche。
 7. 完整句子：半句话/未收尾 → incomplete。
 8. 段落衔接：解说块要为随后的原声留白铺垫，下一块要承接原声刚呈现的内容；若两块各说各的、原声进来接不上 → disjoint_handoff。
-另外给一份内容效果 scorecard（1-5，advisory：除事实矛盾/残句外不要据此给 error）：promise_match/hook_3s/first_15s_delivery/spine_clarity/stakes_escalation/information_gain/spoken_language/sentence_brevity/tts_pacing/grounding/original_audio_use/subtitle_readability。
+9. 结尾回收：结尾要兑现开头承诺/主线情绪，不要突然停、只复述最后画面、没有情绪/信息回报；弱回收 → weak_payoff。
+10. 风格一致性：若提供 style_card.json，把它当作表达意图/语气/节奏边界；不符合意图 → style_mismatch。不要把 style_card 当标题/封面/首句包装计划。
+11. 包装一致性：若提供 packaging_plan.json，只评估标题/封面/首句/卖点承诺与正文兑现；不一致 → packaging_mismatch。不要把 packaging_plan 当正文风格卡。
+12. 去AI味：若出现模板化、空泛拔高、过度对仗、机械转折、明显 agent 示例残留，可报 ai_flavor；若出现示例人物/占位实体泄漏（如未替换示例名、模板角色）→ example_entity_leak。deslop_qc.json 是 deterministic local report-only QC，不是 AIGC detector，不自动重写；只能作为证据参考，不能仅凭它判定。
+另外给一份内容效果 scorecard（1-5，advisory：除事实矛盾/残句外不要据此给 error；缺项可以省略，系统会保留为 null/未评分）：promise_match/hook_3s/first_15s_delivery/spine_clarity/stakes_escalation/information_gain/spoken_language/sentence_brevity/tts_pacing/grounding/original_audio_use/subtitle_readability/ending_payoff/style_consistency/ai_flavor/packaging_consistency。ai_flavor 分数含义：5=自然、人味强，1=AI味明显。
 只返回 JSON（不要额外解释），格式：
-{"verdict":"PASS|REVISE|FAIL","summary":"一两句总体判断","scorecard":{"promise_match":1-5,"hook_3s":1-5,"first_15s_delivery":1-5,"spine_clarity":1-5,"stakes_escalation":1-5,"information_gain":1-5,"spoken_language":1-5,"sentence_brevity":1-5,"tts_pacing":1-5,"grounding":1-5,"original_audio_use":1-5,"subtitle_readability":1-5},"hook_candidates_review":[{"candidate":"首句","type":"suspense|contrast|stakes","score":1-5,"keep":true}],"retention_risk_points":[{"time":"00:28","risk":"为什么可能掉人","fix":"怎么改"}],"highest_return_edits":["最值得改的动作"],"information_gain_notes":[{"segment":0,"label":"motive|relationship|stakes|foreshadowing|payoff|context|visual_restatement","note":"证据/改法"}],"spoken_language_rewrites":[{"segment":0,"original":"原句","rewrite":"口语改写","why":"为什么更适合听"}],"grounding_assertions":[{"segment":0,"assertion":"人物/关系/因果断言","source":"visual|asr|research|user_context|unsupported","risk":"谨慎说明"}],"findings":[{"segment":<草稿段号(从0起)或null表示整体>,"severity":"error|warning|suggestion","category":"<上面类别之一>","issue":"问题","fix":"具体改法"}]}"""
-
+{"verdict":"PASS|REVISE|FAIL","summary":"一两句总体判断","scorecard":{"promise_match":1-5,"hook_3s":1-5,"first_15s_delivery":1-5,"spine_clarity":1-5,"stakes_escalation":1-5,"information_gain":1-5,"spoken_language":1-5,"sentence_brevity":1-5,"tts_pacing":1-5,"grounding":1-5,"original_audio_use":1-5,"subtitle_readability":1-5,"ending_payoff":1-5,"style_consistency":1-5,"ai_flavor":1-5,"packaging_consistency":1-5},"hook_candidates_review":[{"candidate":"首句","type":"suspense|contrast|stakes","score":1-5,"keep":true}],"retention_risk_points":[{"time":"00:28","risk":"为什么可能掉人","fix":"怎么改"}],"highest_return_edits":["最值得改的动作"],"information_gain_notes":[{"segment":0,"label":"motive|relationship|stakes|foreshadowing|payoff|context|visual_restatement","note":"证据/改法"}],"spoken_language_rewrites":[{"segment":0,"original":"原句","rewrite":"口语改写","why":"为什么更适合听"}],"grounding_assertions":[{"segment":0,"assertion":"人物/关系/因果断言","source":"visual|asr|research|user_context|unsupported","risk":"谨慎说明"}],"findings":[{"segment":<草稿段号(从0起)或null表示整体>,"severity":"error|warning|suggestion","category":"<上面类别之一>","issue":"问题","fix":"具体改法"}]}"""
 
 
 def _load(work_dir, name):
@@ -61,6 +70,19 @@ def _load(work_dir, name):
         return None
 
 
+
+
+def _source_fingerprint(work_dir, name):
+    path = Path(work_dir) / name
+    if not path.exists():
+        return ""
+    try:
+        return stable_hash(json.loads(path.read_text(encoding="utf-8")))
+    except (ValueError, OSError):
+        try:
+            return stable_hash(path.read_text(encoding="utf-8"))
+        except OSError:
+            return ""
 
 
 def _load_cut_clip_spans(work_dir):
@@ -104,6 +126,9 @@ def _load_cut_clip_spans(work_dir):
             "source_end": source_end,
             "output_start": output_start,
             "output_end": output_end,
+            "source_id": str(clip.get("source_id", clip.get("source", "0"))),
+            "source_clip_id": clip.get("source_clip_id", clip.get("id", clip.get("clip_id"))),
+            "output_segment_index": len(spans),
         })
     return spans or None
 
@@ -122,6 +147,9 @@ def _source_output_overlaps(start, end, spans):
             "source_end": source_end,
             "output_start": output_start,
             "output_end": output_end,
+            "source_id": span.get("source_id", "0"),
+            "source_clip_id": span.get("source_clip_id"),
+            "output_segment_index": span.get("output_segment_index"),
         })
     return overlaps
 
@@ -166,6 +194,11 @@ def remap_grounding_to_output_timeline(vlm_analysis, asr_result, clip_spans):
             item["start"] = round(overlap["output_start"], 3)
             item["end"] = round(overlap["output_end"], 3)
             item["frame_facts"] = _remap_frame_facts(scene.get("frame_facts"), overlap)
+            item["source_start"] = round(overlap["source_start"], 3)
+            item["source_end"] = round(overlap["source_end"], 3)
+            item["source_id"] = overlap.get("source_id", "0")
+            item["source_clip_id"] = overlap.get("source_clip_id")
+            item["output_segment_index"] = overlap.get("output_segment_index")
             if len(overlaps) > 1:
                 item["scene_id"] = f"{scene.get('scene_id', '?')}.{part_idx}"
             remapped_scenes.append(item)
@@ -186,6 +219,11 @@ def remap_grounding_to_output_timeline(vlm_analysis, asr_result, clip_spans):
             item = dict(seg)
             item["start"] = round(overlap["output_start"], 3)
             item["end"] = round(overlap["output_end"], 3)
+            item["source_start"] = round(overlap["source_start"], 3)
+            item["source_end"] = round(overlap["source_end"], 3)
+            item["source_id"] = overlap.get("source_id", "0")
+            item["source_clip_id"] = overlap.get("source_clip_id")
+            item["output_segment_index"] = overlap.get("output_segment_index")
             remapped_asr.append(item)
 
     remapped_scenes.sort(key=lambda x: (float(x.get("start", 0)), float(x.get("end", 0))))
@@ -236,6 +274,540 @@ def _asr_grounding(asr_result, limit=80):
     return "\n".join(lines)
 
 
+def _safe_time(item, key, default=0.0):
+    try:
+        value = float(item.get(key, default))
+    except (AttributeError, TypeError, ValueError):
+        return default
+    return value if math.isfinite(value) else default
+
+
+def _overall_duration(scenes, asr, narration):
+    ends = []
+    for seq in (scenes or [], asr or [], narration or []):
+        for item in seq:
+            if isinstance(item, dict):
+                ends.append(_safe_time(item, "end", _safe_time(item, "start", 0.0)))
+    return max(ends or [0.0])
+
+
+def _range(start, end, reason, priority=2):
+    start = max(0.0, float(start))
+    end = max(start, float(end))
+    return {"start": round(start, 3), "end": round(end, 3), "selection_reason": reason, "priority": priority}
+
+
+def _merge_ranges(ranges):
+    merged = []
+    for r in sorted((r for r in ranges if r["end"] > r["start"]), key=lambda x: (x["start"], x["end"])):
+        if not merged or r["start"] > merged[-1]["end"]:
+            merged.append(dict(r))
+            continue
+        merged[-1]["end"] = max(merged[-1]["end"], r["end"])
+        reasons = {part for part in str(merged[-1].get("selection_reason", "")).split("+") if part}
+        reasons.update(part for part in str(r.get("selection_reason", "")).split("+") if part)
+        order = {"beginning": 0, "middle": 1, "end": 2, "longest_gap": 3, "narration_window": 4}
+        merged[-1]["selection_reason"] = "+".join(sorted(reasons, key=lambda x: order.get(x, 99)))
+        merged[-1]["priority"] = min(merged[-1].get("priority", 2), r.get("priority", 2))
+    return merged
+
+
+def coverage_policy_v1(scenes, asr_result, narration, *, max_coverage_ranges=12, min_baseline_ranges=6, window_seconds=30.0):
+    """Deterministic B/M/E floor → longest-gap fill → narration-window coverage."""
+    duration = _overall_duration(scenes, asr_result, narration)
+    if duration <= 0:
+        return {"coverage_policy_version": COVERAGE_POLICY_VERSION, "selected_ranges": [], "dropped_ranges": [], "duration": 0.0}
+    width = min(float(window_seconds), max(5.0, duration / 8.0))
+    ranges = [
+        _range(0.0, min(duration, width), "beginning", 0),
+        _range(max(0.0, duration / 2.0 - width / 2.0), min(duration, duration / 2.0 + width / 2.0), "middle", 0),
+        _range(max(0.0, duration - width), duration, "end", 0),
+    ]
+    ranges = _merge_ranges(ranges)
+    while len(ranges) < min_baseline_ranges:
+        ranges = _merge_ranges(ranges)
+        gaps = []
+        cursor = 0.0
+        for r in ranges:
+            if r["start"] > cursor:
+                gaps.append((r["start"] - cursor, cursor, r["start"]))
+            cursor = max(cursor, r["end"])
+        if cursor < duration:
+            gaps.append((duration - cursor, cursor, duration))
+        if not gaps:
+            break
+        gap_len, gs, ge = max(gaps, key=lambda g: (g[0], -g[1]))
+        if gap_len <= 0.001:
+            break
+        center = (gs + ge) / 2.0
+        half = min(width / 2.0, gap_len / 2.0)
+        ranges.append(_range(center - half, center + half, "longest_gap", 2))
+    before_narration = len(ranges)
+    for i, seg in enumerate(narration or []):
+        if not isinstance(seg, dict):
+            continue
+        start = _safe_time(seg, "start", None)
+        end = _safe_time(seg, "end", start)
+        if start is None or end <= start:
+            continue
+        priority = 1 if str(seg.get("narration", "")).strip() else 2
+        r = _range(max(0.0, start - 3.0), min(duration, end + 3.0), "narration_window", priority)
+        r["narration_segment"] = i
+        ranges.append(r)
+    merged = _merge_ranges(ranges)
+    dropped = []
+    if len(merged) > max_coverage_ranges:
+        protected = [r for r in merged if any(x in r["selection_reason"] for x in ("beginning", "middle", "end"))]
+        candidates = [r for r in merged if r not in protected]
+        candidates.sort(key=lambda r: (r.get("priority", 2), -float(r["end"] - r["start"]), r["start"]))
+        keep = protected + candidates[:max(0, max_coverage_ranges - len(protected))]
+        keep_ids = {id(r) for r in keep}
+        dropped = [r for r in merged if id(r) not in keep_ids]
+        merged = sorted(keep, key=lambda r: (r["start"], r["end"]))
+    for r in merged + dropped:
+        r.pop("priority", None)
+    return {
+        "coverage_policy_version": COVERAGE_POLICY_VERSION,
+        "selected_ranges": merged,
+        "dropped_ranges": dropped,
+        "dropped_range_count": len(dropped),
+        "duration": round(duration, 3),
+        "baseline_range_count_before_narration": before_narration,
+    }
+
+
+def _in_ranges(start, end, ranges):
+    return any(float(r["start"]) < end and float(r["end"]) > start for r in ranges or [])
+
+
+def _scene_evidence_text(scene):
+    desc = str(scene.get("description", "")).strip().replace("\n", " ")
+    facts = scene.get("frame_facts")
+    picks = []
+    if isinstance(facts, dict):
+        def fact_sort_key(value):
+            try:
+                return (0, float(value))
+            except (TypeError, ValueError):
+                return (1, str(value))
+        for ts in sorted(facts.keys(), key=fact_sort_key):
+            vals = facts[ts]
+            picks.extend(vals if isinstance(vals, list) else [str(vals)])
+    elif isinstance(facts, list):
+        for f in facts:
+            picks.append(str(f.get("fact", f.get("text", ""))).strip() if isinstance(f, dict) else str(f).strip())
+    fact_txt = "；".join(p for p in picks[:4] if p)
+    return (desc + (" | 帧实: " + fact_txt if fact_txt else "")).strip()
+
+
+def _research_context_items(research):
+    if not isinstance(research, dict) or not research:
+        return []
+    items = []
+    for key in ("synopsis", "episode_context", "worldbuilding"):
+        value = _clip_text(research.get(key), 400)
+        if value:
+            items.append({"id": f"research:{key}", "source": "research", "clock": None, "source_id": "context", "start": None, "end": None, "text": value, "support": "context_only", "confidence": "medium"})
+    for name, desc in list((research.get("characters") or {}).items())[:12] if isinstance(research.get("characters"), dict) else []:
+        text = f"{_clip_text(name, 80)}：{_clip_text(desc, 200)}"
+        items.append({"id": f"research:character:{len(items)}", "source": "research", "clock": None, "source_id": "context", "start": None, "end": None, "text": text, "support": "context_only", "confidence": "medium"})
+    details = research.get("character_details")
+    if isinstance(details, dict):
+        for name, info in list(details.items())[:8]:
+            if not isinstance(info, dict):
+                continue
+            aliases = info.get("aliases") if isinstance(info.get("aliases"), list) else []
+            bits = []
+            if aliases:
+                bits.append("aliases=" + "/".join(_clip_text(a, 40) for a in aliases[:4]))
+            role = _clip_text(info.get("role"), 120)
+            if role:
+                bits.append(role)
+            if bits:
+                items.append({"id": f"research:detail:{len(items)}", "source": "research", "clock": None, "source_id": "context", "start": None, "end": None, "text": f"{name}: {'; '.join(bits)}", "support": "context_only", "confidence": "medium"})
+    return items
+
+
+def select_coverage_ranges(scenes, asr_result, narration, **kwargs):
+    """Pure compatibility seam: return deterministic review coverage ranges.
+
+    This is a thin public alias over coverage_policy_v1's selected_ranges so tests and
+    downstream orchestration can depend on a stable API without reaching into policy
+    internals.
+    """
+    return coverage_policy_v1(scenes, asr_result, narration, **kwargs).get("selected_ranges", [])
+
+
+def filter_evidence_by_ranges(vlm_analysis, asr_result, ranges, *, timeline="source"):
+    """Pure compatibility seam: collect visual/ASR evidence items inside ranges."""
+    clock = "output" if timeline == "cut_output" else "source"
+    items = []
+    dropped = {"visual": 0, "asr": 0}
+    for i, scene in enumerate(vlm_analysis or []):
+        if not isinstance(scene, dict):
+            continue
+        start = _safe_time(scene, "start")
+        end = _safe_time(scene, "end", start)
+        if end <= start or not _in_ranges(start, end, ranges):
+            dropped["visual"] += 1
+            continue
+        item = {"id": f"visual:{i}", "source": "visual", "clock": clock, "source_id": str(scene.get("source_id", "0")), "start": round(start, 3), "end": round(end, 3), "text": _scene_evidence_text(scene), "support": "direct", "confidence": "high"}
+        for k in ("source_start", "source_end", "source_clip_id", "output_segment_index"):
+            if k in scene:
+                item[k] = scene.get(k)
+        items.append(item)
+    for i, seg in enumerate(asr_result or []):
+        if not isinstance(seg, dict):
+            continue
+        text = str(seg.get("text", "")).strip()
+        if not text:
+            continue
+        start = _safe_time(seg, "start")
+        end = _safe_time(seg, "end", start)
+        if end <= start or not _in_ranges(start, end, ranges):
+            dropped["asr"] += 1
+            continue
+        item = {"id": f"asr:{i}", "source": "asr", "clock": clock, "source_id": str(seg.get("source_id", "0")), "start": round(start, 3), "end": round(end, 3), "text": text, "support": "direct", "confidence": "high"}
+        for k in ("source_start", "source_end", "source_clip_id", "output_segment_index"):
+            if k in seg:
+                item[k] = seg.get(k)
+        items.append(item)
+    return {"items": items, "dropped_visual_count": dropped["visual"], "dropped_asr_count": dropped["asr"]}
+
+
+def build_review_coverage_metadata(bundle):
+    """Pure compatibility seam: summarize the evidence coverage contract."""
+    items = bundle.get("items") or [] if isinstance(bundle, dict) else []
+    coverage = bundle.get("coverage", {}) if isinstance(bundle, dict) else {}
+    metadata = bundle.get("metadata", {}) if isinstance(bundle, dict) else {}
+    return {
+        "coverage_policy_version": coverage.get("coverage_policy_version", COVERAGE_POLICY_VERSION),
+        "time_ranges": coverage.get("selected_ranges", []),
+        "dropped_ranges": coverage.get("dropped_ranges", []),
+        "dropped_range_count": coverage.get("dropped_range_count", len(coverage.get("dropped_ranges", []))),
+        "scene_count": metadata.get("reviewed_scene_count", sum(1 for item in items if item.get("source") == "visual")),
+        "asr_count": metadata.get("reviewed_asr_count", sum(1 for item in items if item.get("source") == "asr")),
+        "dropped_scene_count": metadata.get("dropped_scene_count", 0),
+        "dropped_asr_count": metadata.get("dropped_asr_count", 0),
+    }
+
+
+def validate_public_evidence_contract(bundle):
+    """Pure compatibility seam: validate the public evidence bundle shape.
+
+    Returns a non-throwing report so callers can use it in tests or advisory QC paths.
+    """
+    errors = []
+    warnings = []
+    if not isinstance(bundle, dict):
+        return {"valid": False, "errors": ["bundle must be a dict"], "warnings": []}
+    if bundle.get("schema_version") != EVIDENCE_CONTRACT_VERSION:
+        errors.append("unsupported schema_version")
+    if bundle.get("clock") not in ("source", "output"):
+        errors.append("clock must be source or output")
+    for idx, item in enumerate(bundle.get("items") or []):
+        if not isinstance(item, dict):
+            errors.append(f"items[{idx}] must be a dict")
+            continue
+        if item.get("source") not in ("visual", "asr"):
+            errors.append(f"items[{idx}].source must be visual or asr")
+        if item.get("clock") not in ("source", "output"):
+            errors.append(f"items[{idx}].clock must be source or output")
+        if item.get("support") != "direct":
+            warnings.append(f"items[{idx}].support is not direct")
+        start, end = item.get("start"), item.get("end")
+        try:
+            if float(end) <= float(start):
+                errors.append(f"items[{idx}] has non-positive time range")
+        except (TypeError, ValueError):
+            errors.append(f"items[{idx}] has invalid time range")
+    for idx, item in enumerate(bundle.get("context_items") or []):
+        if not isinstance(item, dict):
+            errors.append(f"context_items[{idx}] must be a dict")
+            continue
+        if item.get("clock") is not None:
+            errors.append(f"context_items[{idx}].clock must be null")
+        if item.get("support") != "context_only":
+            errors.append(f"context_items[{idx}].support must be context_only")
+    return {"valid": not errors, "errors": errors, "warnings": warnings}
+
+
+def render_evidence_for_review(bundle_or_vlm, asr_result=None, narration=None, **kwargs):
+    """Pure compatibility seam: render a bundle, or build+render from raw inputs."""
+    limit_items = kwargs.pop("limit_items", 220)
+    if isinstance(bundle_or_vlm, dict) and "items" in bundle_or_vlm:
+        return render_evidence_bundle(bundle_or_vlm, limit_items=limit_items)
+    bundle = build_evidence_bundle(bundle_or_vlm, asr_result, narration, **kwargs)
+    return render_evidence_bundle(bundle, limit_items=limit_items)
+
+
+def validate_timeline_mapping(clip_spans):
+    """Pure compatibility seam: validate source→output clip-span mapping."""
+    errors = []
+    prev_output_end = None
+    for idx, span in enumerate(clip_spans or []):
+        if not isinstance(span, dict):
+            errors.append(f"clip_spans[{idx}] must be a dict")
+            continue
+        try:
+            ss = float(span["source_start"]); se = float(span["source_end"])
+            os_ = float(span["output_start"]); oe = float(span["output_end"])
+        except (KeyError, TypeError, ValueError):
+            errors.append(f"clip_spans[{idx}] has invalid required times")
+            continue
+        if not all(math.isfinite(v) for v in (ss, se, os_, oe)):
+            errors.append(f"clip_spans[{idx}] has non-finite times")
+        if se <= ss:
+            errors.append(f"clip_spans[{idx}] source_end must be > source_start")
+        if oe <= os_:
+            errors.append(f"clip_spans[{idx}] output_end must be > output_start")
+        if prev_output_end is not None and os_ < prev_output_end:
+            errors.append(f"clip_spans[{idx}] overlaps previous output span")
+        prev_output_end = max(prev_output_end if prev_output_end is not None else os_, oe)
+    return {"valid": not errors, "errors": errors, "span_count": len(clip_spans or [])}
+
+
+def build_evidence_bundle(vlm_analysis, asr_result, narration, *, timeline="source", research=None, warnings=None):
+    clock = "output" if timeline == "cut_output" else "source"
+    coverage = coverage_policy_v1(vlm_analysis, asr_result, narration)
+    ranges = coverage.get("selected_ranges", [])
+    items = []
+    dropped_scenes = dropped_asr = 0
+    for i, scene in enumerate(vlm_analysis or []):
+        if not isinstance(scene, dict):
+            continue
+        start = _safe_time(scene, "start")
+        end = _safe_time(scene, "end", start)
+        if end <= start or not _in_ranges(start, end, ranges):
+            dropped_scenes += 1
+            continue
+        item = {"id": f"visual:{i}", "source": "visual", "clock": clock, "source_id": str(scene.get("source_id", "0")), "start": round(start, 3), "end": round(end, 3), "text": _scene_evidence_text(scene), "support": "direct", "confidence": "high"}
+        for k in ("source_start", "source_end", "source_clip_id", "output_segment_index"):
+            if k in scene:
+                item[k] = scene.get(k)
+        items.append(item)
+    for i, seg in enumerate(asr_result or []):
+        if not isinstance(seg, dict):
+            continue
+        text = str(seg.get("text", "")).strip()
+        if not text:
+            continue
+        start = _safe_time(seg, "start")
+        end = _safe_time(seg, "end", start)
+        if end <= start or not _in_ranges(start, end, ranges):
+            dropped_asr += 1
+            continue
+        item = {"id": f"asr:{i}", "source": "asr", "clock": clock, "source_id": str(seg.get("source_id", "0")), "start": round(start, 3), "end": round(end, 3), "text": text, "support": "direct", "confidence": "high"}
+        for k in ("source_start", "source_end", "source_clip_id", "output_segment_index"):
+            if k in seg:
+                item[k] = seg.get(k)
+        items.append(item)
+    context_items = _research_context_items(research)
+    return {
+        "schema_version": EVIDENCE_CONTRACT_VERSION,
+        "timeline": timeline,
+        "clock": clock,
+        "items": items,
+        "context_items": context_items,
+        "coverage": coverage,
+        "warnings": list(warnings or []),
+        "metadata": {
+            "reviewed_scene_count": sum(1 for x in items if x["source"] == "visual"),
+            "reviewed_asr_count": sum(1 for x in items if x["source"] == "asr"),
+            "dropped_scene_count": dropped_scenes,
+            "dropped_asr_count": dropped_asr,
+        },
+    }
+
+
+def render_evidence_bundle(bundle, *, limit_items=220):
+    clock = str(bundle.get("clock") or "source").upper()
+    lines = [f"## Timeline evidence (clock={clock}; source=visual/asr)"]
+    items = bundle.get("items") or []
+    if not items:
+        lines.append("(无 timeline evidence)")
+    for item in items[:limit_items]:
+        label = "画面" if item.get("source") == "visual" else "对白"
+        backref = ""
+        if item.get("clock") == "output" and "source_start" in item and "source_end" in item:
+            backref = f" ← SOURCE {float(item['source_start']):.1f}-{float(item['source_end']):.1f}s"
+            if item.get("output_segment_index") is not None:
+                backref += f" clip#{item.get('output_segment_index')}"
+        lines.append(f"[{clock} {float(item.get('start', 0)):.1f}-{float(item.get('end', 0)):.1f}s {label} id={item.get('id')}{backref}] {item.get('text','')}")
+    if len(items) > limit_items:
+        lines.append(f"... dropped from prompt: {len(items) - limit_items} items (artifact metadata keeps counts)")
+    context = bundle.get("context_items") or []
+    lines.extend(["", "## Context-only evidence (clock=null; source=research/user_context; advisory, not current-timeline fact)"])
+    if not context:
+        lines.append("(无 context-only evidence)")
+    for item in context[:40]:
+        lines.append(f"[clock=null {item.get('source')} support=context_only id={item.get('id')}] {item.get('text','')}")
+    return "\n".join(lines)
+
+
+def merge_review_findings(chunks):
+    """Merge chunk review findings deterministically, keeping highest severity."""
+    severity_rank = {"error": 3, "warning": 2, "suggestion": 1}
+    by_key = {}
+    for chunk in chunks or []:
+        for f in (chunk or {}).get("findings", []) or []:
+            if not isinstance(f, dict):
+                continue
+            key = (f.get("segment"), f.get("category"), f.get("issue"))
+            old = by_key.get(key)
+            if old is None or severity_rank.get(f.get("severity"), 0) > severity_rank.get(old.get("severity"), 0):
+                by_key[key] = dict(f)
+    return sorted(by_key.values(), key=lambda f: (f.get("segment") is None, f.get("segment") if f.get("segment") is not None else 10**9, f.get("category") or "", f.get("issue") or ""))
+
+
+
+
+def _bundle_fingerprint(bundle):
+    try:
+        return stable_hash({
+            "schema_version": bundle.get("schema_version"),
+            "clock": bundle.get("clock"),
+            "coverage": bundle.get("coverage"),
+            "items": bundle.get("items"),
+            "context_items": bundle.get("context_items"),
+        })
+    except (TypeError, ValueError, RecursionError) as exc:
+        if isinstance(bundle, dict):
+            bundle.setdefault("metadata", {})["evidence_bundle_fingerprint_warning"] = (
+                f"evidence bundle fingerprint unavailable: {type(exc).__name__}"
+            )
+        return ""
+
+
+def _bundle_fingerprint_warning(bundle):
+    if not isinstance(bundle, dict):
+        return "evidence bundle fingerprint unavailable: invalid bundle"
+    warning = (bundle.get("metadata") or {}).get("evidence_bundle_fingerprint_warning")
+    if warning:
+        return warning
+    return ""
+
+
+def _append_warning_once(target, warning):
+    if warning and warning not in target:
+        target.append(warning)
+
+
+def _bundle_prompt_size(bundle):
+    return len(render_evidence_bundle(bundle))
+
+
+def _chunk_evidence_bundle(bundle, *, max_items=80, max_chars=12000):
+    """Split oversized evidence bundles for actual review calls.
+
+    Chunks are deterministic and range-oriented: selected coverage ranges remain the
+    contract, but each chunk carries only the timeline items whose spans overlap that
+    range. Context-only research remains advisory and is repeated in each chunk so the
+    judge can still use alias/background hints without upgrading them to timeline facts.
+    """
+    items = list(bundle.get("items") or [])
+    if len(items) <= max_items and _bundle_prompt_size(bundle) <= max_chars:
+        one = dict(bundle)
+        one["chunk_index"] = 0
+        one["chunk_count"] = 1
+        fp = _bundle_fingerprint(bundle)
+        fp_warning = _bundle_fingerprint_warning(bundle)
+        one.setdefault("metadata", {})["evidence_bundle_fingerprint"] = fp
+        if fp_warning:
+            one["metadata"]["evidence_bundle_fingerprint_warning"] = fp_warning
+            one.setdefault("warnings", list(bundle.get("warnings") or []))
+            _append_warning_once(one["warnings"], fp_warning)
+        return [one]
+    ranges = bundle.get("coverage", {}).get("selected_ranges") or []
+    chunks = []
+    used_ids = set()
+    for r in ranges:
+        r_items = [item for item in items if _in_ranges(_safe_time(item, "start"), _safe_time(item, "end", _safe_time(item, "start")), [r])]
+        if not r_items:
+            continue
+        for start in range(0, len(r_items), max_items):
+            part = r_items[start:start + max_items]
+            used_ids.update(id(item) for item in part)
+            chunk = dict(bundle)
+            chunk["items"] = part
+            chunk["coverage"] = dict(bundle.get("coverage") or {})
+            chunk["coverage"]["selected_ranges"] = [r]
+            chunk["chunk_index"] = len(chunks)
+            chunks.append(chunk)
+    leftovers = [item for item in items if id(item) not in used_ids]
+    for start in range(0, len(leftovers), max_items):
+        chunk = dict(bundle)
+        chunk["items"] = leftovers[start:start + max_items]
+        chunk["coverage"] = dict(bundle.get("coverage") or {})
+        chunk["coverage"]["selected_ranges"] = []
+        chunk["chunk_index"] = len(chunks)
+        chunks.append(chunk)
+    if not chunks:
+        chunk = dict(bundle)
+        chunk["items"] = []
+        chunk["chunk_index"] = 0
+        chunks = [chunk]
+    count = len(chunks)
+    fp = _bundle_fingerprint(bundle)
+    fp_warning = _bundle_fingerprint_warning(bundle)
+    for chunk in chunks:
+        chunk["chunk_count"] = count
+        chunk.setdefault("metadata", {})["chunked_review"] = count > 1
+        chunk["metadata"]["evidence_bundle_fingerprint"] = fp
+        if fp_warning:
+            chunk["metadata"]["evidence_bundle_fingerprint_warning"] = fp_warning
+            chunk.setdefault("warnings", list(bundle.get("warnings") or []))
+            _append_warning_once(chunk["warnings"], fp_warning)
+    return chunks
+
+
+def _merge_chunk_reviews(chunk_reviews):
+    if not chunk_reviews:
+        return parse_review_response("")
+    if len(chunk_reviews) == 1:
+        return chunk_reviews[0]
+    verdict_rank = {"PASS": 0, "OK": 0, "REVISE": 1, "FAIL": 2}
+    best = max(chunk_reviews, key=lambda r: verdict_rank.get(r.get("verdict"), 1))
+    merged = dict(best)
+    merged["findings"] = merge_review_findings(chunk_reviews)
+    if any(f.get("severity") == "error" for f in merged["findings"]):
+        merged["verdict"] = "FAIL" if best.get("verdict") == "FAIL" else "REVISE"
+    else:
+        merged["verdict"] = best.get("verdict", "REVISE")
+    summaries = [str(r.get("summary", "")).strip() for r in chunk_reviews if str(r.get("summary", "")).strip()]
+    merged["summary"] = summaries[0] if summaries else merged.get("summary", "")
+    merged["chunked_review"] = {
+        "chunk_count": len(chunk_reviews),
+        "findings_before_merge": sum(len(r.get("findings") or []) for r in chunk_reviews),
+        "findings_after_merge": len(merged.get("findings") or []),
+    }
+    return merged
+
+
+def _research_guardrail_qc(review, context_items):
+    assertions = [a for a in (review.get("grounding_assertions") or []) if isinstance(a, dict)]
+    research_context_assertions = [
+        a for a in assertions
+        if str(a.get("source", "")).lower() == "research"
+        or a.get("support") == "context_only"
+        or a.get("clock") is None
+    ]
+    risk_assertions = [
+        a for a in research_context_assertions
+        if "spoiler" in str(a.get("risk", "")).lower()
+        or "research-only" in str(a.get("risk", "")).lower()
+        or "current-timeline" in str(a.get("risk", "")).lower()
+    ]
+    grounding_risk_findings = [
+        f for f in (review.get("findings") or [])
+        if isinstance(f, dict) and f.get("category") == "grounding_risk"
+    ]
+    return {
+        "context_only_assertions": len(context_items or []) + len(research_context_assertions),
+        "spoiler_risk_assertions": len(risk_assertions) + len(grounding_risk_findings),
+        "policy": "research evidence is context_only unless visual/asr-supported",
+    }
+
 def _clip_text(text, limit):
     value = re.sub(r"\s+", " ", str(text or "")).strip()
     return value[:limit]
@@ -255,8 +827,8 @@ def _load_review_research_context(work_dir):
 def _format_review_research_context(research, limit=1200):
     """Compact background_research.json for the quality reviewer.
 
-    Background research is valid grounding alongside visual/ASR: a claim it supports is
-    not a hallucination; only claims contradicting all available evidence are errors.
+    Background research is rendered as context-only/advisory: it can help aliases and
+    disambiguation, but it is not timeline grounding for current visual/ASR facts.
     """
     if not isinstance(research, dict) or not research:
         return ""
@@ -344,7 +916,7 @@ def _clamp_score(value, default=3):
 
 
 def _normalise_scorecard(raw):
-    # Keep a stable 12-key schema, but do NOT fabricate a judge-looking score for a dimension
+    # Keep a stable scorecard schema, but do NOT fabricate a judge-looking score for a dimension
     # the model omitted: those stay None ("未评分") rather than a neutral-looking 3.
     source = raw if isinstance(raw, dict) else {}
     return {key: (_clamp_score(source[key]) if key in source else None) for key in SCORECARD_KEYS}
@@ -383,35 +955,60 @@ def _format_draft(narration):
     return "\n".join(lines)
 
 
-def build_review_messages(narration, vlm_analysis, asr_result, work_dir=None, research_context=None):
+def build_review_messages(narration, vlm_analysis, asr_result, work_dir=None, research_context=None, evidence_bundle=None):
     """Pure: assemble the reviewer chat messages (testable without the API)."""
-    grounding = _scene_grounding(vlm_analysis)
-    dialogue = _asr_grounding(asr_result)
     draft = _format_draft(narration)
-    if research_context is None and work_dir is not None:
-        research_context = _format_review_research_context(_load_review_research_context(work_dir))
-    # Optional, agent-authored planning artifacts. Absent in most runs today — review then
-    # scores from the narration + grounding alone; present (future R1 pilot) they sharpen
-    # promise/spine/anchor scoring. Either way the review degrades gracefully.
+    research_obj = _load_review_research_context(work_dir) if work_dir is not None else {}
+    if research_context is None:
+        research_context = _format_review_research_context(research_obj)
+    bundle = evidence_bundle or build_evidence_bundle(
+        vlm_analysis, asr_result, narration,
+        timeline="cut_output" if any("source_start" in x for x in (vlm_analysis or []) if isinstance(x, dict)) else "source",
+        research=research_obj)
+    evidence_text = render_evidence_bundle(bundle)
+    # Optional, agent-authored planning/QC artifacts. Bad JSON returns None via _load, matching
+    # existing fail-open optional artifact behavior; these only sharpen advisory scoring.
     packaging = _load_optional_json(work_dir, "packaging_plan.json")
     story_plan = _load_optional_json(work_dir, "recap_story_plan.json")
     av_board = _load_optional_json(work_dir, "visual_audio_board.json")
+    style_card = _load_optional_json(work_dir, "style_card.json")
+    deslop_qc = _load_optional_json(work_dir, "deslop_qc.json")
     user = (
         f"{RUBRIC}\n\n"
         "## Scorecard 评估提示\n"
-        "若 work_dir 提供了 packaging_plan/recap_story_plan/visual_audio_board，则结合评估：标题/封面/首句承诺是否一致并在前15秒兑现、主线是否清晰、关键原声是否保留；"
+        "若 work_dir 提供了 packaging_plan/recap_story_plan/visual_audio_board/style_card/deslop_qc，则结合评估："
+        "packaging_plan 只负责标题/封面/首句/卖点承诺与正文兑现；style_card 只负责表达意图、语气、节奏和禁忌；"
+        "recap_story_plan 负责主线/beats；visual_audio_board 负责画面/原声/字幕/剪辑锚点；deslop_qc 是 deterministic local report-only QC，不是 AIGC detector，也不会自动重写，只能当证据参考。"
         "若未提供，则基于解说本身与画面/对白证据评分。统一评估：hook 是否有悬念/反差/高利害；每段是否有信息增量而非看图说话；"
-        "是否写给耳朵听（短句、口语、TTS可呼吸）；人物/关系/因果断言是否有 visual/ASR/research/user_context 证据。\n"
-        "审美项是 advisory：可 REVISE，但除事实矛盾/残句外不要给 error。\n\n"
-        f"{_format_json_context('packaging_plan.json（点击承诺/标题/封面/首句，可能为空）', packaging)}\n\n"
+        "结尾是否兑现开头承诺/主线情绪；是否写给耳朵听（短句、口语、TTS可呼吸）；人物/关系/因果断言是否有 visual/ASR timeline evidence；research/user_context 仅可作为 context-only 辅助。\n"
+        "审美/风格/包装/去AI味项是 advisory：可 REVISE，但除事实矛盾/残句外不要给 error。\n\n"
+        f"{_format_json_context('packaging_plan.json（标题/封面/首句/卖点包装承诺，可能为空）', packaging)}\n\n"
         f"{_format_json_context('recap_story_plan.json（主线/beats/original moments，可能为空）', story_plan)}\n\n"
         f"{_format_json_context('visual_audio_board.json（画面/原声/字幕/剪辑锚点，可能为空）', av_board)}\n\n"
-        f"## 背景资料（与画面/对白并列的有效依据：被其支撑的事实不算幻觉，仅与全部证据矛盾才算）\n{research_context or '(无)'}\n\n"
-        f"## 画面证据（场景描述 + 帧实）\n{grounding or '(无)'}\n\n"
-        f"## 对白（ASR）\n{dialogue or '(无对白/静音视频)'}\n\n"
+        f"{_format_json_context('style_card.json（表达意图/语气/节奏/禁忌，不负责包装，可能为空）', style_card)}\n\n"
+        f"{_format_json_context('deslop_qc.json（deterministic report-only QC；非AIGC检测器；不自动重写，可能为空）', deslop_qc)}\n\n"
+        f"## 背景资料（context-only/advisory：只辅助识别/消歧/弱背景，不是当前画面强事实）\n"
+        f"Guardrail: clock=null/context_only；不得把未来剧情或 research-only 关系/因果升级为当前事实。\n"
+        f"{research_context or '(无)'}\n\n"
+        f"{evidence_text}\n\n"
         f"## 解说草稿（共 {len([s for s in (narration or []) if isinstance(s, dict)])} 段）\n{draft or '(空)'}\n"
     )
     return [{"role": "user", "content": user}]
+
+
+def _downgrade_context_assertions(assertions):
+    out = []
+    for item in assertions or []:
+        src = str(item.get("source", "")).strip().lower()
+        if src in {"research", "user_context"}:
+            item = dict(item)
+            item["support"] = "context_only"
+            item["clock"] = None
+            risk = str(item.get("risk", "")).strip()
+            label = "research-only" if src == "research" else "user_context-only"
+            item["risk"] = (risk + "; " if risk else "") + f"{label}: advisory/context_only, not a strong current-timeline fact"
+        out.append(item)
+    return out
 
 
 def parse_review_response(text):
@@ -472,8 +1069,8 @@ def parse_review_response(text):
             data.get("information_gain_notes"), ["segment", "label", "note", "rewrite"]),
         "spoken_language_rewrites": _normalise_list_of_dicts(
             data.get("spoken_language_rewrites"), ["segment", "original", "rewrite", "why"]),
-        "grounding_assertions": _normalise_list_of_dicts(
-            data.get("grounding_assertions"), ["segment", "assertion", "source", "risk"]),
+        "grounding_assertions": _downgrade_context_assertions(_normalise_list_of_dicts(
+            data.get("grounding_assertions"), ["segment", "assertion", "source", "risk", "support", "clock"])),
         "findings": findings,
     }
 
@@ -536,35 +1133,132 @@ def format_review_md(review):
     return "\n".join(out) + "\n"
 
 
-def review_narration(work_dir, *, timeline="source"):
+def build_grounding_qc(work_dir, review, bundle, *, timeline="source"):
+    """Pure-ish compatibility seam: build grounding QC payload without writing it.
+
+    It reads optional source fingerprints/QC from work_dir to preserve the existing artifact
+    contract, but has no side effects.
+    """
+    work_dir = Path(work_dir)
+    items = bundle.get("items") or []
+    context = bundle.get("context_items") or []
+    warnings = list(bundle.get("warnings") or []) + list(review.get("warnings") or [])
+    verdict = "warn" if warnings else "pass"
+    if any(f.get("severity") == "error" for f in (review.get("findings") or []) if isinstance(f, dict)):
+        verdict = "fail"
+    if any(item.get("clock") not in ("source", "output") for item in items):
+        verdict = "warn" if verdict == "pass" else verdict
+    coverage_meta = build_review_coverage_metadata(bundle)
+    return {
+        "schema_version": 1,
+        "owner": "video-script.review",
+        "timeline": timeline,
+        "coverage_policy_version": COVERAGE_POLICY_VERSION,
+        "source_fingerprints": {
+            "vlm": _source_fingerprint(work_dir, "vlm_analysis.json"),
+            "asr": _source_fingerprint(work_dir, "asr_result.json"),
+            "research": _source_fingerprint(work_dir, "background_research.json"),
+            "clip_plan": _source_fingerprint(work_dir, "clip_plan_validated.json"),
+        },
+        "review_coverage": {
+            "time_ranges": coverage_meta["time_ranges"],
+            "scene_count": coverage_meta["scene_count"],
+            "asr_count": coverage_meta["asr_count"],
+            "dropped_ranges": coverage_meta["dropped_ranges"],
+        },
+        "evidence_contract": {
+            "source_items": sum(1 for item in items if item.get("clock") == "source"),
+            "output_items": sum(1 for item in items if item.get("clock") == "output"),
+            "unclocked_items": sum(1 for item in items if item.get("clock") not in ("source", "output")),
+            "context_only_items": len(context),
+            "validation": validate_public_evidence_contract(bundle),
+        },
+        "index_inputs": {
+            "vlm": bool(_source_fingerprint(work_dir, "vlm_analysis.json")),
+            "asr": bool(_source_fingerprint(work_dir, "asr_result.json")),
+            "research": bool(_source_fingerprint(work_dir, "background_research.json")),
+        },
+        "speech_window_qc": _load_optional_json(work_dir, "silence_periods.qc.json") or {"coarse_asr_windows": 0, "low_confidence_speech_flags": 0},
+        "research_guardrail": _research_guardrail_qc(review, context),
+        "warnings": warnings,
+        "verdict": verdict,
+    }
+
+
+def write_grounding_qc(work_dir, qc):
+    """Compatibility seam: write a prebuilt grounding_qc.json payload."""
+    work_dir = Path(work_dir)
+    (work_dir / "grounding_qc.json").write_text(json.dumps(qc, ensure_ascii=False, indent=2), encoding="utf-8")
+    return qc
+
+
+def _write_grounding_qc(work_dir, review, bundle, *, timeline="source"):
+    qc = build_grounding_qc(work_dir, review, bundle, timeline=timeline)
+    return write_grounding_qc(work_dir, qc)
+
+
+def review_narration(work_dir, *, timeline="source", strict_evidence=False):
     work_dir = Path(work_dir)
     narration = _load(work_dir, "narration.json")
     if narration is None:
         raise SystemExit(f"缺少 {work_dir / 'narration.json'}；先写解说草稿再评审")
     vlm_analysis = _load(work_dir, "vlm_analysis.json") or []
     asr_result = _load(work_dir, "asr_result.json") or []
+    warnings = []
     if timeline == "cut_output":
         spans = _load_cut_clip_spans(work_dir)
         if not spans:
-            raise SystemExit("cut_output review requires fresh clip_plan_validated.json with explicit source/output spans")
-        vlm_analysis, asr_result = remap_grounding_to_output_timeline(vlm_analysis, asr_result, spans)
+            msg = "cut_output review missing/stale clip_plan_validated.json; advisory fail-open, no strong OUTPUT-clock facts"
+            if strict_evidence:
+                raise SystemExit(msg)
+            warnings.append(msg)
+            vlm_analysis, asr_result = [], []
+        else:
+            vlm_analysis, asr_result = remap_grounding_to_output_timeline(vlm_analysis, asr_result, spans)
     elif timeline != "source":
         raise SystemExit(f"unknown review timeline: {timeline}")
 
-    messages = build_review_messages(narration, vlm_analysis, asr_result, work_dir=work_dir)
-    resp = api_call({
-        "model": CONFIG.get("vlm_model", ""),
-        "messages": messages,
-        "max_tokens": 2000,
-        "temperature": 0,
-        "seed": 7,
-    })
-    content = ""
-    try:
-        content = resp["choices"][0]["message"]["content"]
-    except (KeyError, IndexError, TypeError):
-        log("评审 API 返回结构异常")
-    review = parse_review_response(content)
+    bundle = build_evidence_bundle(vlm_analysis, asr_result, narration, timeline=timeline,
+                                   research=_load_review_research_context(work_dir), warnings=warnings)
+    bundle_fp = _bundle_fingerprint(bundle)
+    fp_warning = _bundle_fingerprint_warning(bundle)
+    if fp_warning:
+        _append_warning_once(warnings, fp_warning)
+        _append_warning_once(bundle.setdefault("warnings", []), fp_warning)
+    chunk_reviews = []
+    chunks = _chunk_evidence_bundle(bundle)
+    for chunk in chunks:
+        messages = build_review_messages(narration, vlm_analysis, asr_result, work_dir=work_dir, evidence_bundle=chunk)
+        resp = api_call({
+            "model": CONFIG.get("vlm_model", ""),
+            "messages": messages,
+            "max_tokens": 2000 if len(chunks) == 1 else 1600,
+            "temperature": 0,
+            "seed": 7 + int(chunk.get("chunk_index", 0)),
+        })
+        content = ""
+        try:
+            content = resp["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            log("评审 API 返回结构异常")
+        parsed = parse_review_response(content)
+        parsed["chunk_index"] = chunk.get("chunk_index", 0)
+        parsed["chunk_count"] = chunk.get("chunk_count", len(chunks))
+        chunk_reviews.append(parsed)
+    review = _merge_chunk_reviews(chunk_reviews)
+    if warnings:
+        review["warnings"] = list(warnings)
+    review["evidence_contract"] = {
+        "schema_version": EVIDENCE_CONTRACT_VERSION,
+        "timeline": timeline,
+        "clock": bundle.get("clock"),
+        "coverage_policy_version": COVERAGE_POLICY_VERSION,
+        "selected_ranges": bundle.get("coverage", {}).get("selected_ranges", []),
+        "evidence_bundle_fingerprint": bundle_fp,
+        "chunk_count": len(chunks),
+        "warnings": warnings,
+    }
+    _write_grounding_qc(work_dir, review, bundle, timeline=timeline)
 
     (work_dir / "narration_review.json").write_text(
         json.dumps(review, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -612,11 +1306,13 @@ def main():
                     help="grounding timeline for narration.json; DEFAULT auto-detects cut_output when a "
                          "validated cut (clip_plan_validated.json + edited_source.mp4) is present, else source. "
                          "cut_output remaps source VLM/ASR to the cut output timeline via clip_plan_validated.json")
+    ap.add_argument("--strict-evidence", action="store_true",
+                    help="block instead of advisory fail-open when required cut-output evidence mapping is missing/stale")
     args = ap.parse_args()
     timeline = args.timeline or _auto_timeline(args.work_dir)
     if args.timeline is None and timeline != "source":
         log(f"评审 grounding 时间轴自动判定为 {timeline}（检测到已校验的剪辑产物）")
-    review = review_narration(args.work_dir, timeline=timeline)
+    review = review_narration(args.work_dir, timeline=timeline, strict_evidence=args.strict_evidence)
     print(json.dumps({
         "status": "reviewed",
         "verdict": review["verdict"],

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -550,8 +550,10 @@ def validate_timeline_mapping(clip_spans):
             errors.append(f"clip_spans[{idx}] must be a dict")
             continue
         try:
-            ss = float(span["source_start"]); se = float(span["source_end"])
-            os_ = float(span["output_start"]); oe = float(span["output_end"])
+            ss = float(span["source_start"])
+            se = float(span["source_end"])
+            os_ = float(span["output_start"])
+            oe = float(span["output_end"])
         except (KeyError, TypeError, ValueError):
             errors.append(f"clip_spans[{idx}] has invalid required times")
             continue

--- a/skills/video-script/scripts/review.py
+++ b/skills/video-script/scripts/review.py
@@ -573,37 +573,10 @@ def build_evidence_bundle(vlm_analysis, asr_result, narration, *, timeline="sour
     clock = "output" if timeline == "cut_output" else "source"
     coverage = coverage_policy_v1(vlm_analysis, asr_result, narration)
     ranges = coverage.get("selected_ranges", [])
-    items = []
-    dropped_scenes = dropped_asr = 0
-    for i, scene in enumerate(vlm_analysis or []):
-        if not isinstance(scene, dict):
-            continue
-        start = _safe_time(scene, "start")
-        end = _safe_time(scene, "end", start)
-        if end <= start or not _in_ranges(start, end, ranges):
-            dropped_scenes += 1
-            continue
-        item = {"id": f"visual:{i}", "source": "visual", "clock": clock, "source_id": str(scene.get("source_id", "0")), "start": round(start, 3), "end": round(end, 3), "text": _scene_evidence_text(scene), "support": "direct", "confidence": "high"}
-        for k in ("source_start", "source_end", "source_clip_id", "output_segment_index"):
-            if k in scene:
-                item[k] = scene.get(k)
-        items.append(item)
-    for i, seg in enumerate(asr_result or []):
-        if not isinstance(seg, dict):
-            continue
-        text = str(seg.get("text", "")).strip()
-        if not text:
-            continue
-        start = _safe_time(seg, "start")
-        end = _safe_time(seg, "end", start)
-        if end <= start or not _in_ranges(start, end, ranges):
-            dropped_asr += 1
-            continue
-        item = {"id": f"asr:{i}", "source": "asr", "clock": clock, "source_id": str(seg.get("source_id", "0")), "start": round(start, 3), "end": round(end, 3), "text": text, "support": "direct", "confidence": "high"}
-        for k in ("source_start", "source_end", "source_clip_id", "output_segment_index"):
-            if k in seg:
-                item[k] = seg.get(k)
-        items.append(item)
+    filtered = filter_evidence_by_ranges(vlm_analysis, asr_result, ranges, timeline=timeline)
+    items = filtered["items"]
+    dropped_scenes = filtered["dropped_visual_count"]
+    dropped_asr = filtered["dropped_asr_count"]
     context_items = _research_context_items(research)
     return {
         "schema_version": EVIDENCE_CONTRACT_VERSION,

--- a/skills/video-understanding/references/data-schema.md
+++ b/skills/video-understanding/references/data-schema.md
@@ -135,6 +135,90 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 常见 code：`invalid_time`、`empty_narration`、`time_overlap`、`outside_clip_plan`、`over_budget`、`incomplete_sentence`、`slot_too_short`、`under_narrated`、`over_narrated`、`fragmented_beats`、`no_original_blocks`。
 
+## style_card.json（Agent 撰写，可选/按 brief 要求）
+
+`style_card.json` 是表达层契约：由 Agent 根据 `--style`、`--context`、素材证据、ASR 和用户偏好信号综合撰写。`--style` 是 freeform verbatim guidance（原样自由文本指导），不是枚举、preset、switch，也不是一组可穷举风格名；不要把它翻译成固定档位。
+
+这个文件记录声音、节奏、回收意图和证据支撑的表达判断；字段可以随项目增减，下游只把它当 JSON object 读取，不要求固定键名。它不负责标题、封面、首句承诺或卖点包装。
+
+```json
+{
+  "voice": "冷静但有压迫感，少讲大道理，多用人物动作和台词里的证据推进",
+  "pacing": "前 15 秒短句建立冲突，中段留原声喘息，结尾回收开头疑问",
+  "payoff_intent": "让观众先看到误会，再看到人物选择的代价",
+  "subtitle_read_posture": "句子可听、可读，不堆长抽象句",
+  "evidence_intent": ["优先引用画面动作", "关键转折保留原声"]
+}
+```
+
+## packaging_plan.json（Agent 撰写，可选）
+
+`packaging_plan.json` 是包装层契约：标题、封面帧/视觉钩子、首句、观众承诺、卖点和发布包装信息。它帮助 review 判断“包装承诺”和正文前 15 秒是否对齐。
+
+它不是文风策略，不覆盖 `style_card.json` 的声音、节奏或表达规则；如果包装需要某个承诺，正文仍要用素材证据兑现。
+
+```json
+{
+  "title": "一句能对外展示的标题",
+  "cover_frame": {"time": 12.4, "reason": "人物第一次正面做出关键选择"},
+  "first_line": "开场第一句解说",
+  "viewer_promise": "观众看完会明白的冲突/反转/信息增量",
+  "selling_points": ["强冲突", "原声高光"],
+  "packaging_notes": "发布侧备注，不写文风规则"
+}
+```
+
+## deslop_qc_requirements.json（工具/brief 生成的运行契约）
+
+`deslop_qc_requirements.json` 是 tool/brief generated run contract：工具或 brief 生成本次运行的 QC 要求，供 `deslop_qc` 读取，不由 Agent 手写。字段包括 `schema_version`、`owner`、`style_card_required`、`packaging_plan_expected`、`deslop_qc.report_only`、`deslop_qc.aigc_detector`、`deslop_qc.auto_rewrite`。
+
+`deslop_qc` 只根据这个运行契约判断缺少 `style_card.json` 是否是 blocker；它不扫描 `agent_narration_brief.md` 的 prompt wording 来推断 `style_card_required`。如果 requirements 文件缺失或损坏，按 legacy/migration advisory 处理，不作为 hard failure。
+
+该契约不改变 `--style`：`--style` 仍是 freeform verbatim guidance，不增加固定风格档位。它也不改变 `deslop_qc` 边界：仍然是 report-only，不是 AIGC detector，不自动改写。
+
+最小示例：
+
+```json
+{
+  "schema_version": "1.0",
+  "owner": "tool_or_brief",
+  "style_card_required": true,
+  "packaging_plan_expected": true,
+  "deslop_qc": {
+    "report_only": true,
+    "aigc_detector": false,
+    "auto_rewrite": false
+  }
+}
+```
+
+## deslop_qc.json（CLI 生成，报告型 QC）
+
+`deslop_qc.json` 由本地 deterministic scanner 生成，Agent 不手写。它只是 report-only QC：不是 AIGC detector，不判断文本是不是 AI 写的，不会自动改写。修改仍由 Agent/人工根据报告回到 `narration.json`、`style_card.json` 或字幕源里处理。
+
+报告分两层：
+
+- `blockers`：客观阻断项，会并入 `narration_lint.json` 的 error，例如 requirements 要求但缺少/损坏 `style_card.json`、破折号、占位符泄漏、模板化“不是……而是……”转折。
+- `advisories`：建议项，只提示可读性/口语化风险，例如套话密度、抽象总结词、解释链、比喻标记、过长段落；它们不自动阻断，也不自动改写。
+
+```json
+{
+  "ok": false,
+  "contract": "Local readability/QC report only: this is not an AIGC detector, does not claim AI-generation accuracy, and never rewrites text. Corrections remain human/agent rewrite work.",
+  "scanner": "deslop_qc.py",
+  "style_card_required": true,
+  "blocker_count": 1,
+  "advisory_count": 1,
+  "blockers": [
+    {"severity": "blocker", "code": "missing_style_card", "source": "style_card", "index": null, "message": "style_card.json is required by this expression/packaging run but is missing"}
+  ],
+  "advisories": [
+    {"severity": "advisory", "code": "cliche_density", "source": "narration", "index": null, "message": "套话/高频抽象词偏密，建议换成具体行动、选择和后果"}
+  ],
+  "metrics": {"segments_scanned": 12, "text_units": 860, "sentence_count": 38}
+}
+```
+
 ## clip_plan.json
 
 cut 模式下 Agent 选择要保留的原片片段，数组或 `{ "clips": [...] }` 都可接受。默认片段不能重叠，避免同一原片时间映射到多个输出位置：

--- a/skills/video-understanding/references/data-schema.md
+++ b/skills/video-understanding/references/data-schema.md
@@ -170,9 +170,9 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 ## deslop_qc_requirements.json（工具/brief 生成的运行契约）
 
-`deslop_qc_requirements.json` 是 tool/brief generated run contract：工具或 brief 生成本次运行的 QC 要求，供 `deslop_qc` 读取，不由 Agent 手写。字段包括 `schema_version`、`owner`、`style_card_required`、`packaging_plan_expected`、`deslop_qc.report_only`、`deslop_qc.aigc_detector`、`deslop_qc.auto_rewrite`。
+`deslop_qc_requirements.json` 是 tool/brief generated run contract：工具或 brief 生成本次运行的 QC 要求，供 `deslop_qc` 读取，不由 Agent 手写。字段为 `schema_version` 与 `style_card_required`。
 
-`deslop_qc` 只根据这个运行契约判断缺少 `style_card.json` 是否是 blocker；它不扫描 `agent_narration_brief.md` 的 prompt wording 来推断 `style_card_required`。如果 requirements 文件缺失或损坏，按 legacy/migration advisory 处理，不作为 hard failure。
+`style_card_required` 默认 `false`（advisory）：缺少 `style_card.json` 只是 warning，不阻断出片。将来的 opt-in 运行可把它设为 `true`，让 `style_card.json` 成为硬性要求——`deslop_qc` 只读这个字段判断缺少 `style_card.json` 是否是 blocker，不扫描 `agent_narration_brief.md` 的 prompt wording 来推断。如果 requirements 文件缺失或损坏，按 legacy/migration advisory 处理，不作为 hard failure。
 
 该契约不改变 `--style`：`--style` 仍是 freeform verbatim guidance，不增加固定风格档位。它也不改变 `deslop_qc` 边界：仍然是 report-only，不是 AIGC detector，不自动改写。
 
@@ -180,15 +180,8 @@ Agent 撰写的解说词。full 模式下使用原视频时间；**orchestrated 
 
 ```json
 {
-  "schema_version": "1.0",
-  "owner": "tool_or_brief",
-  "style_card_required": true,
-  "packaging_plan_expected": true,
-  "deslop_qc": {
-    "report_only": true,
-    "aigc_detector": false,
-    "auto_rewrite": false
-  }
+  "schema_version": 1,
+  "style_card_required": false
 }
 ```
 

--- a/skills/video-understanding/scripts/asr.py
+++ b/skills/video-understanding/scripts/asr.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import re
 import time
 from pathlib import Path
 
@@ -165,6 +166,20 @@ def transcribe_audio(video_path, work_dir):
     return asr_result
 
 
+def _strip_reasoning_residue(text):
+    """Remove MiMo reasoning-model <think>…</think> leakage from ASR content.
+
+    Thinking-disable is not applied to -asr models (lib._prepare_api_payload), so the reasoning
+    model can leak a <think> block — full, truncated/unclosed, or a leading orphan/residual tag
+    (a bare "think>" prefix) — into the transcript. Independent copy of the same strip in
+    video-voiceover/scripts/dub.py (skills share no code); keep the two in sync.
+    """
+    text = re.sub(r"(?is)<think\b.*?</think\s*>", "", text)  # full <think>…</think> block
+    text = re.sub(r"(?is)<think\b.*\Z", "", text)            # unclosed/truncated <think tail
+    text = re.sub(r"(?i)^\s*<?/?think\s*>\s*", "", text)     # leading orphan/residual think tag
+    return text
+
+
 def _run_asr(wav_path):
     """用 MiMo ASR (mimo-v2.5-asr) 转录单个 wav 文件，返回纯文本。
 
@@ -203,7 +218,7 @@ def _run_asr(wav_path):
     except Exception as e:
         raise RuntimeError(f"MiMo ASR 调用失败: {e}") from e
     try:
-        return str(resp["choices"][0]["message"]["content"] or "").strip()
+        return _strip_reasoning_residue(str(resp["choices"][0]["message"]["content"] or "")).strip()
     except (KeyError, IndexError, TypeError):
         raise RuntimeError(f"MiMo ASR 返回结构异常: {json.dumps(resp, ensure_ascii=False)[:200]}")
 

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib.util
 import json
 import math
 import re
@@ -7,6 +8,17 @@ from pathlib import Path
 
 from lib import CONFIG, file_fingerprint, stable_hash
 from lib import log
+
+try:
+    from deslop_qc import analyze_deslop_qc
+except ModuleNotFoundError:
+    _deslop_qc_path = Path(__file__).resolve().parents[1].parent / "video-script" / "scripts" / "deslop_qc.py"
+    _deslop_qc_spec = importlib.util.spec_from_file_location("deslop_qc", _deslop_qc_path)
+    if _deslop_qc_spec is None or _deslop_qc_spec.loader is None:
+        raise
+    _deslop_qc_module = importlib.util.module_from_spec(_deslop_qc_spec)
+    _deslop_qc_spec.loader.exec_module(_deslop_qc_module)
+    analyze_deslop_qc = _deslop_qc_module.analyze_deslop_qc
 
 
 # ── Agent narration preparation and validation helpers ────────────────
@@ -617,15 +629,28 @@ def lint_narration(narration, scenes_analysis=None, *, clip_plan=None, mode="ful
                 avg_block_chars=round(avg_chars, 1), block_min_chars=block_min_chars,
             ))
 
+    deslop_qc = analyze_deslop_qc(narration, work_dir=work_dir)
+    for blocker in deslop_qc.get("blockers", []):
+        errors.append(_lint_issue(
+            "error", blocker.get("index"), blocker.get("code", "deslop_qc_blocker"),
+            blocker.get("message", "deslop QC objective blocker"),
+            source=blocker.get("source"), matches=blocker.get("matches"),
+            sentence=blocker.get("sentence"),
+        ))
+
     report = {
         "ok": not errors,
         "error_count": len(errors),
         "warning_count": len(warnings),
         "metrics": metrics,
+        "deslop_qc": deslop_qc,
         "errors": errors,
         "warnings": warnings,
     }
     if work_dir is not None:
+        Path(work_dir, "deslop_qc.json").write_text(
+            json.dumps(deslop_qc, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
         Path(work_dir, "narration_lint.json").write_text(
             json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
         )
@@ -710,7 +735,7 @@ def _align_narration_to_quiet(narration, scenes_analysis, silence_periods):
             n["overlaps_speech"] = True
         return _validate_narration_budget(narration, scenes_analysis)
 
-    quiet_windows = [qp for qp in silence_periods if not qp.get("has_speech", False)]
+    quiet_windows = [qp for qp in silence_periods if _silence_window_is_usable_quiet(qp)]
     quiet_ratio_min = float(CONFIG.get("quiet_overlap_min_ratio", 0.8) or 0.8)
 
     # Run budget/dedup FIRST, then set the flag on the final (possibly merged) spans,
@@ -749,7 +774,7 @@ def _scene_asr_lines(asr_result, scene):
 def _quiet_windows_for_scene(silence_periods, scene):
     windows = []
     for qp in silence_periods or []:
-        if qp.get("has_speech", False):
+        if not _silence_window_is_usable_quiet(qp):
             continue
         if qp["start"] < scene["end"] and qp["end"] > scene["start"]:
             start = max(qp["start"], scene["start"])
@@ -757,6 +782,18 @@ def _quiet_windows_for_scene(silence_periods, scene):
             if end > start:
                 windows.append((start, end))
     return windows
+
+
+def _silence_window_is_usable_quiet(qp):
+    if not isinstance(qp, dict):
+        return False
+    reason = str(qp.get("has_speech_reason", "")).lower()
+    granularity = str(qp.get("asr_granularity", "")).lower()
+    if reason in {"coarse_asr_overlap_ignored", "asr_overlap_low_confidence_quiet", "coarse_asr_no_overlap"}:
+        return True
+    if granularity == "coarse_grid" and qp.get("has_speech") is True:
+        return True
+    return not qp.get("has_speech", False)
 
 
 def _quiet_overlap_seconds(start, end, quiet_windows):
@@ -783,7 +820,7 @@ def _overlap_seconds(start, end, other_start, other_end):
 def _build_timeline_fusion(scenes, asr_segments, silence_periods):
     """Fuse VLM scenes, ASR dialogue and quiet narration slots on one timeline."""
     fusion = []
-    quiet_windows = [w for w in silence_periods or [] if not w.get("has_speech", False)]
+    quiet_windows = [w for w in silence_periods or [] if _silence_window_is_usable_quiet(w)]
     for scene in scenes or []:
         try:
             start = float(scene.get("start", 0))
@@ -872,7 +909,7 @@ def _format_background_research(research, limit=1800):
     """Render background_research.json into a bounded Story-context brief section."""
     if not isinstance(research, dict) or not research:
         return []
-    lines = ["## Story context (from background_research.json)", ""]
+    lines = ["## Story context (from background_research.json)", "", "Research is context_only: use it for aliases/names/world terms and weak background only; do NOT reveal future plot or upgrade research-only relationships/causes into current on-screen facts without visual/ASR support.", ""]
     for key, label in (
         ("synopsis", "Synopsis"),
         ("worldbuilding", "Worldbuilding"),
@@ -1670,9 +1707,35 @@ def _format_output_clip_list(work_dir):
         except (TypeError, ValueError):
             continue
         reason = str(c.get("reason", "")).strip()
-        out.append(f"- output {os_:.1f}–{oe:.1f}s ← source {ss:.1f}–{se:.1f}s" + (f" — {reason}" if reason else ""))
+        source_id = c.get("source_id", c.get("source", "0"))
+        clip_id = c.get("id", c.get("clip_id", "?"))
+        out.append(f"- OUTPUT {os_:.1f}–{oe:.1f}s ← SOURCE[{source_id}] {ss:.1f}–{se:.1f}s (clip_id={clip_id})" + (f" — {reason}" if reason else ""))
     out.append("")
     return out if len(out) > 2 else []
+
+
+def _deslop_qc_owner():
+    skill_name = Path(__file__).resolve().parents[1].name
+    script_name = Path(__file__).stem
+    return f"{skill_name}.{script_name}"
+
+
+def _write_deslop_qc_requirements(work_dir, *, owner):
+    """Write the stable deslop QC contract consumed by deslop_qc.py."""
+    payload = {
+        "schema_version": 1,
+        "owner": owner,
+        "style_card_required": True,
+        "packaging_plan_expected": True,
+        "deslop_qc": {
+            "report_only": True,
+            "aigc_detector": False,
+            "auto_rewrite": False,
+        },
+    }
+    path = Path(work_dir) / "deslop_qc_requirements.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
 
 
 def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_duration, work_dir, style="纪录片", *, mimo_overview_enabled=None, mimo_overview_video_path=None):
@@ -1717,7 +1780,8 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "Write the required JSON artifact(s) manually from the analysis files in this work directory.",
         "The CLI will not generate final narration text; it will only validate timing, run TTS, and assemble the video.",
         "",
-        f"- Style: {style}",
+        f"- Style (--style, freeform verbatim guidance): {style}",
+        "- Do not translate `--style` into a preset, enum, switch, or fallback ladder; synthesize the voice from this freeform text plus evidence.",
         f"- Edit mode: {edit_mode}",
         f"- Source video duration: {video_duration:.1f}s",
         f"- Target duration (cut mode): {target_duration}",
@@ -1754,6 +1818,13 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
     lines.extend([
         f"- Default pause between beats: {target_pause_ms}ms",
         f"- Context: {CONFIG.get('context_info') or '(none)'}",
+        "",
+        "## Shared expression / packaging artifacts",
+        "",
+        "Before final narration, author `style_card.json` and `packaging_plan.json` from `--style`, `--context`, source materials, ASR, scene evidence, and user preference signals.",
+        "- `style_card.json` owns freeform voice, pacing, payoff shape, subtitle/read posture, and evidence-backed expression intent. It is not a preset enum, fixed taxonomy, title plan, cover plan, or packaging promise.",
+        "- `packaging_plan.json` owns title, cover-frame/visual hook, first-line, viewer promise, packaging metadata, and packaging-to-story alignment. It must not override `style_card.json` voice or pacing policy.",
+        "- `deslop_qc.json` is deterministic report-only tool QC: do not hand-author it, do not treat it as an AIGC detector, and do not auto-rewrite from it. Corrections remain human/agent rewrite work guided by objective blockers and advisory readability signals.",
         "",
     ])
 
@@ -1812,7 +1883,9 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
                 "- Keep clips that carry causality, a reveal, a decision, or a strong emotional beat; cut establishing/transition/repeated/static shots.",
                 "- SKIP non-story footage: 片头/片尾 credits, 演职员表, 广告/赞助, 台标/水印 stretches, and any scene the analysis marks rejected/无法描述 (often a watermark) — they look bad on screen and add nothing.",
                 "- Prefer scenes that have a real visual description in the guide; favor faces, action and dialogue over scenery.",
-                "- Clip length ~3–15s; vary the pace; order clips in story order so the cut reads as a coherent story.",
+                "- Clip order is the story spine, not unordered highlights: you may use 0–1 optional cold-open/high-impact clip first, then return to the coherent main arc (setup → turn → payoff) and escalate to the ending.",
+                "- Use the `reason` field as craft intent where useful: `cold_open`, `setup`, `turn`, or `payoff` plus a short concrete why. Example: `cold_open: trial explosion reveals the stakes`.",
+                "- Clip length ~3–15s; vary the pace; after any cold-open, order clips by causality so the cut reads as one coherent story, not a flat highlights reel.",
                 "- End a clip on a COMPLETE spoken line — set the clip end at or just after an ASR line-end (or inside the quiet window that follows it), never mid-sentence, so the original dialogue is never chopped off. Use the ASR [start–end] times + Quiet windows below as safe cut points; the CLI also snaps clip ends to the nearest line-end as a safety net.",
                 "",
                 "### clip_plan.json shape (original source timestamps)",
@@ -1843,7 +1916,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
                 "block's text, then leave a few-second gap before the next block for an original-audio moment.",
                 "```json",
                 "[",
-                "  {\"start\": 2.0, \"end\": 13.0, \"narration\": \"范闲表面是个闲散少爷，背地里却握着监察院的暗线。这一次，他要赌上身家去查母亲的死。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"紧张\"}",
+                "  {\"start\": 2.0, \"end\": 13.0, \"narration\": \"【主角】表面只是旁观者，暗中却握着关键线索。这一次，TA要赌上全部去查清旧案真相。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"紧张\"}",
                 "]",
                 "```",
             ])
@@ -1855,7 +1928,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
             "block's text, then leave a few-second gap before the next block for an original-audio moment.",
             "```json",
             "[",
-            "  {\"start\": 5.0, \"end\": 16.0, \"narration\": \"范闲表面是个闲散少爷，背地里却握着监察院的暗线。这一次，他要赌上身家去查母亲的死。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"平静\"}",
+            "  {\"start\": 5.0, \"end\": 16.0, \"narration\": \"【主角】表面只是旁观者，暗中却握着关键线索。这一次，TA要赌上全部去查清旧案真相。\", \"pause_after_ms\": 250, \"overlaps_speech\": true, \"emotion\": \"平静\"}",
             "]",
             "```",
         ])
@@ -1907,7 +1980,7 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
         "",
         "看图说话 (bad) vs recap (good) — same shot:",
         "- ✗ \"一个蒙眼的男人抱着一个篮子走在雨里。\"  (just describes the frame)",
-        "- ✓ \"杀手五竹本可以一走了之，却为了一个不是自己孩子的婴儿，把整座京都的追兵引向自己。\"  (who, why, stakes)",
+        "- ✓ \"护送者本可以独自离开，却为了保护那个孩子，主动把追兵引向自己。\"  (who, why, stakes)",
         "",
         "## Scene timing guide",
         "",
@@ -1937,5 +2010,6 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
 
     brief_path = Path(work_dir) / "agent_narration_brief.md"
     brief_path.write_text("\n".join(lines), encoding="utf-8")
+    _write_deslop_qc_requirements(work_dir, owner=_deslop_qc_owner())
     log(f"已写入 Agent 解说写作 brief: {brief_path}")
     return brief_path

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1137,13 +1137,17 @@ def _clean_asr_prompt_fingerprint():
 
 
 def _index_prompt_fingerprint():
-    prompt = """你在根据逐场景画面分析，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
-只依据给到的画面证据（场景描述 + 帧实动作），不要脑补画面之外的剧情。
+    prompt = """你在根据逐场景画面分析、ASR对白、background_research术语表，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
+规则：
+- visual/asr 是当前视频事实证据；每个人物、关系、剧情节点、物件尽量给 evidence_ids。
+- background_research 只能用于人名/别名/术语/身份消歧，默认 support=context_only；不能把后续剧情或未出现关系升级为当前画面事实。
+- ASR 中出现但画面描述未命名的人名，应进入 characters[*].asr_mentions。
 只返回 JSON：
-{"characters":[{"name":"角色名或外观指代","description":"身份/特征"}],
- "relationships":[{"a":"角色","b":"角色","relation":"关系"}],
- "plot_points":["按时间顺序的关键剧情节点"],
- "entities":["重要物件/地点/线索"]}"""
+{"characters":[{"name":"角色名或外观指代","description":"身份/特征","aliases":[],"visual_descriptions":[],"asr_mentions":[],"research_role":"","evidence_ids":[],"confidence":"high|medium|low"}],
+ "relationships":[{"a":"角色","b":"角色","relation":"关系","evidence_ids":[],"support":"direct|indirect|context_only"}],
+ "plot_points":[{"time":"00:00","text":"按时间顺序的关键剧情节点","evidence_ids":[]}],
+ "entities":[{"name":"重要物件/地点/线索","evidence_ids":[]}],
+ "research_glossary":[{"name":"名字/术语","aliases":[],"role":"说明","support":"context_only"}]}"""
     return hashlib.md5(prompt.encode("utf-8")).hexdigest()
 
 
@@ -1202,10 +1206,14 @@ def _format_consolidation(index):
     plot = index.get("plot_points") or []
     if plot:
         lines.append("- Plot spine:")
-        lines.extend(f"    {i + 1}. {p}" for i, p in enumerate(plot))
+        lines.extend(
+            f"    {i + 1}. {p.get('text', p) if isinstance(p, dict) else p}"
+            for i, p in enumerate(plot)
+        )
     ents = index.get("entities") or []
     if ents:
-        lines.append(f"- Entities: {', '.join(str(e) for e in ents)}")
+        ent_names = [str(e.get("name", e) if isinstance(e, dict) else e) for e in ents]
+        lines.append(f"- Entities: {', '.join(ent_names)}")
     lines.append("")
     return lines
 

--- a/skills/video-understanding/scripts/brief.py
+++ b/skills/video-understanding/scripts/brief.py
@@ -1722,24 +1722,16 @@ def _format_output_clip_list(work_dir):
     return out if len(out) > 2 else []
 
 
-def _deslop_qc_owner():
-    skill_name = Path(__file__).resolve().parents[1].name
-    script_name = Path(__file__).stem
-    return f"{skill_name}.{script_name}"
+def _write_deslop_qc_requirements(work_dir):
+    """Write the stable deslop QC contract consumed by deslop_qc.py.
 
-
-def _write_deslop_qc_requirements(work_dir, *, owner):
-    """Write the stable deslop QC contract consumed by deslop_qc.py."""
+    style_card_required defaults to False (advisory): a missing style_card.json is a
+    warning, not a render-blocking error. A future opt-in run can set it True to make
+    style_card.json a hard requirement — deslop_qc.py reads that field.
+    """
     payload = {
         "schema_version": 1,
-        "owner": owner,
-        "style_card_required": True,
-        "packaging_plan_expected": True,
-        "deslop_qc": {
-            "report_only": True,
-            "aigc_detector": False,
-            "auto_rewrite": False,
-        },
+        "style_card_required": False,
     }
     path = Path(work_dir) / "deslop_qc_requirements.json"
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -2018,6 +2010,6 @@ def build_agent_brief(scenes_analysis, asr_result, silence_periods, video_durati
 
     brief_path = Path(work_dir) / "agent_narration_brief.md"
     brief_path.write_text("\n".join(lines), encoding="utf-8")
-    _write_deslop_qc_requirements(work_dir, owner=_deslop_qc_owner())
+    _write_deslop_qc_requirements(work_dir)
     log(f"已写入 Agent 解说写作 brief: {brief_path}")
     return brief_path

--- a/skills/video-understanding/scripts/consolidate.py
+++ b/skills/video-understanding/scripts/consolidate.py
@@ -264,7 +264,7 @@ def build_index_messages(vlm_analysis, asr_result=None, asr_clean=None, backgrou
         f"{INDEX_PROMPT}\n\n"
         f"## 逐场景画面分析（共 {len(lines)} 段）\n" + "\n".join(lines) + "\n\n"
         f"## ASR / cleaned dialogue（共 {len(asr_lines)} 段）\n" + ("\n".join(asr_lines) or "(无)") + "\n\n"
-        f"## Research glossary（clock=null/context_only，不得升级为当前剧情事实）\n" + ("\n".join(glossary_lines) or "(无)")
+        "## Research glossary（clock=null/context_only，不得升级为当前剧情事实）\n" + ("\n".join(glossary_lines) or "(无)")
     )
     return [{"role": "user", "content": user}]
 

--- a/skills/video-understanding/scripts/consolidate.py
+++ b/skills/video-understanding/scripts/consolidate.py
@@ -34,13 +34,19 @@ CLEAN_PROMPT = """你在清洗中文视频的 ASR 逐段转写。对【每一段
 - 只清洗 text，不要增删事实、不要脑补画面。
 只返回 JSON：{"segments":[{"i":0,"text":"清洗后的文本","speaker":"可选说话人"}, ...]}，i 为输入段的下标。"""
 
-INDEX_PROMPT = """你在根据逐场景画面分析，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
-只依据给到的画面证据（场景描述 + 帧实动作），不要脑补画面之外的剧情。
+INDEX_SCHEMA_VERSION = 2
+
+INDEX_PROMPT = """你在根据逐场景画面分析、ASR对白、background_research术语表，为一个视频建立【全局理解索引】，供后续写解说词时保持人物/关系/主线一致。
+规则：
+- visual/asr 是当前视频事实证据；每个人物、关系、剧情节点、物件尽量给 evidence_ids。
+- background_research 只能用于人名/别名/术语/身份消歧，默认 support=context_only；不能把后续剧情或未出现关系升级为当前画面事实。
+- ASR 中出现但画面描述未命名的人名，应进入 characters[*].asr_mentions。
 只返回 JSON：
-{"characters":[{"name":"角色名或外观指代","description":"身份/特征"}],
- "relationships":[{"a":"角色","b":"角色","relation":"关系"}],
- "plot_points":["按时间顺序的关键剧情节点"],
- "entities":["重要物件/地点/线索"]}"""
+{"characters":[{"name":"角色名或外观指代","description":"身份/特征","aliases":[],"visual_descriptions":[],"asr_mentions":[],"research_role":"","evidence_ids":[],"confidence":"high|medium|low"}],
+ "relationships":[{"a":"角色","b":"角色","relation":"关系","evidence_ids":[],"support":"direct|indirect|context_only"}],
+ "plot_points":[{"time":"00:00","text":"按时间顺序的关键剧情节点","evidence_ids":[]}],
+ "entities":[{"name":"重要物件/地点/线索","evidence_ids":[]}],
+ "research_glossary":[{"name":"名字/术语","aliases":[],"role":"说明","support":"context_only"}]}"""
 
 
 # ── pure seams (no I/O; unit-testable) ────────────────────────────────────────
@@ -85,37 +91,194 @@ def parse_clean_response(text, asr_result):
     return out
 
 
-def build_index_messages(vlm_analysis):
+def _json_md5_file(work_dir, name):
+    path = Path(work_dir) / name
+    return hashlib.md5(path.read_bytes()).hexdigest() if path.exists() else ""
+
+
+def _asr_clean_source_md5(work_dir):
+    return _json_md5_file(work_dir, "asr_clean.json")
+
+
+def _research_source_md5(work_dir):
+    return _json_md5_file(work_dir, "background_research.json")
+
+
+def _clip_plan_source_md5(work_dir):
+    return _json_md5_file(work_dir, "clip_plan_validated.json")
+
+
+def _research_glossary_from_context(background_research):
+    glossary = []
+    if not isinstance(background_research, dict):
+        return glossary
+    chars = background_research.get("characters")
+    if isinstance(chars, dict):
+        for name, role in chars.items():
+            if str(name).strip():
+                glossary.append({"name": str(name).strip(), "aliases": [], "role": str(role).strip(), "support": "context_only"})
+    details = background_research.get("character_details")
+    if isinstance(details, dict):
+        for name, info in details.items():
+            if not isinstance(info, dict):
+                continue
+            aliases = [str(a).strip() for a in (info.get("aliases") or []) if str(a).strip()] if isinstance(info.get("aliases"), list) else []
+            role = str(info.get("role", "")).strip()
+            if str(name).strip() or aliases or role:
+                glossary.append({"name": str(name).strip(), "aliases": aliases, "role": role, "support": "context_only"})
+    return glossary
+
+
+
+
+def _dialogue_segments_for_index(asr_result=None, asr_clean=None):
+    clean_segments = (asr_clean or {}).get("segments") if isinstance(asr_clean, dict) else None
+    source = clean_segments if isinstance(clean_segments, list) else (asr_result or [])
+    out = []
+    for i, seg in enumerate(source or []):
+        if not isinstance(seg, dict):
+            continue
+        text = str(seg.get("text", "")).strip()
+        if not text:
+            continue
+        out.append({
+            "id": f"asr:{i}",
+            "start": seg.get("start"),
+            "end": seg.get("end"),
+            "text": text,
+        })
+    return out
+
+
+def _stable_unique(values):
+    seen = set()
+    out = []
+    for value in values or []:
+        key = json.dumps(value, ensure_ascii=False, sort_keys=True) if isinstance(value, dict) else str(value)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(value)
+    return out
+
+
+def _apply_deterministic_asr_research_fallback(index, asr_result=None, asr_clean=None, background_research=None):
+    """Guarantee ASR/research mentions survive even when the LLM omits them.
+
+    The LLM still owns synthesis, but cacheable deterministic fields make ASR contribution
+    observable: aliases/names from background_research are matched against ASR/asr_clean text
+    and written to characters[*].asr_mentions/evidence_ids without inventing relationships or
+    plot facts. Research remains context_only via research_glossary.
+    """
+    index = dict(index or {})
+    for key in ("characters", "relationships", "plot_points", "entities", "research_glossary"):
+        index.setdefault(key, [])
+    glossary = index.get("research_glossary") or _research_glossary_from_context(background_research)
+    if not glossary:
+        glossary = _research_glossary_from_context(background_research)
+    for item in glossary:
+        if isinstance(item, dict):
+            item["support"] = "context_only"
+    index["research_glossary"] = glossary
+
+    segments = _dialogue_segments_for_index(asr_result=asr_result, asr_clean=asr_clean)
+    char_by_name = {}
+    for c in index.get("characters") or []:
+        if isinstance(c, dict) and str(c.get("name", "")).strip():
+            char_by_name[str(c.get("name")).strip()] = c
+    for g in glossary:
+        if not isinstance(g, dict):
+            continue
+        name = str(g.get("name", "")).strip()
+        aliases = [str(a).strip() for a in (g.get("aliases") or []) if str(a).strip()]
+        terms = [t for t in [name] + aliases if t]
+        if not terms:
+            continue
+        matches = []
+        evidence_ids = []
+        for seg in segments:
+            text = seg["text"]
+            hit_terms = [term for term in terms if term and term in text]
+            if hit_terms:
+                matches.append({"text": text, "evidence_id": seg["id"], "matched_aliases": hit_terms})
+                evidence_ids.append(seg["id"])
+        if not matches:
+            continue
+        char = char_by_name.get(name)
+        if char is None:
+            char = {"name": name or matches[0]["matched_aliases"][0], "description": "", "aliases": aliases, "visual_descriptions": [], "asr_mentions": [], "research_role": str(g.get("role", "")).strip(), "evidence_ids": [], "confidence": "medium"}
+            index["characters"].append(char)
+            char_by_name[char["name"]] = char
+        char.setdefault("aliases", [])
+        char["aliases"] = _stable_unique(list(char.get("aliases") or []) + aliases)
+        char.setdefault("asr_mentions", [])
+        char["asr_mentions"] = _stable_unique(list(char.get("asr_mentions") or []) + matches)
+        char.setdefault("evidence_ids", [])
+        char["evidence_ids"] = _stable_unique(list(char.get("evidence_ids") or []) + evidence_ids)
+        if not char.get("research_role"):
+            char["research_role"] = str(g.get("role", "")).strip()
+        char.setdefault("confidence", "medium")
+    return index
+
+def build_index_messages(vlm_analysis, asr_result=None, asr_clean=None, background_research=None):
     lines = []
-    for scene in (vlm_analysis or []):
+    for i, scene in enumerate(vlm_analysis or []):
         if not isinstance(scene, dict):
             continue
-        sid = scene.get("scene_id", "?")
+        sid = scene.get("scene_id", i)
         start = float(scene.get("start", 0) or 0)
         end = float(scene.get("end", 0) or 0)
         desc = str(scene.get("description", "")).strip().replace("\n", " ")
         facts = scene.get("frame_facts")
         fact_txt = ""
-        if isinstance(facts, dict) and facts:  # frame_facts is a DICT {ts: [actions]}
+        if isinstance(facts, dict) and facts:
             actions = []
-            for ts in sorted(facts.keys(), key=lambda x: float(x)):
+            def fact_key(x):
+                try:
+                    return (0, float(x))
+                except (TypeError, ValueError):
+                    return (1, str(x))
+            for ts in sorted(facts.keys(), key=fact_key):
                 vals = facts[ts]
                 actions.extend(vals if isinstance(vals, list) else [str(vals)])
             if actions:
                 fact_txt = " | 帧实: " + "；".join(a for a in actions[:6] if a)
-        lines.append(f"[场景{sid} {start:.0f}-{end:.0f}s] {desc}{fact_txt}")
-    user = f"{INDEX_PROMPT}\n\n## 逐场景画面分析（共 {len(lines)} 段）\n" + "\n".join(lines)
+        lines.append(f"[visual:{i} 场景{sid} {start:.0f}-{end:.0f}s] {desc}{fact_txt}")
+    asr_lines = []
+    clean_segments = (asr_clean or {}).get("segments") if isinstance(asr_clean, dict) else None
+    source_asr = clean_segments if isinstance(clean_segments, list) else (asr_result or [])
+    for i, seg in enumerate(source_asr or []):
+        if not isinstance(seg, dict):
+            continue
+        text = str(seg.get("text", "")).strip()
+        if not text:
+            continue
+        asr_lines.append(f"[asr:{i} {float(seg.get('start', 0) or 0):.0f}-{float(seg.get('end', 0) or 0):.0f}s] {text}")
+    glossary = _research_glossary_from_context(background_research)
+    glossary_lines = []
+    for i, item in enumerate(glossary[:80]):
+        aliases = "/".join(item.get("aliases") or [])
+        alias_txt = f" aliases={aliases}" if aliases else ""
+        glossary_lines.append(f"[research:{i} support=context_only] {item.get('name','')}{alias_txt}: {item.get('role','')}")
+    user = (
+        f"{INDEX_PROMPT}\n\n"
+        f"## 逐场景画面分析（共 {len(lines)} 段）\n" + "\n".join(lines) + "\n\n"
+        f"## ASR / cleaned dialogue（共 {len(asr_lines)} 段）\n" + ("\n".join(asr_lines) or "(无)") + "\n\n"
+        f"## Research glossary（clock=null/context_only，不得升级为当前剧情事实）\n" + ("\n".join(glossary_lines) or "(无)")
+    )
     return [{"role": "user", "content": user}]
-
 
 def parse_index_response(text):
     data = _extract_json(text)
     if not isinstance(data, dict):
-        return {"characters": [], "relationships": [], "plot_points": [], "entities": []}
-    out = {}
-    for key in ("characters", "relationships", "plot_points", "entities"):
+        return {"schema_version": INDEX_SCHEMA_VERSION, "characters": [], "relationships": [], "plot_points": [], "entities": [], "research_glossary": []}
+    out = {"schema_version": INDEX_SCHEMA_VERSION}
+    for key in ("characters", "relationships", "plot_points", "entities", "research_glossary"):
         val = data.get(key)
         out[key] = val if isinstance(val, list) else []
+    for item in out["research_glossary"]:
+        if isinstance(item, dict):
+            item["support"] = "context_only"
     return out
 
 
@@ -142,12 +305,25 @@ def format_index_md(index):
     plot = index.get("plot_points") or []
     if plot:
         out.append("## Plot spine")
-        out.extend(f"{i+1}. {p}" for i, p in enumerate(plot))
+        for i, p in enumerate(plot):
+            out.append(f"{i+1}. {p.get('text', p) if isinstance(p, dict) else p}")
         out.append("")
     ents = index.get("entities") or []
     if ents:
         out.append("## Entities")
-        out.extend(f"- {e}" for e in ents)
+        for e in ents:
+            out.append(f"- {e.get('name', e) if isinstance(e, dict) else e}")
+        out.append("")
+    glossary = index.get("research_glossary") or []
+    if glossary:
+        out.append("## Research glossary (context_only)")
+        for g in glossary:
+            if isinstance(g, dict):
+                aliases = "/".join(g.get("aliases") or [])
+                alias_txt = f" ({aliases})" if aliases else ""
+                out.append(f"- {g.get('name', '?')}{alias_txt}: {g.get('role', '')} [{g.get('support', 'context_only')}]")
+            else:
+                out.append(f"- {g}")
         out.append("")
     return "\n".join(out).rstrip() + "\n"
 
@@ -188,8 +364,13 @@ def _prompt_fingerprint(prompt):
 
 def _write_index_meta(work_dir, vlm_analysis):
     _index_meta_path(work_dir).write_text(json.dumps({
-        "schema_version": 1,
+        "schema_version": INDEX_SCHEMA_VERSION,
         "source_md5": _vlm_source_md5(work_dir),
+        "vlm_md5": _vlm_source_md5(work_dir),
+        "asr_md5": _asr_source_md5(work_dir),
+        "asr_clean_md5": _asr_clean_source_md5(work_dir),
+        "research_md5": _research_source_md5(work_dir),
+        "clip_plan_md5": _clip_plan_source_md5(work_dir),
         "scene_count": len([s for s in (vlm_analysis or []) if isinstance(s, dict)]),
         "model": CONFIG.get("vlm_model", ""),
         "prompt_md5": _prompt_fingerprint(INDEX_PROMPT),
@@ -206,7 +387,13 @@ def _index_cache_matches(work_dir, vlm_analysis):
         return False
     return (
         isinstance(meta, dict)
+        and meta.get("schema_version") == INDEX_SCHEMA_VERSION
         and meta.get("source_md5") == _vlm_source_md5(work_dir)
+        and meta.get("vlm_md5", meta.get("source_md5")) == _vlm_source_md5(work_dir)
+        and meta.get("asr_md5", "") == _asr_source_md5(work_dir)
+        and meta.get("asr_clean_md5", "") == _asr_clean_source_md5(work_dir)
+        and meta.get("research_md5", "") == _research_source_md5(work_dir)
+        and meta.get("clip_plan_md5", "") == _clip_plan_source_md5(work_dir)
         and meta.get("scene_count") == len([s for s in (vlm_analysis or []) if isinstance(s, dict)])
         and meta.get("model") == CONFIG.get("vlm_model", "")
         and meta.get("prompt_md5") == _prompt_fingerprint(INDEX_PROMPT)
@@ -267,10 +454,15 @@ def consolidate_index(work_dir):
     if _fresh(out_path, work_dir / "vlm_analysis.json") and _index_cache_matches(work_dir, vlm_analysis):
         log("consolidate(index): understanding_index.json 已最新，跳过")
         return _load(work_dir, "understanding_index.json")
+    asr_result = _load(work_dir, "asr_result.json") or []
+    asr_clean = _load(work_dir, "asr_clean.json") or {}
+    background_research = _load(work_dir, "background_research.json") or {}
     resp = api_call({"model": CONFIG.get("vlm_model", ""),
-                     "messages": build_index_messages(vlm_analysis),
-                     "max_tokens": 2500, "temperature": 0.2})
+                     "messages": build_index_messages(vlm_analysis, asr_result=asr_result, asr_clean=asr_clean, background_research=background_research),
+                     "max_tokens": 3000, "temperature": 0.2})
     index = parse_index_response(_response_text(resp))
+    index = _apply_deterministic_asr_research_fallback(
+        index, asr_result=asr_result, asr_clean=asr_clean, background_research=background_research)
     out_path.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
     _write_index_meta(work_dir, vlm_analysis)
     (work_dir / "understanding_index.md").write_text(format_index_md(index), encoding="utf-8")

--- a/skills/video-understanding/scripts/consolidate.py
+++ b/skills/video-understanding/scripts/consolidate.py
@@ -104,10 +104,6 @@ def _research_source_md5(work_dir):
     return _json_md5_file(work_dir, "background_research.json")
 
 
-def _clip_plan_source_md5(work_dir):
-    return _json_md5_file(work_dir, "clip_plan_validated.json")
-
-
 def _research_glossary_from_context(background_research):
     glossary = []
     if not isinstance(background_research, dict):
@@ -366,11 +362,9 @@ def _write_index_meta(work_dir, vlm_analysis):
     _index_meta_path(work_dir).write_text(json.dumps({
         "schema_version": INDEX_SCHEMA_VERSION,
         "source_md5": _vlm_source_md5(work_dir),
-        "vlm_md5": _vlm_source_md5(work_dir),
         "asr_md5": _asr_source_md5(work_dir),
         "asr_clean_md5": _asr_clean_source_md5(work_dir),
         "research_md5": _research_source_md5(work_dir),
-        "clip_plan_md5": _clip_plan_source_md5(work_dir),
         "scene_count": len([s for s in (vlm_analysis or []) if isinstance(s, dict)]),
         "model": CONFIG.get("vlm_model", ""),
         "prompt_md5": _prompt_fingerprint(INDEX_PROMPT),
@@ -389,11 +383,9 @@ def _index_cache_matches(work_dir, vlm_analysis):
         isinstance(meta, dict)
         and meta.get("schema_version") == INDEX_SCHEMA_VERSION
         and meta.get("source_md5") == _vlm_source_md5(work_dir)
-        and meta.get("vlm_md5", meta.get("source_md5")) == _vlm_source_md5(work_dir)
         and meta.get("asr_md5", "") == _asr_source_md5(work_dir)
         and meta.get("asr_clean_md5", "") == _asr_clean_source_md5(work_dir)
         and meta.get("research_md5", "") == _research_source_md5(work_dir)
-        and meta.get("clip_plan_md5", "") == _clip_plan_source_md5(work_dir)
         and meta.get("scene_count") == len([s for s in (vlm_analysis or []) if isinstance(s, dict)])
         and meta.get("model") == CONFIG.get("vlm_model", "")
         and meta.get("prompt_md5") == _prompt_fingerprint(INDEX_PROMPT)

--- a/skills/video-understanding/scripts/detect.py
+++ b/skills/video-understanding/scripts/detect.py
@@ -163,6 +163,75 @@ def _filter_junk_scenes(scenes, video_path):
 
 # ── Step 3.5: 静音检测 ─────────────────────────────────────────────
 
+def annotate_quiet_windows_with_asr(periods, asr_result=None, *, video_duration=None, configured_segment_seconds=None):
+    """Pure helper: annotate quiet windows with ASR-overlap confidence and QC.
+
+    Coarse grid ASR (large synthetic windows from chunking) must not turn every quiet
+    window into speech. The return value is (annotated_periods, qc). Inputs are copied.
+    """
+    out = [dict(p) for p in (periods or []) if isinstance(p, dict)]
+    qc = {"coarse_asr_windows": 0, "low_confidence_speech_flags": 0, "asr_granularity": "none"}
+    for qp in out:
+        qp.setdefault("speech_overlap_ratio", 0.0)
+        qp.setdefault("asr_overlap_seconds", 0.0)
+        qp.setdefault("asr_granularity", "none")
+        qp.setdefault("has_speech", False)
+        qp.setdefault("has_speech_reason", "no_asr_overlap")
+    if not asr_result:
+        return out, qc
+
+    valid_segments = []
+    for seg in asr_result:
+        if not isinstance(seg, dict):
+            continue
+        try:
+            ss, se = float(seg.get("start", 0)), float(seg.get("end", 0))
+        except (TypeError, ValueError):
+            continue
+        if se > ss:
+            valid_segments.append((ss, se))
+    asr_coverage = sum(se - ss for ss, se in valid_segments)
+    avg_seg_dur = asr_coverage / len(valid_segments) if valid_segments else 0
+    if video_duration is None:
+        ends = [float(p.get("end", 0) or 0) for p in out] + [se for _, se in valid_segments]
+        video_duration = max(ends or [0.0])
+    configured = float(configured_segment_seconds if configured_segment_seconds is not None else (CONFIG.get("asr_segment_seconds", 30) or 30))
+    coarse_asr = (
+        (len(valid_segments) <= 5 and asr_coverage > float(video_duration) * 0.8) or
+        asr_coverage > float(video_duration) * 1.5 or
+        avg_seg_dur > max(45.0, configured * 1.5) or
+        (avg_seg_dur >= configured * 0.9 and asr_coverage > float(video_duration) * 0.7)
+    )
+    granularity = "coarse_grid" if coarse_asr else "segment"
+    qc["asr_granularity"] = granularity
+    qc["avg_asr_segment_seconds"] = round(avg_seg_dur, 3)
+    for qp in out:
+        overlap_seconds = 0.0
+        for ss, se in valid_segments:
+            overlap_seconds += max(0.0, min(float(qp["end"]), se) - max(float(qp["start"]), ss))
+        ratio = overlap_seconds / max(0.001, float(qp.get("duration", 0.0) or 0.0))
+        qp["asr_overlap_seconds"] = round(overlap_seconds, 3)
+        qp["speech_overlap_ratio"] = round(ratio, 4)
+        qp["asr_granularity"] = granularity
+        if coarse_asr:
+            qp["has_speech"] = False
+            qp["has_speech_reason"] = "coarse_asr_overlap_ignored" if overlap_seconds > 0 else "coarse_asr_no_overlap"
+            if overlap_seconds > 0:
+                qc["coarse_asr_windows"] += 1
+            continue
+        if ratio >= 0.3:
+            qp["has_speech"] = True
+            qp["has_speech_reason"] = "asr_overlap_high_confidence"
+        elif overlap_seconds > 0:
+            qp["has_speech"] = False
+            qp["has_speech_reason"] = "asr_overlap_low_confidence_quiet"
+            qc["low_confidence_speech_flags"] += 1
+        else:
+            qp["has_speech"] = False
+            qp["has_speech_reason"] = "no_asr_overlap"
+    return out, qc
+
+
 def detect_silence_periods(video_path, work_dir, asr_result=None):
     """用 ffmpeg silencedetect 检测安静时段，作为解说插入的候选窗口"""
     audio_path = work_dir / "audio.wav"
@@ -226,31 +295,16 @@ def detect_silence_periods(video_path, work_dir, asr_result=None):
     quiet_min = CONFIG["quiet_window_min"]
     periods = [p for p in merged if p["duration"] >= quiet_min]
 
-    # 与 ASR 交叉验证：标记有语音的窗口
-    # 跳过条件：ASR 段太粗（无法精确判断语音位置）
-    # 1. 段数少(<=5)且覆盖>80%视频时长 → 时间戳不可靠
-    # 2. 覆盖率>150% → 时间戳明显异常
-    # 3. 平均段长过大 → 粒度太粗，无法判断哪些窗口有语音
-    #    阈值 45s 给默认 ASR 窗口(asr_segment_seconds=30s)留出余量，使交叉验证重新生效；
-    #    粗粒度(如 180s 旧窗口)仍会被正确跳过。
-    if asr_result:
-        video_dur = get_video_duration(str(audio_path))
-        asr_coverage = sum(seg.get("end", 0) - seg.get("start", 0) for seg in asr_result)
-        avg_seg_dur = asr_coverage / len(asr_result) if asr_result else 0
-        skip_cross_check = (
-            (len(asr_result) <= 5 and asr_coverage > video_dur * 0.8) or
-            asr_coverage > video_dur * 1.5 or
-            avg_seg_dur > 45
-        )
-        if not skip_cross_check:
-            for qp in periods:
-                for seg in asr_result:
-                    seg_s = seg.get("start", 0)
-                    seg_e = seg.get("end", 0)
-                    overlap = min(qp["end"], seg_e) - max(qp["start"], seg_s)
-                    if overlap > qp["duration"] * 0.3:
-                        qp["has_speech"] = True
-                        break
+    # 与 ASR 交叉验证：标记有语音的窗口，并记录可观测 confidence/reason。
+    periods, qc = annotate_quiet_windows_with_asr(
+        periods,
+        asr_result,
+        video_duration=get_video_duration(str(audio_path)) if asr_result else None,
+        configured_segment_seconds=CONFIG.get("asr_segment_seconds", 30),
+    )
+
+    (work_dir / "silence_periods.qc.json").write_text(
+        json.dumps(qc, ensure_ascii=False, indent=2), encoding="utf-8")
 
     # 保存
     (work_dir / "silence_periods.json").write_text(

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -209,7 +209,7 @@ CONFIG = {
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
     "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 300,  # TTS fade-in/fade-out 时长(ms)
+    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
     # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
     "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
@@ -235,7 +235,10 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
+    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
+    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
+    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
@@ -266,6 +269,9 @@ CONFIG = {
     "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
     "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
     "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
+    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
+    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
+    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
     "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
@@ -280,6 +286,7 @@ CONFIG = {
     "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
     "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
     "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
+    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
     "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
     "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
     "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
@@ -297,6 +304,24 @@ CONFIG = {
 
 SCRIPT_DIR = Path(__file__).parent
 PROMPTS_DIR = SCRIPT_DIR.parent / "references"
+
+def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):
+    """Return the canonical tempo budget shared by voiceover and assemble."""
+    cfg = config or CONFIG
+    global_speed = max(0.01, float(cfg.get("narration_speed", 1.0) or 1.0))
+    rate_factor = max(0.01, 1.0 + float(tts_rate_offset or 0.0))
+    cumulative_max = max(1.0, float(cfg.get("narration_cumulative_tempo_max", 1.35) or 1.35))
+    hard_max = max(cumulative_max, float(cfg.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40))
+    legacy_segment_cap = max(1.0, float(cfg.get("tts_segment_tempo_max", 1.20) or 1.20))
+    segment_tempo_max = max(1.0, min(legacy_segment_cap, cumulative_max / (global_speed * rate_factor)))
+    return {
+        "global_narration_speed": global_speed,
+        "tts_rate_factor": rate_factor,
+        "cumulative_tempo_max": cumulative_max,
+        "cumulative_tempo_hard_max": hard_max,
+        "segment_tempo_max": segment_tempo_max,
+        "max_raw_duration_factor": global_speed * segment_tempo_max,
+    }
 
 def log(msg):
     print(f"[video-recap] {msg}", flush=True)

--- a/skills/video-voiceover/scripts/dub.py
+++ b/skills/video-voiceover/scripts/dub.py
@@ -22,6 +22,7 @@ import argparse
 import base64
 import json
 import re
+import unicodedata
 import wave
 from pathlib import Path
 
@@ -38,6 +39,8 @@ CLONE_MODEL = "mimo-v2.5-tts-voiceclone"
 CLONE_SR = 24000  # mimo voiceclone returns 24kHz mono PCM16 wav
 ASR_MIME = "audio/wav"
 ATEMPO_CAP = 2.0  # max compression before we trim instead (atempo>2 also sounds rushed)
+DUB_FAST_SPEECH_CPS = 7.0
+DUB_TRIM_RISK_CPS = 7.0
 
 DUB_SCHEMA_VERSION = 1
 # Tolerate ~1-frame rounding in agent-estimated timings so the gate blocks only GENUINE
@@ -82,7 +85,15 @@ DUB_ARTIFACT_SCHEMAS = {
 
 def _chars_per_second(text, room):
     room = max(float(room or 0.0), 0.001)
-    return len(str(text or "")) / room
+    effective = 0
+    for ch in str(text or ""):
+        if ch.isspace():
+            continue
+        cat = unicodedata.category(ch)
+        if cat.startswith("P") or cat.startswith("S"):
+            continue
+        effective += 1
+    return effective / room
 
 
 def _issue(severity, code, line, message, start=None, end=None):
@@ -164,9 +175,9 @@ def lint_dub_script(script, duration, work_dir=None):
             max_cps = max(max_cps, cps)
             if room < 0.4:
                 issues.append(_issue("error", "room_too_short", line_no, "line has less than 0.4s room for speech", start, end))
-            elif zh and cps > 8.0:
+            elif zh and cps >= DUB_FAST_SPEECH_CPS:
                 issues.append(_issue("warning", "fast_speech", line_no, f"translation is dense ({cps:.1f} chars/s)", start, end))
-            if zh and cps > 12.0:
+            if zh and cps >= DUB_TRIM_RISK_CPS:
                 trim_risk.append(line_no)
                 issues.append(_issue("warning", "trim_risk", line_no, "likely to be compressed hard or trimmed by render", start, end))
     error_items = [x for x in issues if x["severity"] == "error"]

--- a/skills/video-voiceover/scripts/dub.py
+++ b/skills/video-voiceover/scripts/dub.py
@@ -271,6 +271,20 @@ def _wav_frames(path):
 
 # ── ASR (timed windows) ──────────────────────────────────────────────
 
+def _strip_reasoning_residue(text):
+    """Remove MiMo reasoning-model <think>…</think> leakage from ASR content.
+
+    Thinking-disable is not applied to -asr models (lib._prepare_api_payload), so a reasoning
+    model can leak a <think> block — full, truncated/unclosed, or a leading orphan/residual tag
+    (observed as a bare "think>" prefix) — into the transcript. Strip all shapes; the generic
+    marker strip in _run_asr then handles the remaining "<chinese>"-style tags.
+    """
+    text = re.sub(r"(?is)<think\b.*?</think\s*>", "", text)  # full <think>…</think> block
+    text = re.sub(r"(?is)<think\b.*\Z", "", text)            # unclosed/truncated <think tail
+    text = re.sub(r"(?i)^\s*<?/?think\s*>\s*", "", text)     # leading orphan/residual think tag
+    return text
+
+
 def _run_asr(wav_path, lang="en"):
     raw = Path(wav_path).read_bytes()
     if not raw:
@@ -288,7 +302,7 @@ def _run_asr(wav_path, lang="en"):
         text = str(resp["choices"][0]["message"]["content"] or "").strip()
     except (KeyError, IndexError, TypeError):
         return ""
-    return re.sub(r"<[^>]{1,20}>", "", text).strip()  # strip ASR markers like "<chinese>"
+    return re.sub(r"<[^>]{1,20}>", "", _strip_reasoning_residue(text)).strip()  # strip reasoning + ASR markers like "<chinese>"
 
 
 def _asr_windows(audio_wav, segs_dir, duration, window):

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -14,6 +14,7 @@ from email.utils import parsedate_to_datetime
 
 
 # ── 配置 ──────────────────────────────────────────────────────────────
+_EXISTING_CONFIG_REF = globals().get("CONFIG")
 
 DEFAULT_MIMO_API_URL = "https://api.xiaomimimo.com/v1"
 DEFAULT_MIMO_TOKEN_PLAN_CLUSTER = "cn"
@@ -203,7 +204,7 @@ CONFIG = {
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
     "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 300,  # TTS fade-in/fade-out 时长(ms)
+    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
     # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
     "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
@@ -229,7 +230,10 @@ CONFIG = {
     "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
     "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
     "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.3, minimum=0.5),  # 解说整体提速(atempo)，默认偏快适配短视频；长片可设 1.0
+    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
+    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
+    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
+    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
     "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
     "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
     "narration_delay_seconds": 1.5,  # 解说延迟放置秒数，让画面先出现再解说
@@ -260,6 +264,9 @@ CONFIG = {
     "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
     "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
     "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
+    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
+    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
+    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
     "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
@@ -274,6 +281,7 @@ CONFIG = {
     "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
     "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
     "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
+    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
     "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
     "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
     "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
@@ -288,9 +296,31 @@ CONFIG = {
     "subtitle_play_res_x": env_int("SUBTITLE_PLAY_RES_X", 1280, minimum=1),
     "subtitle_play_res_y": env_int("SUBTITLE_PLAY_RES_Y", 720, minimum=1),
 }
+if isinstance(_EXISTING_CONFIG_REF, dict):
+    _EXISTING_CONFIG_REF.clear()
+    _EXISTING_CONFIG_REF.update(CONFIG)
+    CONFIG = _EXISTING_CONFIG_REF
 
 SCRIPT_DIR = Path(__file__).parent
 PROMPTS_DIR = SCRIPT_DIR.parent / "references"
+
+def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):
+    """Return the canonical tempo budget shared by voiceover and assemble."""
+    cfg = config or CONFIG
+    global_speed = max(0.01, float(cfg.get("narration_speed", 1.0) or 1.0))
+    rate_factor = max(0.01, 1.0 + float(tts_rate_offset or 0.0))
+    cumulative_max = max(1.0, float(cfg.get("narration_cumulative_tempo_max", 1.35) or 1.35))
+    hard_max = max(cumulative_max, float(cfg.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40))
+    legacy_segment_cap = max(1.0, float(cfg.get("tts_segment_tempo_max", 1.20) or 1.20))
+    segment_tempo_max = max(1.0, min(legacy_segment_cap, cumulative_max / (global_speed * rate_factor)))
+    return {
+        "global_narration_speed": global_speed,
+        "tts_rate_factor": rate_factor,
+        "cumulative_tempo_max": cumulative_max,
+        "cumulative_tempo_hard_max": hard_max,
+        "segment_tempo_max": segment_tempo_max,
+        "max_raw_duration_factor": global_speed * segment_tempo_max,
+    }
 
 def log(msg):
     print(f"[video-recap] {msg}", flush=True)

--- a/skills/video-voiceover/scripts/voiceover.py
+++ b/skills/video-voiceover/scripts/voiceover.py
@@ -7,11 +7,12 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from lib import CONFIG
-from lib import log, mimo_tts_api_call, get_video_duration
-from lib import _truncate_at_sentence, stable_hash, file_fingerprint
+from lib import log, mimo_tts_api_call, get_video_duration, narration_tempo_budget
+from lib import _truncate_at_sentence, _text_char_count, stable_hash, file_fingerprint
 
 SUPPORTED_TTS_ENGINES = {"mimo-tts"}
-TTS_CACHE_VERSION = 1
+SEGMENT_AUDIO_SCHEMA_VERSION = 1
+TTS_CACHE_VERSION = 2
 
 
 def _parse_rate_offset(rate_str):
@@ -95,33 +96,59 @@ def _synthesize_segment(i, seg, narration, tts_dir, engine):
     seg_slot = seg["end"] - seg["start"]
     seg_pause = seg.get("pause_after_ms", CONFIG.get("breath_ms", 250)) / 1000
     available = max(0.5, seg_slot - seg_pause)
-    # assemble speeds every segment up by narration_speed (global atempo) BEFORE placement, so the
-    # slot actually holds raw_dur / narration_speed; fold that in (plus the local per-segment adjust
-    # headroom atempo_max) or a 1.3x-authored BLOCK gets needlessly truncated into a clipped fragment.
-    narration_speed = float(CONFIG.get("narration_speed", 1.0) or 1.0)
-    raw_budget = available * narration_speed * 1.2
+    rate_offset = _parse_rate_offset(rate)
+    budget = narration_tempo_budget(rate_offset)
+    raw_budget = available * budget["max_raw_duration_factor"]
+    truncated = False
+    truncate_reason = "none"
     if dur > raw_budget and len(text) > 5:
-        chars_per_sec = len(text) / dur if dur > 0 else 3.0
+        chars_per_sec = _text_char_count(text) / dur if dur > 0 else 3.0
         target_chars = max(5, int(raw_budget * chars_per_sec) - 1)
-        truncated = _truncate_at_sentence(text, target_chars)
-        if truncated and len(truncated) >= 5 and truncated != text:
-            log(f"  段 {i+1}: 解说超出片段时长，自动截断 {len(text)}→{len(truncated)} 字以适配（建议在解说里改写得更短）")
-            text = truncated
+        shortened = _truncate_at_sentence(text, target_chars)
+        if shortened and len(shortened) >= 5 and shortened != text:
+            log(f"  段 {i+1}: 解说超出片段时长，按累计语速预算句界缩短 {len(text)}→{len(shortened)} 字以适配（建议在解说里改写得更短）")
+            text = shortened
+            truncated = True
+            truncate_reason = "sentence_boundary"
             _run_tts_engine(engine, text, output_wav, rate=rate, pitch=pitch, emotion=seg.get("emotion"))
             dur = _get_audio_duration(output_wav)
 
-    _write_tts_segment_cache(output_wav, cache_key, text, dur, _parse_rate_offset(rate))
-    return _build_tts_segment_result(i, seg, text, output_wav, dur, _parse_rate_offset(rate))
+    norm_meta = _maybe_normalize_tts_wav(output_wav)
+    if norm_meta:
+        dur = _get_audio_duration(output_wav)
+    _write_tts_segment_cache(output_wav, cache_key, text, dur, rate_offset,
+                             truncated, truncate_reason, norm_meta)
+    result = _build_tts_segment_result(
+        i, seg, text, output_wav, dur, rate_offset, truncated, truncate_reason, norm_meta)
+    return result
 
 
-def _build_tts_segment_result(index, seg, text, output_wav, duration, rate_offset):
+def _build_tts_segment_result(index, seg, text, output_wav, duration, rate_offset,
+                              truncated=False, truncate_reason="none", norm_meta=None):
+    budget = narration_tempo_budget(rate_offset)
+    authored_text = _clean_narration_text(str(seg.get("narration", text)))
+    resolved_truncated = bool(truncated) or (text != authored_text)
     result = {
+        "segment_audio_schema_version": SEGMENT_AUDIO_SCHEMA_VERSION,
         "index": index,
         "start": seg["start"],
         "end": seg["end"],
-        "narration": text,
+        "narration": authored_text,
+        "spoken_text": text,
+        "truncated": resolved_truncated,
+        "truncate_reason": (truncate_reason if truncate_reason != "none" else "sentence_boundary") if resolved_truncated else "none",
+        "fit_status": "pending_assembly",
         "audio_path": str(output_wav),
         "audio_duration": duration,
+        "placed_audio_duration": None,
+        "actual_place_start": None,
+        "actual_place_end": None,
+        "global_narration_speed": budget["global_narration_speed"],
+        "segment_tempo_factor": 1.0,
+        "effective_tempo": budget["global_narration_speed"] * budget["tts_rate_factor"],
+        "rms_dbfs_before": (norm_meta or {}).get("rms_dbfs_before"),
+        "rms_dbfs_after": (norm_meta or {}).get("rms_dbfs_after"),
+        "peak_after": (norm_meta or {}).get("peak_after"),
         "tts_rate_offset": rate_offset,
         "pause_after_ms": seg.get("pause_after_ms", CONFIG.get("breath_ms", 250)),
         "overlaps_speech": seg.get("overlaps_speech", True),
@@ -278,6 +305,93 @@ def _cleanup_partial_tts_outputs(output_wav):
             pass
 
 
+def _normalize_tts_wav_rms(input_wav, output_wav, *, target_rms_dbfs=-20.0, peak_limit=0.98):
+    """Normalize a mono/stereo 16-bit WAV to a target RMS with peak guard.
+
+    This helper is intentionally dependency-free so QC/assembly can reuse the
+    returned metadata even when normalization is applied in a later lane.
+    """
+    import math
+    import wave
+
+    input_wav = Path(input_wav)
+    output_wav = Path(output_wav)
+    with wave.open(str(input_wav), "rb") as wf:
+        channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        framerate = wf.getframerate()
+        frames = wf.getnframes()
+        data = wf.readframes(frames)
+    if sampwidth != 2:
+        raise ValueError(f"仅支持 16-bit PCM WAV: {input_wav}")
+
+    samples = [int.from_bytes(data[i:i + 2], "little", signed=True) for i in range(0, len(data), 2)]
+    if not samples:
+        output_wav.write_bytes(input_wav.read_bytes())
+        return {
+            "rms_dbfs_before": None,
+            "rms_dbfs_after": None,
+            "peak_after": 0.0,
+            "gain_db": 0.0,
+        }
+    rms = math.sqrt(sum(s * s for s in samples) / len(samples))
+    peak = max(abs(s) for s in samples) / 32768.0
+    rms_dbfs_before = 20 * math.log10(max(rms, 1e-9) / 32768.0)
+    target_linear = 10 ** (float(target_rms_dbfs) / 20.0) * 32768.0
+    gain = target_linear / max(rms, 1e-9)
+    if peak > 0:
+        gain = min(gain, float(peak_limit) / peak)
+    normalized = []
+    for sample in samples:
+        value = int(round(sample * gain))
+        value = max(-32768, min(32767, value))
+        normalized.append(value.to_bytes(2, "little", signed=True))
+    out_data = b"".join(normalized)
+    with wave.open(str(output_wav), "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sampwidth)
+        wf.setframerate(framerate)
+        wf.writeframes(out_data)
+
+    out_samples = [int.from_bytes(out_data[i:i + 2], "little", signed=True) for i in range(0, len(out_data), 2)]
+    out_rms = math.sqrt(sum(s * s for s in out_samples) / len(out_samples))
+    out_peak = max(abs(s) for s in out_samples) / 32768.0
+    return {
+        "rms_dbfs_before": rms_dbfs_before,
+        "rms_dbfs_after": 20 * math.log10(max(out_rms, 1e-9) / 32768.0),
+        "peak_after": out_peak,
+        "gain_db": 20 * math.log10(max(gain, 1e-9)),
+    }
+
+
+def _maybe_normalize_tts_wav(output_wav):
+    """Normalize a synthesized TTS block in-place when possible.
+
+    Unit tests often stub TTS with text bytes rather than real WAV. In that case
+    normalization is skipped safely; real MiMo WAV output gets RMS/peak metadata.
+    """
+    if not CONFIG.get("tts_segment_normalize", True):
+        return None
+    output_wav = Path(output_wav)
+    tmp = output_wav.with_name(f"{output_wav.stem}_norm{output_wav.suffix}")
+    try:
+        meta = _normalize_tts_wav_rms(
+            output_wav,
+            tmp,
+            target_rms_dbfs=float(CONFIG.get("tts_segment_target_rms_dbfs", -20.0) or -20.0),
+            peak_limit=float(CONFIG.get("tts_segment_peak_limit", 0.98) or 0.98),
+        )
+        os.replace(tmp, output_wav)
+        return meta
+    except Exception as exc:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        log(f"  TTS RMS 归一跳过: {exc}")
+        return None
+
+
 def _tts_segment_cache_path(output_wav):
     return Path(str(output_wav) + ".cache.json")
 
@@ -304,8 +418,12 @@ def _reuse_tts_segment_cache(index, seg, output_wav, source_text, rate, cache_ke
         return None
     spoken_text = str(cached.get("spoken_text") or source_text)
     rate_offset = float(cached.get("tts_rate_offset", _parse_rate_offset(rate)) or 0.0)
+    truncated = bool(cached.get("truncated", False))
+    truncate_reason = str(cached.get("truncate_reason") or ("sentence_boundary" if truncated else "none"))
+    norm_meta = cached.get("normalization") if isinstance(cached.get("normalization"), dict) else None
     log(f"  段 {index+1}: 复用已有 ({existing_dur:.1f}s)")
-    return _build_tts_segment_result(index, seg, spoken_text, output_wav, existing_dur, rate_offset)
+    return _build_tts_segment_result(index, seg, spoken_text, output_wav, existing_dur,
+                                     rate_offset, truncated, truncate_reason, norm_meta)
 
 
 def _tts_segment_cache_key(engine, index, seg, source_text, rate, pitch):
@@ -353,7 +471,8 @@ def _load_tts_segment_cache(output_wav, cache_key):
     return data
 
 
-def _write_tts_segment_cache(output_wav, cache_key, spoken_text, duration, rate_offset):
+def _write_tts_segment_cache(output_wav, cache_key, spoken_text, duration, rate_offset,
+                             truncated=False, truncate_reason="none", norm_meta=None):
     """Persist non-secret provenance for safe per-segment TTS reuse."""
     try:
         import json
@@ -365,6 +484,9 @@ def _write_tts_segment_cache(output_wav, cache_key, spoken_text, duration, rate_
                 "spoken_text": spoken_text,
                 "audio_duration": duration,
                 "tts_rate_offset": rate_offset,
+                "truncated": bool(truncated),
+                "truncate_reason": truncate_reason if truncated else "none",
+                "normalization": norm_meta or None,
             }, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
@@ -405,6 +527,12 @@ def tts_settings_fingerprint(engine=None):
         "mimo_tts_voice": CONFIG.get("mimo_tts_voice"),
         "mimo_tts_style": CONFIG.get("mimo_tts_style"),
         "narration_speed": float(CONFIG.get("narration_speed", 1.0) or 1.0),
+        "narration_cumulative_tempo_max": float(CONFIG.get("narration_cumulative_tempo_max", 1.35) or 1.35),
+        "narration_cumulative_tempo_hard_max": float(CONFIG.get("narration_cumulative_tempo_hard_max", 1.40) or 1.40),
+        "tts_segment_tempo_max": float(CONFIG.get("tts_segment_tempo_max", 1.20) or 1.20),
+        "tts_segment_normalize": bool(CONFIG.get("tts_segment_normalize", True)),
+        "tts_segment_target_rms_dbfs": float(CONFIG.get("tts_segment_target_rms_dbfs", -20.0) or -20.0),
+        "tts_segment_peak_limit": float(CONFIG.get("tts_segment_peak_limit", 0.98) or 0.98),
     }
 
 

--- a/tests/assemble/test_original_gap_subtitles.py
+++ b/tests/assemble/test_original_gap_subtitles.py
@@ -11,6 +11,7 @@ import assemble  # noqa: E402
 def _burn_on(monkeypatch):
     monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", True)
     monkeypatch.setitem(assemble.CONFIG, "mask_source_subtitles", True)
+    monkeypatch.setitem(assemble.CONFIG, "source_subtitle_mask_policy", "opt_in")
     monkeypatch.setitem(assemble.CONFIG, "subtitle_original_in_gaps", True)
 
 
@@ -81,6 +82,7 @@ def test_original_gap_entries_gated_off(monkeypatch, tmp_path):
     # burn off
     monkeypatch.setitem(assemble.CONFIG, "burn_subtitles", False)
     monkeypatch.setitem(assemble.CONFIG, "mask_source_subtitles", True)
+    monkeypatch.setitem(assemble.CONFIG, "source_subtitle_mask_policy", "opt_in")
     monkeypatch.setitem(assemble.CONFIG, "subtitle_original_in_gaps", True)
     assert assemble._original_gap_subtitle_entries([], tmp_path, 10.0) == []
     # not masking → source subs already show, so we must NOT add ours
@@ -89,6 +91,7 @@ def test_original_gap_entries_gated_off(monkeypatch, tmp_path):
     assert assemble._original_gap_subtitle_entries([], tmp_path, 10.0) == []
     # explicit override off
     monkeypatch.setitem(assemble.CONFIG, "mask_source_subtitles", True)
+    monkeypatch.setitem(assemble.CONFIG, "source_subtitle_mask_policy", "opt_in")
     monkeypatch.setitem(assemble.CONFIG, "subtitle_original_in_gaps", False)
     assert assemble._original_gap_subtitle_entries([], tmp_path, 10.0) == []
 

--- a/tests/assemble/test_portrait_subtitles.py
+++ b/tests/assemble/test_portrait_subtitles.py
@@ -8,7 +8,9 @@ metrics in the PlayRes coordinate space, so a 16:9 PlayRes on a 9:16 frame squis
 glyphs horizontally and mis-sized the source-subtitle mask band. Landscape output must
 stay byte-identical; portrait must use a frame-matching PlayRes that fits the width.
 """
-from assemble import _subtitle_style_config, _generate_ass  # noqa: E402
+from subprocess import CompletedProcess
+from assemble import _subtitle_style_config, _generate_ass, _probe_canvas  # noqa: E402
+import assemble  # noqa: E402
 
 
 def test_canvas_none_is_legacy_default():
@@ -66,3 +68,104 @@ def test_generate_ass_writes_canvas_driven_playres(tmp_path):
     _generate_ass(segs, tmp_path, None)
     legacy = (tmp_path / "subtitles.ass").read_text(encoding="utf-8")
     assert "PlayResX: 1280" in legacy and "PlayResY: 720" in legacy
+
+
+def test_probe_canvas_preserves_legacy_landscape(monkeypatch, tmp_path):
+    def fake_run_cmd(cmd):
+        return CompletedProcess(cmd, 0, json_text({
+            "streams": [{
+                "width": 1280,
+                "height": 720,
+                "r_frame_rate": "30000/1001",
+                "sample_aspect_ratio": "1:1",
+                "display_aspect_ratio": "16:9",
+            }]
+        }), "")
+
+    monkeypatch.setattr(assemble, "run_cmd", fake_run_cmd)
+    canvas = _probe_canvas(tmp_path / "landscape.mp4")
+    assert canvas["width"] == 1280
+    assert canvas["height"] == 720
+    assert canvas["fps"] == 29.97
+    assert canvas["rotation"] == 0
+
+
+def test_probe_canvas_applies_rotation_and_sar(monkeypatch, tmp_path):
+    def fake_run_cmd(cmd):
+        return CompletedProcess(cmd, 0, json_text({
+            "streams": [{
+                "width": 1920,
+                "height": 1080,
+                "r_frame_rate": "30/1",
+                "sample_aspect_ratio": "4:3",
+                "display_aspect_ratio": "64:27",
+                "tags": {"rotate": "90"},
+            }]
+        }), "")
+
+    monkeypatch.setattr(assemble, "run_cmd", fake_run_cmd)
+    canvas = _probe_canvas(tmp_path / "rotated.mp4")
+    assert canvas["storage_width"] == 1920
+    assert canvas["storage_height"] == 1080
+    assert canvas["rotation"] == 90
+    # DAR widens the display canvas first (1080 * 64/27 = 2560), then rotation swaps.
+    assert canvas["width"] == 1080
+    assert canvas["height"] == 2560
+    assert canvas["sample_aspect_ratio"] == "4:3"
+
+
+def json_text(value):
+    import json
+    return json.dumps(value)
+
+
+def test_probe_canvas_applies_rotation_metadata_and_preserves_landscape(monkeypatch):
+    """Rotation metadata changes display canvas; unrotated landscape remains legacy width x height."""
+    import assemble
+    from subprocess import CompletedProcess
+
+    outputs = iter([
+        "width=1920\nheight=1080\nr_frame_rate=30000/1001\nrotation=90\nsample_aspect_ratio=1:1\ndisplay_aspect_ratio=9:16\n",
+        "width=1280\nheight=720\nr_frame_rate=30/1\nrotation=0\nsample_aspect_ratio=1:1\ndisplay_aspect_ratio=16:9\n",
+    ])
+
+    def fake_run_cmd(cmd):
+        return CompletedProcess(cmd, 0, stdout=next(outputs), stderr="")
+
+    monkeypatch.setattr(assemble, "run_cmd", fake_run_cmd)
+
+    rotated = assemble._probe_canvas("rotated_portrait.mp4")
+    assert rotated["width"] == 1080
+    assert rotated["height"] == 1920
+    assert rotated["rotation"] == 90
+    assert rotated["sar"] == "1:1"
+    assert rotated["dar"] == "9:16"
+
+    landscape = assemble._probe_canvas("landscape.mp4")
+    assert landscape["width"] == 1280
+    assert landscape["height"] == 720
+    assert landscape["rotation"] == 0
+
+
+def test_subtitle_layout_qc_flags_multiline_safe_area_overflow():
+    """Subtitle layout QC must be multi-line aware and fail/warn when text exceeds safe area."""
+    import assemble
+
+    layout_qc = getattr(assemble, "_subtitle_layout_qc", None)
+    assert callable(layout_qc), "assemble must expose subtitle layout QC for overflow checks"
+
+    ok = layout_qc(
+        [{"start": 0.0, "end": 2.0, "text": "第一行\n第二行"}],
+        canvas={"width": 1080, "height": 1920},
+        safe_area={"x": 54, "y": 96, "w": 972, "h": 1728},
+    )
+    assert ok["max_lines"] == 2
+    assert ok["overflow"] is False
+
+    overflow = layout_qc(
+        [{"start": 0.0, "end": 2.0, "text": "超长字幕" * 120}],
+        canvas={"width": 360, "height": 640},
+        safe_area={"x": 36, "y": 64, "w": 288, "h": 120},
+    )
+    assert overflow["overflow"] is True
+    assert any(v.get("kind") in {"safe_area", "line_width", "line_count"} for v in overflow["violations"])

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -6,6 +6,30 @@ import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
 from assemble import _wrap_subtitle_text, _split_subtitle_chunks, _subtitle_entries, _adjust_tts_speed, _apply_narration_speed, _assembly_manifest_payload, _build_audio_filter_complex, _build_timed_narration, _build_video_clips, _emit_timeline, _resolve_final_output, _value_fingerprint, _escape_ass_text, _generate_ass, _generate_srt, _seconds_to_ass_time, _seconds_to_srt_time, _source_subtitle_mask_filter, _subtitle_burn_filter, _output_downscale_filter, assemble_video, assembly_settings_fingerprint, final_loudnorm_filter
 from lib import CONFIG
+import assemble
+
+
+def _volume_expr_from_filter(filter_complex):
+    marker = "volume='"
+    start = filter_complex.index(marker) + len(marker)
+    end = filter_complex.index("':eval=frame", start)
+    return filter_complex[start:end]
+
+
+def _eval_duck_expr(filter_complex, t):
+    expr = _volume_expr_from_filter(filter_complex)
+    return eval(expr, {"__builtins__": {}}, {
+        "t": float(t),
+        "min": min,
+        "max": max,
+        "between": lambda value, lo, hi: 1.0 if lo <= value <= hi else 0.0,
+    })
+
+
+def _adjust_result_parts(result):
+    assert isinstance(result, tuple), "_adjust_tts_speed should return path, duration, metadata"
+    assert len(result) >= 3, "P0 requires machine-readable fit metadata from _adjust_tts_speed"
+    return result[0], result[1], result[2]
 
 
 def test_adjust_tts_speed_derives_outputs_from_audio_name_only(monkeypatch, tmp_path):
@@ -24,14 +48,17 @@ def test_adjust_tts_speed_derives_outputs_from_audio_name_only(monkeypatch, tmp_
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 2.2 if Path(path) == src else 2.0)
     monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
 
-    adjusted, actual_dur = _adjust_tts_speed(src, target_duration=2.0, work_dir=tmp_path)
+    adjusted, actual_dur, meta = _adjust_result_parts(
+        _adjust_tts_speed(src, target_duration=2.0, work_dir=tmp_path)
+    )
 
     assert actual_dur == 2.0
     assert Path(adjusted) == wav_parent / "narr_000_adj.wav"
+    assert meta["fit_status"] in {"fit", "tempo_adjusted"}
     assert commands[-1][-1] == str(wav_parent / "narr_000_adj.wav")
 
 
-def test_adjust_tts_speed_truncation_keeps_output_next_to_audio(monkeypatch, tmp_path):
+def test_adjust_tts_speed_no_safe_fit_keeps_source_audio_and_metadata(monkeypatch, tmp_path):
     wav_parent = tmp_path / "episode.wav-cache"
     wav_parent.mkdir()
     src = wav_parent / "narr_000.wav"
@@ -40,17 +67,23 @@ def test_adjust_tts_speed_truncation_keeps_output_next_to_audio(monkeypatch, tmp
 
     def fake_run_cmd(cmd, **kw):
         commands.append(cmd)
-        Path(cmd[-1]).write_bytes(b"cut")
+        Path(cmd[-1]).write_bytes(b"unexpected")
         return CompletedProcess(cmd, 0, "", "")
 
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.2)
+    monkeypatch.setitem(CONFIG, "narration_cumulative_tempo_max", 1.35)
     monkeypatch.setattr("assemble.get_video_duration", lambda path: 10.0 if Path(path) == src else 1.0)
     monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
 
-    adjusted, actual_dur = _adjust_tts_speed(src, target_duration=1.0, work_dir=tmp_path)
+    adjusted, actual_dur, meta = _adjust_result_parts(
+        _adjust_tts_speed(src, target_duration=1.0, work_dir=tmp_path)
+    )
 
-    assert actual_dur == 1.0
-    assert Path(adjusted) == wav_parent / "narr_000_cut.wav"
-    assert commands[-1][-1] == str(wav_parent / "narr_000_cut.wav")
+    assert actual_dur == 10.0
+    assert Path(adjusted) == src
+    assert meta["fit_status"] == "no_safe_fit"
+    assert meta.get("blocking") is True
+    assert commands == []
 
 
 def test_build_video_clips_prefers_fingerprint_matched_validated_cut_plan(monkeypatch, tmp_path):
@@ -185,6 +218,7 @@ def test_source_subtitle_mask_filter_toggles_with_effective_burn_policy(monkeypa
     # no-burn means sidecar-subtitle mode: ambient/default source masking must not
     # create a black band without burned recap subtitles.
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "opt_in")
     monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.15)
     assert _source_subtitle_mask_filter() is None
 
@@ -201,6 +235,7 @@ def test_mask_band_stays_one_line_small_when_burning(monkeypatch):
     line + margin (small), NOT two lines. A 2-line band ate ~23% of the height and compressed the
     picture; a one-line band keeps it near the raw mask ratio."""
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "opt_in")
     monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.14)
     monkeypatch.setitem(CONFIG, "subtitle_font_size", 42)
     monkeypatch.setitem(CONFIG, "subtitle_margin_v", 30)
@@ -518,10 +553,11 @@ def test_build_audio_filter_complex_gap_fill_envelope(monkeypatch):
     ])
     assert "volume='max(0,min(1,0.85" in fc          # idle baseline holds the original up in the gaps
     assert "eval=frame" in fc
-    assert "min(t-0.00,2.00-t)/0.25" in fc            # faded duck under the dialogue-overlap beat
-    assert "min(t-5.00,7.00-t)/0.25" in fc            # faded duck under the quiet-window beat
-    assert "(-0.650)" in fc                           # 0.85 -> 0.20 under dialogue
-    assert "(-0.730)" in fc                           # 0.85 -> 0.12 in quiet window
+    assert _eval_duck_expr(fc, 0.00) == pytest.approx(0.2)   # already ducked at spoken start
+    assert _eval_duck_expr(fc, 2.00) == pytest.approx(0.2)   # holds through spoken end
+    assert _eval_duck_expr(fc, 5.00) == pytest.approx(0.12)
+    assert _eval_duck_expr(fc, 7.00) == pytest.approx(0.12)
+    assert _eval_duck_expr(fc, 3.50) == pytest.approx(0.85)  # true gap releases to idle
     assert fc.endswith("[aout]")
 
 
@@ -537,7 +573,9 @@ def test_build_audio_filter_complex_all_overlap_still_fills_gaps(monkeypatch):
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
     ])
     assert "volume='max(0,min(1,0.85" in fc           # NOT a constant; idle baseline present
-    assert "min(t-0.00,2.00-t)/0.25" in fc            # ducks only under the narration window
+    assert _eval_duck_expr(fc, 0.00) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 2.00) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 2.25) == pytest.approx(0.85)
     assert "eval=frame" in fc
     assert fc.endswith("[aout]")
 
@@ -554,9 +592,9 @@ def test_build_audio_filter_complex_bridges_short_gaps(monkeypatch):
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
         {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": True},  # gap 2.0 < 6.0
     ])
-    assert "min(t-0.00,6.00-t)/0.25" in fc            # one held duck across both beats + the gap
-    assert "min(t-0.00,2.00-t)" not in fc             # NOT two separate dips
-    assert "min(t-4.00,6.00-t)" not in fc
+    assert _eval_duck_expr(fc, 0.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 3.0) == pytest.approx(0.2)    # one held duck across both beats + gap
+    assert _eval_duck_expr(fc, 6.0) == pytest.approx(0.2)
     assert fc.count("(-0.650)") == 1                  # a single coalesced duck term
 
 
@@ -572,8 +610,11 @@ def test_build_audio_filter_complex_releases_long_gaps(monkeypatch):
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},
         {"actual_place_start": 10.0, "actual_place_end": 12.0, "overlaps_speech": True},  # gap 8.0 >= 6.0
     ])
-    assert "min(t-0.00,2.00-t)/0.25" in fc            # two separate dips with idle between
-    assert "min(t-10.00,12.00-t)/0.25" in fc
+    assert _eval_duck_expr(fc, 0.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 2.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 6.0) == pytest.approx(0.85)   # two separate dips with idle between
+    assert _eval_duck_expr(fc, 10.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 12.0) == pytest.approx(0.2)
     assert fc.count("(-0.650)") == 2
 
 
@@ -592,8 +633,11 @@ def test_build_audio_filter_complex_original_blocks_play_full_volume(monkeypatch
     ])
     assert "volume='max(0,min(1,1.0" in fc            # full-volume original baseline (was 0.85)
     assert fc.count("(-0.800)") == 2                  # 1.0 -> 0.2 under each block, two separate dips
-    assert "min(t-0.00,8.00-t)/0.3" in fc            # first block ducks, then releases to full
-    assert "min(t-14.00,22.00-t)/0.3" in fc          # second block ducks; the 6s gap stays full between
+    assert _eval_duck_expr(fc, 0.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 8.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 11.0) == pytest.approx(1.0)   # the 6s gap stays full between
+    assert _eval_duck_expr(fc, 14.0) == pytest.approx(0.2)
+    assert _eval_duck_expr(fc, 22.0) == pytest.approx(0.2)
 
 
 def test_build_audio_filter_complex_bridged_mixed_levels_flatten_to_min(monkeypatch):
@@ -609,7 +653,9 @@ def test_build_audio_filter_complex_bridged_mixed_levels_flatten_to_min(monkeypa
         {"actual_place_start": 0.0, "actual_place_end": 2.0, "overlaps_speech": True},   # 0.2
         {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": False},  # 0.12, gap 2 < 6
     ])
-    assert "min(t-0.00,6.00-t)/0.25" in fc            # one coalesced span across both beats
+    assert _eval_duck_expr(fc, 0.0) == pytest.approx(0.12)
+    assert _eval_duck_expr(fc, 3.0) == pytest.approx(0.12)   # one coalesced span across both beats
+    assert _eval_duck_expr(fc, 6.0) == pytest.approx(0.12)
     assert "(-0.730)" in fc                           # held at the MIN level (0.12)
     assert "(-0.650)" not in fc                       # NOT the speech level (0.2)
 
@@ -626,8 +672,8 @@ def test_build_audio_filter_complex_bgm_envelope_bridges_short_gaps(monkeypatch)
         {"actual_place_start": 4.0, "actual_place_end": 6.0, "overlaps_speech": True},  # gap 2 < 6
     ], has_bgm=True)
     bgm_part = fc.split("[bgm]")[0]                    # the bgm chain comes first
-    assert "min(t-0.00,6.00-t)/0.25" in bgm_part      # one coalesced BGM dip across both beats
-    assert "min(t-0.00,2.00-t)" not in bgm_part
+    assert "(-0.080)" in bgm_part                      # 0.18 -> 0.10 in one coalesced BGM dip
+    assert "(-0.080)" in bgm_part and bgm_part.count("(-0.080)") == 1
 
 
 def test_build_audio_filter_complex_all_quiet_ducks_to_zone(monkeypatch):
@@ -638,7 +684,8 @@ def test_build_audio_filter_complex_all_quiet_ducks_to_zone(monkeypatch):
     fc = _build_audio_filter_complex([
         {"actual_place_start": 1.0, "actual_place_end": 4.0, "overlaps_speech": False},
     ])
-    assert "min(t-1.00,4.00-t)/0.25" in fc            # smooth fade
+    assert _eval_duck_expr(fc, 1.0) == pytest.approx(0.12)
+    assert _eval_duck_expr(fc, 4.0) == pytest.approx(0.12)
     assert "(-0.730)" in fc                           # 0.85 -> 0.12
     assert "eval=frame" in fc
 
@@ -689,15 +736,20 @@ def test_final_loudnorm_filter_and_fingerprint(monkeypatch):
     monkeypatch.setitem(CONFIG, "target_lufs", -14.0)
     monkeypatch.setitem(CONFIG, "target_true_peak", -1.0)
     monkeypatch.setitem(CONFIG, "target_lra", 11.0)
-    assert final_loudnorm_filter() == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0"
-    assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "loudnorm=I=-14.0:TP=-1.0:LRA=11.0"
+    filt = final_loudnorm_filter()
+    assert "loudnorm=I=-14.0:TP=-1.0:LRA=11.0" in filt
+    assert "linear=true" in filt
+    assert "alimiter=limit=0.98:level=false" in filt
+    assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == filt
+    assert assembly_settings_fingerprint()["audio_mix"]["loudness_mode"] in {"two_pass_linear", "equivalent"}
 
     monkeypatch.setitem(CONFIG, "target_lufs", -11.9)
-    assert final_loudnorm_filter() == "loudnorm=I=-11.9:TP=-1.0:LRA=11.0"
+    assert "loudnorm=I=-11.9:TP=-1.0:LRA=11.0" in final_loudnorm_filter()
 
     monkeypatch.setitem(CONFIG, "final_loudnorm", False)
-    assert final_loudnorm_filter() is None
-    assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "off"
+    assert final_loudnorm_filter() == "alimiter=limit=0.98:level=false"
+    assert assembly_settings_fingerprint()["audio_mix"]["final_loudnorm"] == "alimiter=limit=0.98:level=false"
+    assert assembly_settings_fingerprint()["audio_mix"]["loudness_mode"] == "limiter_only"
 
 
 def test_assembly_settings_fingerprint_tracks_render_affecting_settings(monkeypatch):
@@ -708,12 +760,18 @@ def test_assembly_settings_fingerprint_tracks_render_affecting_settings(monkeypa
     monkeypatch.setitem(CONFIG, "bgm_path", "")
     monkeypatch.setitem(CONFIG, "bgm_volume", 0.18)
     monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "output_crf", 18)
+    monkeypatch.setitem(CONFIG, "output_preset", "veryfast")
+    monkeypatch.setitem(CONFIG, "output_max_height", 0)
     base = assembly_settings_fingerprint()
 
     monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
-    assert assembly_settings_fingerprint() == base
+    legacy_implicit = assembly_settings_fingerprint()
+    assert legacy_implicit != base
+    assert legacy_implicit["video_filters"]["source_subtitle_mask_policy"] == "legacy_implicit"
+    assert legacy_implicit["video_filters"]["source_subtitle_mask_policy_declared"] is False
     monkeypatch.setitem(CONFIG, "source_subtitle_mask_ratio", 0.20)
-    assert assembly_settings_fingerprint() == base
+    assert assembly_settings_fingerprint() == legacy_implicit
     monkeypatch.setitem(CONFIG, "burn_subtitles", True)
     assert assembly_settings_fingerprint() != base
     monkeypatch.setitem(CONFIG, "burn_subtitles", False)
@@ -729,6 +787,15 @@ def test_assembly_settings_fingerprint_tracks_render_affecting_settings(monkeypa
     assert assembly_settings_fingerprint() != base
     monkeypatch.setitem(CONFIG, "bgm_volume", 0.18)
     monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.50)
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(CONFIG, "output_crf", 24)
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "output_crf", 18)
+    monkeypatch.setitem(CONFIG, "output_preset", "slow")
+    assert assembly_settings_fingerprint() != base
+    monkeypatch.setitem(CONFIG, "output_preset", "veryfast")
+    monkeypatch.setitem(CONFIG, "output_max_height", 720)
     assert assembly_settings_fingerprint() != base
 
 
@@ -942,3 +1009,508 @@ def test_foreign_source_audio_near_mutes_original_under_narration(monkeypatch):
         monkeypatch.delenv("SPEECH_DUCKING_VOLUME", raising=False)
         monkeypatch.delenv("ZONE_DUCKING_VOLUME", raising=False)
         importlib.reload(_lib)  # restore default CONFIG for any later tests
+
+
+def test_p0_adjust_tts_speed_respects_cumulative_tempo_cap(monkeypatch, tmp_path):
+    """Segment atempo must be budgeted against global narration_speed and TTS rate offset."""
+    src = tmp_path / "narr_000.wav"
+    src.write_bytes(b"wav")
+    commands = []
+
+    def fake_run_cmd(cmd, **kw):
+        commands.append(cmd)
+        Path(cmd[-1]).write_bytes(b"adjusted")
+        return CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.2)
+    monkeypatch.setitem(CONFIG, "narration_cumulative_tempo_max", 1.35)
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 11.2 if Path(path) == src else 10.0)
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    out, dur, meta = _adjust_result_parts(
+        _adjust_tts_speed(src, target_duration=10.0, work_dir=tmp_path, tts_rate_offset=0.05)
+    )
+
+    effective_tempo = float(meta["global_narration_speed"]) * (1.0 + float(meta["tts_rate_offset"])) * float(meta["segment_tempo_factor"])
+    assert effective_tempo <= 1.35 + 1e-6
+    assert meta["fit_status"] in {"fit", "tempo_adjusted", "no_safe_fit"}
+    if commands:
+        afilter = " ".join(commands[-1])
+        assert "atempo=1.120" not in afilter, "raw overrun ratio must not be used after global/rate tempo budget"
+
+
+def test_p0_adjust_tts_speed_no_safe_fit_does_not_time_cut(monkeypatch, tmp_path):
+    """When cumulative cap cannot fit a segment, assemble records blocking metadata, not time-only cuts."""
+    src = tmp_path / "narr_000.wav"
+    src.write_bytes(b"wav")
+    commands = []
+
+    def fake_run_cmd(cmd, **kw):
+        commands.append(cmd)
+        Path(cmd[-1]).write_bytes(b"unexpected")
+        return CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.2)
+    monkeypatch.setitem(CONFIG, "narration_cumulative_tempo_max", 1.35)
+    monkeypatch.setattr("assemble.get_video_duration", lambda path: 15.0 if Path(path) == src else 10.0)
+    monkeypatch.setattr("assemble.run_cmd", fake_run_cmd)
+
+    out, dur, meta = _adjust_result_parts(
+        _adjust_tts_speed(src, target_duration=10.0, work_dir=tmp_path, tts_rate_offset=0.05)
+    )
+
+    assert Path(out) == src
+    assert dur == 15.0
+    assert meta["fit_status"] == "no_safe_fit"
+    assert meta["truncate_reason"] in {"no_safe_boundary", "no_room"}
+    assert meta.get("blocking") is True
+    assert not any("-t" in cmd for cmd in commands), "P0 forbids assemble-side time-only speech cuts"
+    assert not any(str(cmd[-1]).endswith("_cut.wav") for cmd in commands)
+
+
+def test_p0_build_timed_narration_propagates_no_safe_fit_metadata(monkeypatch, tmp_path):
+    """_build_timed_narration must preserve audio/text truth and expose no-safe-fit for QC."""
+    wav = tmp_path / "long.wav"
+    import wave
+    with wave.open(str(wav), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(44100)
+        wf.writeframes(b"\x00\x10" * int(2.0 * 44100))
+
+    def fake_adjust(path, target_duration, work_dir, tts_rate_offset=0.0):
+        return str(path), 2.0, {
+            "fit_status": "no_safe_fit",
+            "truncate_reason": "no_safe_boundary",
+            "blocking": True,
+            "segment_tempo_factor": 1.0,
+            "effective_tempo": 1.2,
+        }
+
+    monkeypatch.setitem(CONFIG, "narration_delay_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tail_pad_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tighten", False)
+    monkeypatch.setattr("assemble._adjust_tts_speed", fake_adjust)
+    seg = {
+        "index": 0,
+        "start": 0.0,
+        "end": 1.0,
+        "narration": "原始长文案，不能猜测截断。",
+        "spoken_text": "已合成但仍太长的文案。",
+        "audio_path": str(wav),
+        "audio_duration": 2.0,
+        "tts_rate_offset": 0.0,
+    }
+
+    _build_timed_narration([seg], tmp_path / "narration.wav", 1.5, tmp_path)
+
+    assert seg["fit_status"] == "no_safe_fit"
+    assert seg["truncate_reason"] == "no_safe_boundary"
+    assert seg["blocking"] is True
+    assert seg["spoken_text"] == "已合成但仍太长的文案。"
+    assert seg["narration"] == "原始长文案，不能猜测截断。"
+
+
+def test_p0_subtitles_use_spoken_text_not_authored_narration(tmp_path):
+    segs = [
+        {
+            "start": 0.0,
+            "end": 3.0,
+            "actual_place_start": 0.25,
+            "actual_place_end": 2.0,
+            "narration": "作者原文第一句。作者原文第二句不应出现在字幕。",
+            "spoken_text": "实际说出的第一句。",
+        }
+    ]
+
+    entries = _subtitle_entries(segs)
+    _generate_srt(segs, tmp_path)
+    _generate_ass(segs, tmp_path)
+    srt = (tmp_path / "subtitles.srt").read_text(encoding="utf-8")
+    ass = (tmp_path / "subtitles.ass").read_text(encoding="utf-8")
+
+    assert "实际说出的第一句" in "".join(e["text"] for e in entries)
+    assert "作者原文第二句" not in srt
+    assert "作者原文第二句" not in ass
+    assert "实际说出的第一句" in srt
+    assert "实际说出的第一句" in ass
+
+
+def test_p0_final_loudness_filter_records_mode_and_peak_protection(monkeypatch):
+    monkeypatch.setitem(CONFIG, "final_loudnorm", True)
+    monkeypatch.setitem(CONFIG, "target_lufs", -14.0)
+    monkeypatch.setitem(CONFIG, "target_true_peak", -1.0)
+    monkeypatch.setitem(CONFIG, "target_lra", 11.0)
+    filt = final_loudnorm_filter()
+    assert "loudnorm=" in filt
+    assert "linear=true" in filt
+    assert "alimiter=limit=0.98:level=false" in filt
+    fp = assembly_settings_fingerprint()["audio_mix"]
+    assert fp["loudness_mode"] in {"two_pass_linear", "equivalent"}
+    assert fp["final_loudnorm"] == filt
+
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    off_filt = final_loudnorm_filter()
+    assert "loudnorm" not in off_filt
+    assert "alimiter=limit=0.98:level=false" in off_filt
+    assert assembly_settings_fingerprint()["audio_mix"]["loudness_mode"] == "limiter_only"
+
+
+def test_p0_manifest_references_audio_qc_artifact(tmp_path):
+    video = tmp_path / "input.mp4"
+    output = tmp_path / "out.mp4"
+    video.write_bytes(b"v")
+    output.write_bytes(b"o")
+    qc = tmp_path / "assembly_qc.json"
+    qc.write_text(json.dumps({
+        "schema_version": 1,
+        "verdict": "FAIL",
+        "blocking_codes": ["no_safe_fit"],
+        "loudness_mode": "two_pass_linear",
+        "loudnorm_measurement": {"input_i": "-18.0", "target_offset": "0.1"},
+    }), encoding="utf-8")
+
+    manifest = _assembly_manifest_payload(video, [], tmp_path, output)
+
+    assert manifest["qc_path"].endswith("assembly_qc.json")
+    assert manifest["qc_verdict"] == "FAIL"
+    assert manifest["qc_blocking_codes"] == ["no_safe_fit"]
+    assert manifest["qc_loudness_mode"] == "two_pass_linear"
+    assert manifest["qc_loudnorm_measurement"] == {"input_i": "-18.0", "target_offset": "0.1"}
+    assert manifest["assembly_settings"]["audio_mix"]["loudness_mode"] in {
+        "two_pass_linear", "equivalent", "limiter_only"
+    }
+
+
+def test_p0_assembly_qc_blocks_skipped_segments(tmp_path):
+    qc = assemble._build_assembly_qc(
+        [
+            {
+                "index": 0,
+                "fit_status": "fits",
+                "placed_audio_duration": 0.5,
+                "effective_tempo": 1.15,
+            },
+            {
+                "index": 1,
+                "fit_status": "skipped",
+                "truncate_reason": "missing_wav",
+                "placed_audio_duration": 0.0,
+                "effective_tempo": 1.15,
+            },
+        ],
+        3.0,
+        source_has_audio=True,
+        loudness_mode="two_pass_linear",
+    )
+
+    assert qc["verdict"] == "FAIL"
+    assert "skipped_segments" in qc["blocking_codes"]
+    assert qc["summary"]["skipped_segments"] == [1]
+
+
+def test_p0_assembly_qc_blocks_speed_adjust_failed(tmp_path):
+    qc = assemble._build_assembly_qc(
+        [
+            {
+                "index": 0,
+                "fit_status": "speed_adjust_failed",
+                "truncate_reason": "resample_failed",
+                "placed_audio_duration": 0.0,
+                "effective_tempo": 1.15,
+            }
+        ],
+        3.0,
+        source_has_audio=True,
+        loudness_mode="two_pass_linear",
+    )
+
+    assert qc["verdict"] == "FAIL"
+    assert "fit_failed" in qc["blocking_codes"]
+    assert qc["summary"]["fit_failed_segments"] == [0]
+
+
+# --- Subtitle / visual-presentation special plan contracts -------------------
+
+_VISUAL_QC_ALLOWED_TOP_LEVEL = {
+    "schema_version",
+    "artifact",
+    "verdict",
+    "blocking",
+    "blocking_codes",
+    "geometry",
+    "subtitles",
+    "overlays",
+    "mask",
+    "summary",
+}
+_VISUAL_QC_FORBIDDEN_DELIVERY_KEYS = {
+    "video_encode_passes",
+    "reencode_reason",
+    "audio_sample_rate",
+    "final_compat_notes",
+    "double_encode",
+    "delivery_compatibility",
+    "codec",
+    "audio_codec",
+}
+
+
+def _flatten_keys(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield str(key)
+            yield from _flatten_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _flatten_keys(child)
+
+
+def test_visual_qc_builder_excludes_delivery_facts_from_visual_layer(monkeypatch, tmp_path):
+    """visual_qc.json is a visual-facts artifact only; delivery/encode facts belong to
+    assembly_qc rollup, never to the visual layer."""
+    monkeypatch.setitem(CONFIG, "burn_subtitles", True)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "off")
+    (tmp_path / "visual_overlays.json").write_text(json.dumps({"schema_version": 1, "overlays": [
+        {"type": "top_title", "text": "第一章", "start": 0.0, "end": 2.0},
+    ]}), encoding="utf-8")
+
+    filters, overlay_qc = assemble._visual_overlay_filters(tmp_path, {"width": 1080, "height": 1920}, 5.0)
+    qc = assemble._build_visual_qc(
+        [{"start": 0.0, "end": 2.0, "actual_place_start": 0.0, "actual_place_end": 2.0, "narration": "多行\n字幕"}],
+        tmp_path,
+        5.0,
+        {"width": 1080, "height": 1920, "fps": 30.0, "rotation": 90, "sample_aspect_ratio": "1:1", "display_aspect_ratio": "9:16"},
+        overlay_qc=overlay_qc,
+    )
+
+    assert set(qc) <= _VISUAL_QC_ALLOWED_TOP_LEVEL
+    assert not (_VISUAL_QC_FORBIDDEN_DELIVERY_KEYS & set(_flatten_keys(qc)))
+    assert qc["geometry"]["canvas"]["width"] == 1080
+    assert qc["subtitles"]["multi_line"] is True
+    assert qc["mask"]["policy"] == "off"
+    assert qc["overlays"]["facts"][0]["type"] == "top_title"
+    assert filters and all("drawtext=" in f for f in filters)
+
+
+def test_subtitle_layout_qc_records_multiline_safe_area_and_overflow(monkeypatch):
+    monkeypatch.setitem(CONFIG, "subtitle_max_lines", 2)
+    style = {
+        "font_size": 42,
+        "outline": 2,
+        "shadow": 1,
+        "margin_l": 40,
+        "margin_r": 40,
+        "margin_v": 48,
+        "max_chars": 20,
+        "play_res_x": 640,
+        "play_res_y": 360,
+        "alignment": 2,
+    }
+    qc = assemble._subtitle_layout_qc(
+        [{"start": 0, "end": 2, "text": "第一行\n第二行\n第三行"}],
+        {"width": 640, "height": 360},
+        style,
+    )
+
+    assert qc["safe_area"]["width"] == 560
+    assert qc["multi_line"] is True
+    assert qc["overflow"] is True
+    assert qc["overflow_entries"][0]["overflow_reasons"] == ["max_lines_exceeded"]
+
+
+def test_assembly_qc_rolls_up_visual_and_delivery_facts_without_polluting_visual():
+    """assembly_qc.json is the release-gate rollup: it consumes visual_qc plus
+    delivery facts while preserving visual_qc as a pure visual artifact."""
+    visual_qc = {
+        "artifact": "visual_qc.json",
+        "verdict": "PASS",
+        "blocking": False,
+        "blocking_codes": [],
+        "geometry": {"canvas": {"width": 1080, "height": 1920}, "rotation": 90},
+        "subtitles": {"overflow": False, "entries": 1, "multi_line": True, "safe_area": {"x": 54}},
+        "overlays": {"present": True, "rendered": 1, "facts": [{"type": "inline_label_or_callout", "overflow": False}]},
+        "mask": {"policy": "safe", "scope": "bottom_band", "trigger": "explicit", "reason": "source_subtitles"},
+        "summary": {"subtitle_entries": 1, "overlay_rendered": 1},
+    }
+    delivery_qc = {
+        "video_encode_passes": 1,
+        "reencode_reason": "burn_subtitles",
+        "audio_sample_rate": 48000,
+        "final_compat_notes": ["faststart", "yuv420p"],
+    }
+
+    qc = assemble._build_assembly_qc(
+        [{"index": 0, "fit_status": "fit", "placed_audio_duration": 1.0, "effective_tempo": 1.0}],
+        2.0,
+        source_has_audio=True,
+        loudness_mode="limiter_only",
+        visual_qc=visual_qc,
+        delivery_qc=delivery_qc,
+    )
+
+    assert qc["visual_qc"]["geometry"] == visual_qc["geometry"]
+    assert qc["visual_qc"]["subtitles"]["overflow"] is False
+    assert qc["visual_qc"]["mask"] == visual_qc["mask"]
+    assert qc["delivery_qc"]["audio_sample_rate"] == 48000
+    assert qc["delivery_qc"]["reencode_reason"] == "burn_subtitles"
+    assert qc["release_gate"]["visual_qc"] == "PASS"
+    assert not (_VISUAL_QC_FORBIDDEN_DELIVERY_KEYS & set(_flatten_keys(visual_qc)))
+
+
+def test_mask_policy_must_be_explicit_and_cache_fingerprint_safe(monkeypatch):
+    """Changing source-subtitle mask policy changes rendered pixels, so the
+    effective policy must be declared and included in the assembly cache fingerprint."""
+    monkeypatch.setitem(CONFIG, "burn_subtitles", True)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", True)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "safe")
+    safe_fp = assembly_settings_fingerprint()
+    assert safe_fp["video_filters"]["source_subtitle_mask_policy"] == "safe"
+
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "forced")
+    forced_fp = assembly_settings_fingerprint()
+    assert forced_fp["video_filters"]["source_subtitle_mask_policy"] == "forced"
+    assert forced_fp != safe_fp
+
+    monkeypatch.delitem(CONFIG, "source_subtitle_mask_policy", raising=False)
+    qc = assemble._source_subtitle_mask_policy_qc(canvas={"width": 1280, "height": 720})
+    assert qc["policy"] == "legacy_implicit"
+    assert qc.get("blocking") is True
+
+
+def test_visual_overlay_loader_uses_canonical_artifact_and_rejects_platform_expansion(tmp_path):
+    """visual_overlays.json is the sole first-release overlay input, and only
+    top_title plus inline_label_or_callout are supported."""
+    (tmp_path / "overlays.json").write_text(json.dumps([{"type": "card", "text": "wrong file"}]), encoding="utf-8")
+    (tmp_path / "visual_overlays.json").write_text(json.dumps({"schema_version": 1, "overlays": [
+        {"type": "top_title", "text": "第一章", "start": 0.0, "end": 2.0},
+        {"type": "inline_label_or_callout", "text": "关键证据", "start": 1.0, "end": 3.0, "x": 0.2, "y": 0.3},
+    ]}), encoding="utf-8")
+
+    overlays = assemble._load_visual_overlays(tmp_path)
+    assert [item["type"] for item in overlays] == ["top_title", "inline_label_or_callout"]
+    filters, qc = assemble._visual_overlay_filters(tmp_path, {"width": 1280, "height": 720}, 5.0)
+    assert len(filters) == 2
+    assert qc["rendered"] == 2
+    assert qc["unsupported"] == []
+
+    (tmp_path / "visual_overlays.json").write_text(json.dumps({"schema_version": 1, "overlays": [
+        {"type": "top_title", "text": "allowed", "start": 0.0, "end": 1.0},
+        {"type": "chapter_card", "text": "not in first release", "start": 1.0, "end": 2.0},
+    ]}), encoding="utf-8")
+    filters, qc = assemble._visual_overlay_filters(tmp_path, {"width": 1280, "height": 720}, 5.0)
+    assert len(filters) == 1
+    assert qc["unsupported"] == [{"index": 1, "type": "chapter_card", "reason": "unsupported_overlay_type"}]
+
+
+def test_assemble_video_render_failure_does_not_leave_pass_assembly_qc(monkeypatch, tmp_path):
+    """A stale/pre-render PASS assembly_qc.json must be removed before render, and a
+    failed ffmpeg delivery must not leave a PASS final assembly_qc behind."""
+    from subprocess import CompletedProcess
+
+    input_video = tmp_path / "input.mp4"
+    output = tmp_path / "out.mp4"
+    input_video.write_bytes(b"video")
+    (tmp_path / "assembly_qc.json").write_text(json.dumps({"verdict": "PASS"}), encoding="utf-8")
+    segs = [{
+        "index": 0,
+        "start": 0.0,
+        "end": 1.0,
+        "actual_place_start": 0.0,
+        "actual_place_end": 1.0,
+        "placed_audio_duration": 1.0,
+        "fit_status": "fit",
+        "effective_tempo": 1.0,
+        "narration": "hello",
+    }]
+
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "off")
+    monkeypatch.setattr(assemble, "get_video_duration", lambda path: 2.0)
+    monkeypatch.setattr(assemble, "_probe_canvas", lambda path: {"width": 1280, "height": 720, "fps": 30.0})
+    monkeypatch.setattr(assemble, "_apply_narration_speed", lambda segments, work_dir: None)
+    monkeypatch.setattr(assemble, "_build_timed_narration", lambda segments, wav, duration, work_dir: Path(wav).write_bytes(b"wav"))
+    monkeypatch.setattr(assemble, "_generate_srt", lambda segments, work_dir, duration: Path(work_dir) / "subtitles.srt")
+    monkeypatch.setattr(assemble, "_emit_timeline", lambda *args, **kwargs: None)
+    monkeypatch.setattr(assemble, "_has_audio_stream", lambda path: True)
+    monkeypatch.setattr(assemble, "_run_loudnorm_first_pass", lambda *args, **kwargs: None)
+    monkeypatch.setattr(assemble, "run_cmd", lambda cmd, **kwargs: CompletedProcess(cmd, 1, "", "ffmpeg failed"))
+
+    with pytest.raises(RuntimeError, match="视频组装失败"):
+        assemble_video(input_video, segs, tmp_path, output)
+
+    qc_path = tmp_path / "assembly_qc.json"
+    assert not qc_path.exists() or json.loads(qc_path.read_text(encoding="utf-8")).get("verdict") != "PASS"
+    assert (tmp_path / "visual_qc.json").exists()
+
+
+def test_malformed_visual_overlays_blocks_visual_qc(tmp_path, monkeypatch):
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "off")
+    (tmp_path / "visual_overlays.json").write_text("{not json", encoding="utf-8")
+
+    overlays, source = assemble._load_visual_overlays(tmp_path, with_source=True)
+    filters, overlay_qc = assemble._visual_overlay_filters(tmp_path, {"width": 1280, "height": 720}, 5.0)
+    qc = assemble._build_visual_qc([], tmp_path, 5.0, {"width": 1280, "height": 720, "fps": 30.0}, overlay_qc=overlay_qc)
+
+    assert overlays == []
+    assert filters == []
+    assert source["load_error"] == "invalid_json"
+    assert overlay_qc["load_error"] == "invalid_json"
+    assert qc["verdict"] == "FAIL"
+    assert "invalid_visual_overlays_json" in qc["blocking_codes"]
+
+
+@pytest.mark.parametrize("payload", [
+    [{"type": "top_title", "text": "legacy top-level list"}],
+    {"overlays": []},
+    {"schema_version": 2, "overlays": []},
+    {"schema_version": "1", "overlays": []},
+    {"schema_version": True, "overlays": []},
+    {"overlays": {"type": "top_title", "text": "not a list"}},
+    "not a schema",
+    42,
+    {"schema_version": 1},
+])
+def test_invalid_visual_overlays_schema_blocks_visual_qc(tmp_path, monkeypatch, payload):
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "source_subtitle_mask_policy", "off")
+    (tmp_path / "visual_overlays.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    overlays, source = assemble._load_visual_overlays(tmp_path, with_source=True)
+    filters, overlay_qc = assemble._visual_overlay_filters(tmp_path, {"width": 1280, "height": 720}, 5.0)
+    qc = assemble._build_visual_qc([], tmp_path, 5.0, {"width": 1280, "height": 720, "fps": 30.0}, overlay_qc=overlay_qc)
+
+    assert overlays == []
+    assert filters == []
+    assert source["load_error"] == "invalid_schema"
+    assert overlay_qc["load_error"] == "invalid_schema"
+    assert qc["verdict"] == "FAIL"
+    assert "invalid_visual_overlays_json" in qc["blocking_codes"]
+
+
+def test_legacy_mask_env_without_explicit_policy_is_blocking(monkeypatch):
+    import importlib
+    import lib as assemble_lib
+
+    snapshot = dict(CONFIG)
+    try:
+        monkeypatch.setenv("MASK_SOURCE_SUBTITLES", "1")
+        monkeypatch.delenv("SOURCE_SUBTITLE_MASK_POLICY", raising=False)
+        importlib.reload(assemble_lib)
+
+        policy = assemble._source_subtitle_mask_policy_qc(canvas={"width": 1280, "height": 720})
+
+        assert CONFIG["mask_source_subtitles"] is True
+        assert CONFIG["source_subtitle_mask_policy"] == "off"
+        assert CONFIG["source_subtitle_mask_policy_declared"] is False
+        assert policy["policy"] == "legacy_implicit"
+        assert policy["declared"] is False
+        assert policy["blocking"] is True
+    finally:
+        CONFIG.clear()
+        CONFIG.update(snapshot)

--- a/tests/assemble/test_pure_assemble.py
+++ b/tests/assemble/test_pure_assemble.py
@@ -1111,6 +1111,56 @@ def test_p0_build_timed_narration_propagates_no_safe_fit_metadata(monkeypatch, t
     assert seg["narration"] == "原始长文案，不能猜测截断。"
 
 
+def test_p0_build_timed_narration_trims_subframe_overrun_instead_of_dropping(monkeypatch, tmp_path):
+    """Regression: a rounding-level overrun (<=50ms of post-atempo tail) must be trimmed and
+    PLACED, not dropped as no_safe_fit — which would lose the whole narration block and trip
+    final QC. Previously any 0.00-0.01s overrun discarded the block."""
+    import wave
+    wav = tmp_path / "orig.wav"
+    with wave.open(str(wav), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(44100)
+        wf.writeframes(b"\x00\x10" * int(2.1 * 44100))  # longer than the 2.0s slot -> triggers fit
+
+    def fake_adjust(path, target_duration, work_dir, tts_rate_offset=0.0, *, return_meta=True):
+        # simulate atempo landing ~10ms over the fit target (real ffmpeg rounding drift)
+        over = tmp_path / "over.wav"
+        n = int((target_duration + 0.010) * 44100)
+        with wave.open(str(over), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(44100)
+            w.writeframes(b"\x00\x10" * n)
+        return str(over), target_duration + 0.010, {
+            "fit_status": "tempo_adjusted", "truncate_reason": "none", "blocking": False,
+            "segment_tempo_factor": 1.0, "effective_tempo": 1.2, "global_narration_speed": 1.15,
+        }
+
+    monkeypatch.setitem(CONFIG, "narration_delay_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tail_pad_seconds", 0.0)
+    monkeypatch.setitem(CONFIG, "narration_tighten", False)
+    monkeypatch.setattr("assemble._adjust_tts_speed", fake_adjust)
+    seg = {
+        "index": 0,
+        "start": 0.0,
+        "end": 2.0,
+        "narration": "一段刚好超出零点几帧的解说。",
+        "spoken_text": "一段刚好超出零点几帧的解说。",
+        "audio_path": str(wav),
+        "audio_duration": 2.1,
+        "tts_rate_offset": 0.0,
+    }
+
+    _build_timed_narration([seg], tmp_path / "narration.wav", 2.0, tmp_path)
+
+    assert seg["fit_status"] != "no_safe_fit"
+    assert seg.get("blocking") is not True
+    assert seg["truncate_reason"] == "tail_trim_tolerance"
+    assert seg["placed_audio_duration"] > 1.9
+    assert seg["narration"] == "一段刚好超出零点几帧的解说。"  # authored text is preserved, only the tail is trimmed
+
+
 def test_p0_subtitles_use_spoken_text_not_authored_narration(tmp_path):
     segs = [
         {

--- a/tests/assemble/test_timeline.py
+++ b/tests/assemble/test_timeline.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-assemble' / 'scripts'))
 import json  # noqa: E402
+import pytest  # noqa: E402
 from timeline import build_timeline, ducking_keyframes, load_timeline, save_timeline, variable_ducking_keyframes  # noqa: E402
 
 def _track(timeline, kind, name=None):
@@ -291,3 +292,86 @@ def test_emit_timeline_marks_degraded_multi_source_fallback(monkeypatch, tmp_pat
     assert timeline["provenance"]["degraded"] is True
     assert timeline["provenance"]["degraded_clips"][0]["reason"].startswith("missing_source_path:")
     assert json.loads((work / "timeline.json").read_text(encoding="utf-8"))["provenance"]["degraded"] is True
+
+
+def _eval_filter_gain(filter_complex, t):
+    start = filter_complex.index("volume='") + len("volume='")
+    end = filter_complex.index("':eval=frame", start)
+    expr = filter_complex[start:end]
+    return eval(expr, {"__builtins__": {}}, {"t": float(t), "min": min, "max": max})
+
+
+def _interp_keyframe_gain(keyframes, t):
+    pts = sorted((float(k["t"]), float(k["gain"])) for k in keyframes)
+    if t <= pts[0][0]:
+        return pts[0][1]
+    for (t0, g0), (t1, g1) in zip(pts, pts[1:]):
+        if t <= t1:
+            if abs(t1 - t0) < 1e-9:
+                return g1
+            ratio = (t - t0) / (t1 - t0)
+            return g0 + (g1 - g0) * ratio
+    return pts[-1][1]
+
+
+def test_p0_ducking_ffmpeg_expression_matches_timeline_keyframes(monkeypatch):
+    """Rendered mp4 ducking and timeline/JianYing ducking share the same outside-ramp semantics."""
+    import assemble
+
+    monkeypatch.setitem(assemble.CONFIG, "ducking_mode", "fixed")
+    monkeypatch.setitem(assemble.CONFIG, "idle_orig_volume", 0.85)
+    monkeypatch.setitem(assemble.CONFIG, "speech_ducking_volume", 0.2)
+    monkeypatch.setitem(assemble.CONFIG, "zone_ducking_volume", 0.12)
+    monkeypatch.setitem(assemble.CONFIG, "duck_fade_seconds", 0.25)
+    monkeypatch.setitem(assemble.CONFIG, "duck_bridge_seconds", 6.0)
+    segments = [
+        {"actual_place_start": 2.0, "actual_place_end": 4.0, "overlaps_speech": True},
+        {"actual_place_start": 6.0, "actual_place_end": 8.0, "overlaps_speech": False},
+    ]
+
+    fc = assemble._build_audio_filter_complex(segments)
+    kfs = variable_ducking_keyframes(
+        [(2.0, 4.0, 0.2), (6.0, 8.0, 0.12)],
+        idle=0.85,
+        fade=0.25,
+        span_start=0.0,
+        span_end=10.0,
+        bridge=6.0,
+    )
+
+    # Mixed-level bridged windows flatten to the min level (0.12) and ramp outside [s,e].
+    for t in [1.75, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 8.25]:
+        assert _eval_filter_gain(fc, t) == pytest.approx(_interp_keyframe_gain(kfs, t), abs=0.015)
+
+
+def _sample_keyframes(keyframes, t):
+    prev = keyframes[0]
+    for cur in keyframes[1:]:
+        if t <= cur["t"]:
+            if cur["t"] == prev["t"]:
+                return cur["gain"]
+            ratio = (t - prev["t"]) / (cur["t"] - prev["t"])
+            return prev["gain"] + (cur["gain"] - prev["gain"]) * ratio
+        prev = cur
+    return keyframes[-1]["gain"]
+
+
+def test_ducking_ffmpeg_and_timeline_share_pre_hold_post_semantics():
+    from audio_automation import coalesce_duck_windows, ducking_gain_at
+
+    windows = [(2.0, 4.0, 0.2), (4.5, 6.0, 0.12)]
+    idle = 0.85
+    fade = 0.25
+    merged = coalesce_duck_windows(windows, bridge=1.0)  # bridged mixed levels -> min 0.12
+    keyframes = variable_ducking_keyframes(windows, idle=idle, fade=fade,
+                                           span_start=0.0, span_end=8.0, bridge=1.0)
+
+    for t, expected in [
+        (1.75, idle),   # pre-roll starts at s-fade
+        (2.0, 0.12),    # spoken start is fully ducked
+        (3.0, 0.12),    # hold through midpoint / bridged gap
+        (6.0, 0.12),    # spoken end is still fully ducked
+        (6.25, idle),   # post-roll releases by e+fade
+    ]:
+        assert ducking_gain_at(merged, idle, fade, t) == pytest.approx(expected)
+        assert _sample_keyframes(keyframes, t) == pytest.approx(expected)

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -1,4 +1,6 @@
 import json
+import os
+import shutil
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-cut' / 'scripts'))
@@ -7,6 +9,8 @@ import pytest  # noqa: F401
 from subprocess import CompletedProcess  # noqa: F401
 import cut
 from cut import build_edited_source_video, lint_mapped_narration, map_narration_to_clips, normalize_clip_plan, parse_duration_seconds, snap_clip_ends_to_lines, snap_clips_off_shot_changes, source_time_to_output_time
+
+_HAVE_FFMPEG = bool(shutil.which("ffmpeg") and shutil.which("ffprobe"))
 
 
 def test_lint_mapped_narration_flags_dropped_and_sparse():
@@ -659,15 +663,19 @@ def test_build_edited_source_video_multi_source_uses_multiple_inputs_and_cache_m
     assert cut.should_reuse_edited_source(out, plan, "ignored.mp4") is True
 
 
+@pytest.mark.skipif(
+    not _HAVE_FFMPEG and not os.environ.get("RECAP_REQUIRE_FFMPEG"),
+    reason="ffmpeg/ffprobe required for real render (set RECAP_REQUIRE_FFMPEG=1 to make a missing binary a hard failure instead of a silent skip)",
+)
 def test_build_edited_source_video_multi_resolution_mixed_audio_real_render(tmp_path):
     """Real ffmpeg: heterogeneous sources (different resolution/fps, one silent) must concat
     into ONE playable output with an audio track. This path was previously all-mocked, hiding
     the missing scale/setsar/fps normalization (concat would abort) and the all-or-nothing
-    audio drop."""
-    import shutil
+    audio drop. On a runner where ffmpeg MUST exist, set RECAP_REQUIRE_FFMPEG=1 so a missing
+    binary fails loudly instead of silently skipping this coverage."""
     import subprocess
-    if not (shutil.which("ffmpeg") and shutil.which("ffprobe")):
-        pytest.skip("ffmpeg/ffprobe required for real render")
+    if not _HAVE_FFMPEG:
+        pytest.fail("RECAP_REQUIRE_FFMPEG is set but ffmpeg/ffprobe is not installed")
     import cut
 
     a = tmp_path / "a_1080_audio.mp4"   # 1920x1080@30, WITH audio

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-cut' / 'scripts'))
@@ -75,8 +76,15 @@ def test_cut_main_normalize_only_writes_validated_plan_without_render(monkeypatc
 
     validated = _json.loads((tmp_path / "clip_plan_validated.json").read_text(encoding="utf-8"))
     assert validated["clips"]
+    delivery_qc = validated["qc"]["delivery_qc"]
+    assert delivery_qc["video_encode_passes"] == 1
+    assert delivery_qc["audio_sample_rate"]["target"] == 48000
+    assert delivery_qc["rendered"] is False
+    assert delivery_qc["planned"] is True
+    assert not (tmp_path / "cut_delivery_qc.json").exists()
     assert rendered == []                                   # no render in normalize-only
     assert not (tmp_path / "edited_source.mp4").exists()
+    assert not (tmp_path / "visual_qc.json").exists()
 
 
 def test_cut_main_blocks_on_heavy_drop_unless_allow_sparse(monkeypatch, tmp_path):
@@ -230,6 +238,9 @@ def test_build_edited_source_video_uses_ffmpeg_concat(monkeypatch, tmp_path):
     ffmpeg_cmd = [cmd for cmd in commands if cmd[0] == "ffmpeg"][0]
     assert "trim=start=0.000:end=1.000" in " ".join(ffmpeg_cmd)
     assert "concat=n=2" in " ".join(ffmpeg_cmd)
+    assert ffmpeg_cmd[ffmpeg_cmd.index("-pix_fmt") + 1] == "yuv420p"
+    assert ffmpeg_cmd[ffmpeg_cmd.index("-ar") + 1] == "48000"
+    assert ffmpeg_cmd[ffmpeg_cmd.index("-movflags") + 1] == "+faststart"
 
 
 
@@ -278,6 +289,25 @@ def test_cut_main_does_not_reuse_edited_source_when_normalized_plan_changes(monk
     assert len(calls) == 1
     assert json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["clips"][0]["source_start"] == 5.0
     assert edited.read_bytes() == b"new-edited"
+
+
+def test_edited_source_cache_fingerprint_includes_render_affecting_config(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    edited = tmp_path / "edited_source.mp4"
+    edited.write_bytes(b"edited")
+    plan = cut.normalize_clip_plan([{"start": 0.0, "end": 1.0}], video_duration=2.0)
+
+    monkeypatch.setattr("cut.CONFIG", {**cut.CONFIG, "clip_join_audio_fade_ms": 30.0})
+    cut._write_edited_source_meta(edited, plan, video)
+    meta = json.loads((tmp_path / "edited_source.mp4.meta.json").read_text(encoding="utf-8"))
+    assert meta["render_cache"]["clip_join_audio_fade_ms"] == 30.0
+    assert meta["render_cache"]["geometry_render_algorithm_version"] == cut.GEOMETRY_RENDER_ALGORITHM_VERSION
+    assert cut.should_reuse_edited_source(edited, plan, video) is True
+
+    monkeypatch.setattr("cut.CONFIG", {**cut.CONFIG, "clip_join_audio_fade_ms": 80.0})
+    assert cut.edited_source_render_fingerprint() != meta["render_fingerprint"]
+    assert cut.should_reuse_edited_source(edited, plan, video) is False
 
 
 def test_cut_main_reuses_edited_source_when_fingerprint_matches(monkeypatch, tmp_path):
@@ -740,3 +770,315 @@ def test_snap_multi_source_clips_noops_without_silence_or_flags(tmp_path):
                                       do_scene_snap=False)
     assert out["clips"][0]["source_end"] == 4.0
     assert out["total_duration"] == 3.0
+
+
+def test_snap_clip_starts_prepends_to_prior_quiet_end():
+    plan = _make_plan([(10.0, 14.0)])
+    silence = [{"start": 7.5, "end": 8.4}, {"start": 15.0, "end": 16.0}]
+
+    out = cut.snap_clip_starts_to_lines(plan, silence, video_duration=30.0, max_prepend=1.8, max_trim=0.35)
+
+    assert out["clips"][0]["source_start"] == 8.4
+    assert out["clips"][0]["duration"] == 5.6
+    assert out["qc"]["boundary_status"]["start_snaps"][0]["action"] == "prepended"
+
+
+def test_snap_clip_starts_keeps_when_already_quiet():
+    plan = _make_plan([(10.2, 14.0)])
+    silence = [{"start": 10.0, "end": 10.5}]
+
+    out = cut.snap_clip_starts_to_lines(plan, silence, video_duration=30.0, max_prepend=1.8, max_trim=0.35)
+
+    assert out["clips"][0]["source_start"] == 10.2
+    assert out["qc"]["boundary_status"]["start_snaps"][0]["reason"] == "already_quiet"
+
+
+def test_snap_clip_starts_warns_when_prepend_would_overlap():
+    plan = _make_plan([(8.0, 10.0), (10.0, 14.0)])
+    silence = [{"start": 7.5, "end": 8.4}]
+
+    out = cut.snap_clip_starts_to_lines(plan, silence, video_duration=30.0, max_prepend=1.8, max_trim=0.35)
+    second = out["clips"][1]
+
+    assert second["source_start"] == 10.0
+    event = out["qc"]["boundary_status"]["start_snaps"][1]
+    assert event["start_unsnapped_reason"] == "overlap_or_collapse"
+    assert any(w["code"] == "clip_start_unsnapped" for w in out["qc"]["warnings"])
+
+
+def test_snap_clip_starts_no_prior_quiet_keeps_and_warns_by_default():
+    plan = _make_plan([(10.0, 14.0)])
+    silence = [{"start": 12.0, "end": 12.5}]
+
+    out = cut.snap_clip_starts_to_lines(plan, silence, video_duration=30.0, max_prepend=1.8, max_trim=0.35)
+
+    assert out["clips"][0]["source_start"] == 10.0
+    assert out["qc"]["boundary_status"]["start_snaps"][0]["start_unsnapped_reason"] == "no_prior_quiet"
+
+
+def test_snap_clip_starts_allows_tiny_forward_trim_to_next_quiet():
+    plan = _make_plan([(10.0, 14.0)])
+    silence = [{"start": 10.25, "end": 10.8}]
+
+    out = cut.snap_clip_starts_to_lines(plan, silence, video_duration=30.0, max_prepend=1.8, max_trim=0.35)
+
+    assert out["clips"][0]["source_start"] == 10.25
+    assert out["qc"]["boundary_status"]["start_snaps"][0]["action"] == "trimmed"
+
+
+def test_snap_multi_source_clips_start_snaps_each_source_silence(tmp_path):
+    work = tmp_path / "work"
+    (work / "sources" / "a").mkdir(parents=True)
+    (work / "sources" / "b").mkdir(parents=True)
+    (work / "sources" / "a" / "silence_periods.json").write_text(
+        json.dumps([{"start": 1.0, "end": 1.4}]), encoding="utf-8"
+    )
+    (work / "sources" / "b" / "silence_periods.json").write_text(
+        json.dumps([{"start": 5.0, "end": 5.3}]), encoding="utf-8"
+    )
+    plan = {
+        "allow_overlap": False,
+        "clips": [
+            {"clip_id": 0, "source_id": "a", "source_path": "/a.mp4", "source_start": 2.0, "source_end": 4.0,
+             "output_start": 0.0, "output_end": 2.0, "duration": 2.0},
+            {"clip_id": 1, "source_id": "b", "source_path": "/b.mp4", "source_start": 6.0, "source_end": 8.0,
+             "output_start": 2.0, "output_end": 4.0, "duration": 2.0},
+        ],
+        "total_duration": 4.0,
+    }
+    out = cut.snap_multi_source_clips(
+        plan,
+        {"a": {"source_path": "/a.mp4", "duration": 10.0}, "b": {"source_path": "/b.mp4", "duration": 10.0}},
+        work,
+        line_max_extend=0.0,
+        scene_margin=0.0,
+        scene_threshold=0.4,
+        do_scene_snap=False,
+        start_max_prepend=1.8,
+        start_max_trim=0.35,
+    )
+
+    assert out["clips"][0]["source_start"] == 1.4
+    assert out["clips"][1]["source_start"] == 5.3
+    assert out["clips"][1]["output_start"] == 2.6
+
+
+def test_select_output_geometry_uses_all_used_sources_not_first(monkeypatch):
+    probes = {
+        "/low.mp4": (854, 480, 24.0),
+        "/hd.mp4": (1920, 1080, 30.0),
+    }
+    monkeypatch.setattr(cut, "_probe_video_geometry", lambda p: probes[str(p)])
+    clips = [
+        {"source_id": "low", "source_path": "/low.mp4", "duration": 1.0},
+        {"source_id": "hd", "source_path": "/hd.mp4", "duration": 5.0},
+    ]
+
+    w, h, fps, qc = cut._select_output_geometry(["/low.mp4", "/hd.mp4"], clips)
+
+    assert (w, h, fps) == (1920, 1080, 30.0)
+    assert qc["source_id"] == "hd"
+    assert qc["reason"] == "weighted_orientation_area_fps"
+
+
+def test_select_output_geometry_orientation_duration_and_fps_ties(monkeypatch):
+    probes = {
+        "/portrait.mp4": (1080, 1920, 24.0),
+        "/landscape.mp4": (1280, 720, 60.0),
+        "/landscape2.mp4": (1920, 1080, 30.0),
+    }
+    monkeypatch.setattr(cut, "_probe_video_geometry", lambda p: probes[str(p)])
+    clips = [
+        {"source_id": "p", "source_path": "/portrait.mp4", "duration": 2.0},
+        {"source_id": "l1", "source_path": "/landscape.mp4", "duration": 1.0},
+        {"source_id": "l2", "source_path": "/landscape2.mp4", "duration": 2.0},
+    ]
+
+    w, h, fps, qc = cut._select_output_geometry(["/portrait.mp4", "/landscape.mp4", "/landscape2.mp4"], clips)
+
+    assert (w, h) == (1920, 1080)       # landscape wins by total used duration (3s > 2s)
+    assert fps == 30.0                 # 24/30/60 all tie by duration? 30 bucket has 2s, wins
+    assert qc["orientation"] == "landscape"
+
+
+def test_probe_video_geometry_is_iterable_and_rotation_sar_aware(monkeypatch):
+    payload = {
+        "streams": [{
+            "width": 1920,
+            "height": 1080,
+            "r_frame_rate": "30000/1001",
+            "sample_aspect_ratio": "2:1",
+            "display_aspect_ratio": "16:9",
+            "tags": {"rotate": "90"},
+        }]
+    }
+    monkeypatch.setattr(cut, "run_cmd", lambda cmd: CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr=""))
+
+    geometry = cut._probe_video_geometry("/rotated.mp4")
+    width, height, fps = geometry
+
+    assert (width, height) == (1080, 3840)
+    assert fps == 29.97
+    assert geometry.facts["coded_width"] == 1920
+    assert geometry.facts["coded_height"] == 1080
+    assert geometry.facts["rotation"] == 90
+    assert geometry.facts["sample_aspect_ratio"] == "2:1"
+    assert geometry.facts["rotation_swaps_axes"] is True
+    assert geometry.facts["display_aspect_ratio"] == "16:9"
+    assert geometry.facts["display_aspect_source"] == "sample_aspect_ratio"
+
+
+def test_select_output_geometry_qc_exposes_rotation_sar_dar_facts(monkeypatch):
+    probes = {
+        "/rotated.mp4": cut.VideoGeometry(1080, 1920, 30.0, {
+            "coded_width": 1920,
+            "coded_height": 1080,
+            "display_width": 1080,
+            "display_height": 1920,
+            "rotation": 90,
+            "rotation_swaps_axes": True,
+            "sample_aspect_ratio": "1:1",
+            "sample_aspect_ratio_float": 1.0,
+            "display_aspect_ratio": "16:9",
+        }),
+        "/landscape.mp4": (1280, 720, 30.0),
+    }
+    monkeypatch.setattr(cut, "_probe_video_geometry", lambda p: probes[str(p)])
+    clips = [
+        {"source_id": "r", "source_path": "/rotated.mp4", "duration": 5.0},
+        {"source_id": "l", "source_path": "/landscape.mp4", "duration": 1.0},
+    ]
+
+    w, h, fps, qc = cut._select_output_geometry(["/rotated.mp4", "/landscape.mp4"], clips)
+
+    assert (w, h, fps) == (1080, 1920, 30.0)
+    assert qc["orientation"] == "portrait"
+    assert qc["rotation"] == 90
+    assert qc["coded_width"] == 1920
+    assert qc["sources"][0]["rotation"] == 0
+    assert qc["sources"][1]["rotation"] == 90
+    assert qc["sources"][1]["display_aspect_ratio"] == "16:9"
+
+
+def test_build_edited_source_video_writes_delivery_qc_and_meta_without_visual_qc(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake")
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    plan = normalize_clip_plan([{"start": 0, "end": 1}, {"start": 2, "end": 3}], video_duration=4)
+    commands = []
+
+    def fake_run_cmd(cmd):
+        commands.append(cmd)
+        joined = " ".join(cmd)
+        if cmd[0] == "ffprobe" and "-of json" in joined:
+            return CompletedProcess(cmd, 0, stdout=json.dumps({"streams": [{
+                "width": 1280, "height": 720, "r_frame_rate": "30/1", "sample_aspect_ratio": "1:1",
+            }]}), stderr="")
+        if cmd[0] == "ffprobe" and "stream=sample_rate" in joined:
+            return CompletedProcess(cmd, 0, stdout="48000\n", stderr="")
+        if cmd[0] == "ffprobe":
+            return CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+        Path(cmd[-1]).write_bytes(b"mp4")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("cut.run_cmd", fake_run_cmd)
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 2.0)
+
+    output = build_edited_source_video(video, plan, work_dir)
+
+    delivery = json.loads((work_dir / "cut_delivery_qc.json").read_text(encoding="utf-8"))
+    validated_delivery = plan["qc"]["delivery_qc"]
+    meta = json.loads((work_dir / "edited_source.mp4.meta.json").read_text(encoding="utf-8"))
+    assert output.exists()
+    assert delivery == validated_delivery == meta["delivery_qc"]
+    assert delivery["video_encode_passes"] == 1
+    assert delivery["audio_sample_rate"] == {"target": 48000, "probed": 48000}
+    assert "trim_concat_filter_requires_reencode" in delivery["reencode_reason"]
+    assert delivery["stream_copy_risk"]["status"] == "avoided"
+    assert delivery["output_geometry"]["width"] == 1280
+    assert not (work_dir / "visual_qc.json").exists()
+
+
+def test_audio_join_fade_is_in_filter_graph(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"fake")
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    plan = normalize_clip_plan([{"start": 0, "end": 1}, {"start": 2, "end": 3}], video_duration=4)
+    commands = []
+
+    def fake_run_cmd(cmd):
+        commands.append(cmd)
+        if cmd[0] == "ffprobe":
+            return CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+        Path(cmd[-1]).write_bytes(b"mp4")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("cut.run_cmd", fake_run_cmd)
+    monkeypatch.setattr("cut.get_video_duration", lambda path: 2.0)
+    monkeypatch.setattr("cut.CONFIG", {**cut.CONFIG, "clip_join_audio_fade_ms": 30.0})
+
+    build_edited_source_video(video, plan, work_dir)
+
+    joined = " ".join([cmd for cmd in commands if cmd[0] == "ffmpeg"][0])
+    assert "afade=t=in:st=0:d=0.030" in joined
+    assert "afade=t=out:st=0.970:d=0.030" in joined
+
+
+def test_update_cut_qc_duration_status_and_allow_drift():
+    plan = {"clips": [{"duration": 4.0}], "total_duration": 4.0, "target_duration": 10.0}
+
+    cut.update_cut_qc(plan)
+    assert plan["qc"]["target_duration_status"] == "under"
+    assert plan["qc"]["blocking"][0]["code"] == "target_duration_drift"
+
+    allowed_primary = {"clips": [{"duration": 4.0}], "total_duration": 4.0, "target_duration": 10.0}
+    cut.update_cut_qc(allowed_primary, allow_duration_drift=True)
+    assert "blocking" not in allowed_primary["qc"]
+    assert allowed_primary["qc"]["target_duration"]["duration_drift_allowed_by"] == "--allow-duration-drift"
+
+    allowed_compat = {"clips": [{"duration": 4.0}], "total_duration": 4.0, "target_duration": 10.0}
+    cut.update_cut_qc(allowed_compat, allow_duration_drift=True, duration_drift_allowed_by="--allow-sparse-cut")
+    assert "blocking" not in allowed_compat["qc"]
+    assert allowed_compat["qc"]["target_duration"]["duration_drift_allowed_by"] == "--allow-sparse-cut"
+
+
+def test_cut_probe_video_geometry_is_rotation_sar_dar_aware(monkeypatch):
+    """Cut geometry should use display geometry, not raw encoded width/height, so rotated
+    portrait sources and non-square pixels feed the same canvas truth as assemble."""
+    outputs = iter([
+        "1920,1080,30000/1001,90,1:1,9:16\n",
+        "720,576,25/1,0,16:15,4:3\n",
+    ])
+
+    def fake_run_cmd(cmd):
+        return CompletedProcess(cmd, 0, stdout=next(outputs), stderr="")
+
+    monkeypatch.setattr(cut, "run_cmd", fake_run_cmd)
+
+    assert cut._probe_video_geometry("rotated.mp4") == (1080, 1920, 29.97)
+    # 720x576 PAL with SAR 16:15 displays as 768x576 and should stay even.
+    assert cut._probe_video_geometry("pal_4x3.mp4") == (768, 576, 25.0)
+
+
+def test_cut_probe_video_geometry_dar_does_not_override_rotated_sar_axes(monkeypatch):
+    """When SAR is usable, coded dimensions × SAR are rotated; DAR is only observed."""
+    payload = {
+        "streams": [{
+            "width": 1920,
+            "height": 1080,
+            "r_frame_rate": "30/1",
+            "sample_aspect_ratio": "1:1",
+            "display_aspect_ratio": "16:9",
+            "tags": {"rotate": "90"},
+        }]
+    }
+    monkeypatch.setattr(cut, "run_cmd", lambda cmd: CompletedProcess(cmd, 0, stdout=json.dumps(payload), stderr=""))
+
+    geometry = cut._probe_video_geometry("rotated_with_dar.mp4")
+
+    assert geometry == (1080, 1920, 30.0)
+    assert geometry.facts["rotation_swaps_axes"] is True
+    assert geometry.facts["display_aspect_ratio"] == "16:9"
+    assert geometry.facts["display_aspect_source"] == "sample_aspect_ratio"

--- a/tests/orchestrator/test_audio_policy_parity.py
+++ b/tests/orchestrator/test_audio_policy_parity.py
@@ -1,0 +1,89 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LIBS = {
+    "assemble": ROOT / "skills/video-assemble/scripts/lib.py",
+    "voiceover": ROOT / "skills/video-voiceover/scripts/lib.py",
+    "script": ROOT / "skills/video-script/scripts/lib.py",
+    "recap": ROOT / "skills/video-recap/scripts/lib.py",
+    "understanding": ROOT / "skills/video-understanding/scripts/lib.py",
+}
+
+
+def _load_lib(name, path):
+    spec = importlib.util.spec_from_file_location(f"audio_policy_{name}_lib", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_audio_tempo_policy_config_and_helper_stay_in_sync():
+    libs = {name: _load_lib(name, path) for name, path in LIBS.items()}
+    keys = [
+        "narration_speed",
+        "narration_cumulative_tempo_max",
+        "narration_cumulative_tempo_hard_max",
+        "tts_segment_tempo_max",
+        "fade_ms",
+    ]
+    baseline = {key: libs["assemble"].CONFIG[key] for key in keys}
+
+    for name, lib in libs.items():
+        assert {key: lib.CONFIG[key] for key in keys} == baseline, name
+        assert hasattr(lib, "narration_tempo_budget"), name
+
+    for offset in (-0.05, 0.0, 0.05, 0.08):
+        expected = libs["assemble"].narration_tempo_budget(offset)
+        for name, lib in libs.items():
+            assert lib.narration_tempo_budget(offset) == expected, name
+
+
+def test_audio_mix_and_normalization_policy_stay_in_sync():
+    libs = {name: _load_lib(name, path) for name, path in LIBS.items()}
+    keys = [
+        "ducking_mode",
+        "ducking_threshold",
+        "ducking_ratio",
+        "ducking_attack",
+        "ducking_release",
+        "ducking_level_sc",
+        "ducking_makeup",
+        "ducking_narr_weight",
+        "ducking_orig_volume",
+        "zone_ducking_volume",
+        "zone_fade_seconds",
+        "idle_orig_volume",
+        "duck_fade_seconds",
+        "bgm_volume",
+        "bgm_ducking_volume",
+        "speech_ducking_volume",
+        "final_loudnorm",
+        "target_lufs",
+        "target_true_peak",
+        "target_lra",
+        "final_limiter_peak",
+        "tts_segment_normalize",
+        "tts_segment_target_rms_dbfs",
+        "tts_segment_peak_limit",
+    ]
+    baseline = {key: libs["assemble"].CONFIG[key] for key in keys}
+
+    for name, lib in libs.items():
+        assert {key: lib.CONFIG[key] for key in keys} == baseline, name
+
+
+def test_visual_qc_delivery_boundary_fields_are_not_audio_policy_keys():
+    """Delivery transparency fields are rollup/QC facts, not shared audio policy knobs;
+    this guards against leaking visual-delivery contract fields into CONFIG parity."""
+    libs = {name: _load_lib(name, path) for name, path in LIBS.items()}
+    delivery_fact_keys = {
+        "video_encode_passes",
+        "reencode_reason",
+        "audio_sample_rate",
+        "final_compat_notes",
+        "double_encode",
+    }
+    for name, lib in libs.items():
+        assert not (delivery_fact_keys & set(lib.CONFIG)), name

--- a/tests/orchestrator/test_final_qc_golden_eval.py
+++ b/tests/orchestrator/test_final_qc_golden_eval.py
@@ -40,6 +40,36 @@ def _upstream_blocker(stage="post_render", artifact="assembly_qc.json"):
     return qc.build_report(artifact="final_qc.json", stage=stage, findings=[finding]) | {"artifact": artifact}
 
 
+def test_tail_decode_flags_container_valid_but_undecodable_stream(tmp_path):
+    """Regression: header probing alone passes a container-valid but media-truncated/corrupt
+    render (moov intact + mdat cut). The tail-decode check must flag it as a blocker."""
+    out = tmp_path / "output.mp4"
+    out.write_bytes(b"\x00" * 4096)  # exists + non-empty so we reach the probe/decode branch
+    report = final_qc.build_final_qc(
+        tmp_path,
+        final_output="output.mp4",
+        probe_runner=lambda p: _probe(),                     # header probe passes cleanly
+        decode_runner=lambda p: (False, "Invalid NAL unit size (505 > 107)"),
+    )
+    assert report["ok"] is False
+    assert any(f["code"] == "undecodable_stream" for f in report["findings"])
+
+
+def test_tail_decode_skip_does_not_false_block(tmp_path):
+    """When ffmpeg is unavailable the decode check returns None and must NOT create a blocker."""
+    out = tmp_path / "output.mp4"
+    out.write_bytes(b"\x00" * 4096)
+    report = final_qc.build_final_qc(
+        tmp_path,
+        final_output="output.mp4",
+        probe_runner=lambda p: _probe(),
+        decode_runner=lambda p: (None, "ffmpeg unavailable"),
+    )
+    assert report["ok"] is True
+    assert report["blocker_count"] == 0
+    assert not any(f["code"] == "undecodable_stream" for f in report["findings"])
+
+
 def test_missing_and_empty_final_output_are_valid_blockers(tmp_path):
     missing = tmp_path / "missing.mp4"
     report = final_qc.build_final_qc(tmp_path, final_output=missing, probe_runner=lambda p: (_ for _ in ()).throw(AssertionError("no probe")))

--- a/tests/orchestrator/test_final_qc_golden_eval.py
+++ b/tests/orchestrator/test_final_qc_golden_eval.py
@@ -1,0 +1,275 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-recap" / "scripts"))
+
+import final_qc  # noqa: E402
+import qc_contract as qc  # noqa: E402
+import recap  # noqa: E402
+
+
+def _write_json(path, value):
+    path.write_text(json.dumps(value, ensure_ascii=False), encoding="utf-8")
+
+
+def _probe(duration=12.5, codec="h264"):
+    return {
+        "streams": [
+            {"codec_type": "video", "codec_name": codec, "width": 1920, "height": 1080, "avg_frame_rate": "30000/1001"},
+            {"codec_type": "audio", "codec_name": "aac"},
+        ],
+        "format": {"duration": str(duration), "format_name": "mov,mp4,m4a,3gp,3g2,mj2"},
+    }
+
+
+def _upstream_blocker(stage="post_render", artifact="assembly_qc.json"):
+    finding = qc.build_finding(
+        finding_id=f"{artifact}-blocker",
+        stage=stage,
+        severity="blocker",
+        confidence="objective",
+        sample_policy="deterministic",
+        category="schema_invalid",
+        code="bad_upstream",
+        message="upstream deterministic failure",
+        deterministic=True,
+        source={"artifact": artifact},
+        evidence={"detail": "bad"},
+    )
+    return qc.build_report(artifact="final_qc.json", stage=stage, findings=[finding]) | {"artifact": artifact}
+
+
+def test_missing_and_empty_final_output_are_valid_blockers(tmp_path):
+    missing = tmp_path / "missing.mp4"
+    report = final_qc.build_final_qc(tmp_path, final_output=missing, probe_runner=lambda p: (_ for _ in ()).throw(AssertionError("no probe")))
+
+    assert report["ok"] is False
+    assert report["artifact"] == "final_qc.json"
+    assert report["stage"] == "post_render"
+    assert report["findings"][0]["code"] == "missing_final_output"
+    assert qc.validate_report(report) is True
+
+    empty = tmp_path / "empty.mp4"
+    empty.write_bytes(b"")
+    report = final_qc.build_final_qc(tmp_path, final_output=empty, probe_runner=lambda p: (_ for _ in ()).throw(AssertionError("no probe")))
+
+    assert report["ok"] is False
+    assert any(f["code"] == "empty_final_output" for f in report["findings"])
+    assert qc.validate_report(report) is True
+
+
+def test_probe_fixture_success_writes_valid_final_qc_and_passing_golden_eval(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+    _write_json(tmp_path / "assembly_manifest.json", {"final_output": str(output)})
+    probe_fixture = tmp_path / "probe.json"
+    _write_json(probe_fixture, _probe(duration=9.5, codec="h264"))
+    golden_fixture = tmp_path / "golden.json"
+    _write_json(golden_fixture, {
+        "expected_final_qc_ok": True,
+        "min_duration": 9.0,
+        "max_duration": 10.0,
+        "expected_codec": "h264",
+        "required_artifacts": ["assembly_manifest.json"],
+    })
+
+    summary = final_qc.run(tmp_path, final_output=output, probe_fixture=probe_fixture, golden_fixture=golden_fixture)
+    final_report = json.loads((tmp_path / "final_qc.json").read_text(encoding="utf-8"))
+    golden_report = json.loads((tmp_path / "golden_eval.json").read_text(encoding="utf-8"))
+
+    assert summary["final_qc"] == {"ok": True, "blocker_count": 0}
+    assert summary["golden_eval"] == {"ok": True, "blocker_count": 0}
+    assert qc.validate_report(final_report) is True
+    assert qc.validate_report(golden_report) is True
+    assert final_report["metadata"]["probe"]["format"]["duration"] == "9.5"
+    assert golden_report["metadata"]["observed"]["codec"] == "h264"
+
+
+def test_probe_fixture_missing_objective_media_metadata_are_valid_blockers(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+
+    report = final_qc.build_final_qc(
+        tmp_path,
+        final_output=output,
+        probe_fixture={"streams": [{"codec_type": "audio", "codec_name": "aac"}], "format": {}},
+    )
+
+    codes = {f["code"] for f in report["findings"]}
+    assert {"missing_video_stream", "missing_duration", "missing_codec", "missing_fps"} <= codes
+    categories = {f["code"]: f["category"] for f in report["findings"]}
+    assert categories["missing_video_stream"] == "stream"
+    assert categories["missing_duration"] == "duration"
+    assert categories["missing_codec"] == "stream"
+    assert categories["missing_fps"] == "stream"
+    assert all(f["deterministic"] is True and f["blocking"] is True for f in report["findings"])
+    assert qc.validate_report(report) is True
+
+
+def test_probe_fixture_accepts_numeric_and_rational_video_fps(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+
+    rational = final_qc.build_final_qc(tmp_path, final_output=output, probe_fixture=_probe())
+    numeric = final_qc.build_final_qc(
+        tmp_path,
+        final_output=output,
+        probe_fixture={
+            "streams": [{"codec_type": "video", "codec_name": "h264", "fps": 29.97}],
+            "format": {"duration": "1.5"},
+        },
+    )
+
+    assert rational["ok"] is True
+    assert numeric["ok"] is True
+    assert qc.validate_report(rational) is True
+    assert qc.validate_report(numeric) is True
+
+
+def test_probe_failure_on_existing_nonempty_mp4_is_deterministic_blocker(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+
+    report = final_qc.build_final_qc(
+        tmp_path,
+        final_output=output,
+        probe_runner=lambda p: (_ for _ in ()).throw(RuntimeError("ffprobe boom")),
+    )
+
+    assert report["ok"] is False
+    assert any(f["code"] == "probe_failed" for f in report["findings"])
+    assert qc.validate_report(report) is True
+
+
+def test_assembly_and_visual_qc_blocking_are_rolled_into_deterministic_blockers(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+    _write_json(tmp_path / "assembly_qc.json", _upstream_blocker(artifact="assembly_qc.json"))
+    _write_json(tmp_path / "visual_qc.json", _upstream_blocker(artifact="visual_qc.json"))
+
+    report = final_qc.build_final_qc(tmp_path, final_output=output, probe_fixture=_probe())
+
+    codes = {f["code"] for f in report["findings"]}
+    assert any(code.startswith("upstream_assembly_qc_json") for code in codes)
+    assert any(code.startswith("upstream_visual_qc_json") for code in codes)
+    assert report["blocker_count"] == 2
+    assert all(f["deterministic"] is True and f["blocking"] is True for f in report["findings"])
+    assert qc.validate_report(report) is True
+
+
+def test_assembly_and_visual_qc_artifact_verdict_blocking_codes_are_blockers(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+    _write_json(tmp_path / "assembly_qc.json", {
+        "artifact": "assembly_qc.json",
+        "verdict": "pass",
+        "blocking": True,
+        "blocking_codes": ["missing_scene", "bad_audio_mux"],
+    })
+    _write_json(tmp_path / "visual_qc.json", {
+        "artifact": "visual_qc.json",
+        "verdict": "failed",
+        "blocking": False,
+        "blocking_codes": "black_frames",
+    })
+
+    report = final_qc.build_final_qc(tmp_path, final_output=output, probe_fixture=_probe())
+
+    codes = [f["code"] for f in report["findings"]]
+    assert codes == [
+        "upstream_assembly_qc_json_missing_scene",
+        "upstream_assembly_qc_json_bad_audio_mux",
+        "upstream_visual_qc_json_black_frames",
+    ]
+    assert report["blocker_count"] == 3
+    assert all(f["deterministic"] is True and f["blocking"] is True for f in report["findings"])
+    assert qc.validate_report(report) is True
+
+
+def test_golden_fixture_mismatch_blocker(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+    final_report = final_qc.build_final_qc(tmp_path, final_output=output, probe_fixture=_probe(duration=5.0, codec="h264"))
+
+    golden = final_qc.build_golden_eval(
+        tmp_path,
+        final_qc_report=final_report,
+        golden_fixture={"expected_final_qc_ok": True, "min_duration": 8.0, "expected_codec": "hevc"},
+    )
+
+    codes = {f["code"] for f in golden["findings"]}
+    assert {"min_duration_mismatch", "codec_mismatch"} <= codes
+    assert golden["ok"] is False
+    assert qc.validate_report(golden) is True
+
+
+def test_recap_post_render_helper_calls_final_qc_run(monkeypatch, tmp_path):
+    seen = {}
+
+    def fake_run(work_dir, final_output=None):
+        seen["work_dir"] = Path(work_dir)
+        seen["final_output"] = Path(final_output)
+        return {"written": ["final_qc.json", "golden_eval.json"]}
+
+    monkeypatch.setattr(recap.final_qc, "run", fake_run)
+    result = recap._write_final_qc_reports(tmp_path, tmp_path / "fake.mp4")
+
+    assert result["written"] == ["final_qc.json", "golden_eval.json"]
+    assert seen == {"work_dir": tmp_path, "final_output": tmp_path / "fake.mp4"}
+
+
+def test_no_secret_persistence_in_final_qc_or_golden_eval(tmp_path):
+    output = tmp_path / "recap.mp4"
+    output.write_bytes(b"fake mp4 bytes")
+    _write_json(tmp_path / "assembly_manifest.json", {"final_output": str(output), "api_key": "sk-manifest-secret"})
+    _write_json(tmp_path / "mimo_qc.json", {"ok": True, "token": "tp-mimo-secret"})
+
+    final_qc.run(
+        tmp_path,
+        final_output=output,
+        probe_fixture={"format": {"duration": "3.0", "secret": "sk-probe-secret"}, "streams": [{"codec_type": "video", "codec_name": "h264", "avg_frame_rate": "30/1"}]},
+        golden_fixture={"expected_final_qc_ok": True, "required_artifacts": ["assembly_manifest.json"], "password": "tp-golden-secret"},
+    )
+    text = (tmp_path / "final_qc.json").read_text(encoding="utf-8") + (tmp_path / "golden_eval.json").read_text(encoding="utf-8")
+
+    assert "sk-manifest-secret" not in text
+    assert "tp-mimo-secret" not in text
+    assert "sk-probe-secret" not in text
+    assert "tp-golden-secret" not in text
+    assert "<redacted>" in text
+    assert qc.validate_report(json.loads((tmp_path / "final_qc.json").read_text(encoding="utf-8"))) is True
+    assert qc.validate_report(json.loads((tmp_path / "golden_eval.json").read_text(encoding="utf-8"))) is True
+
+
+def test_recap_shift_left_redacts_direct_tts_and_assembly_metadata(tmp_path):
+    output = tmp_path / "recap.mp4"
+    _write_json(tmp_path / "tts_meta.json", {
+        "segments": [{"index": 0, "audio_path": "tts_segments/narr_000.wav"}],
+        "api_key": "plain-tts-password",
+        "note": "synthetic sk-tts-secret",
+    })
+    _write_json(tmp_path / "assembly_manifest.json", {
+        "final_output": str(output),
+        "callback": "https://user:pass@example.test/render?token=tp-assembly-secret#frag",
+        "credential": "plain-assembly-password",
+    })
+
+    recap._write_shift_left_stage_qc(tmp_path, "pre_tts", metadata={
+        "direct": "sk-direct-secret",
+        "secret": "plain-direct-password",
+    })
+    recap._write_shift_left_stage_qc(tmp_path, "post_tts", metadata=recap._tts_qc_metadata(tmp_path))
+    recap._write_shift_left_stage_qc(tmp_path, "post_render", metadata=recap._post_render_qc_metadata(tmp_path, output))
+    text = (tmp_path / "preflight_qc.json").read_text(encoding="utf-8")
+    report = json.loads(text)
+
+    assert "sk-direct-secret" not in text
+    assert "plain-direct-password" not in text
+    assert "plain-tts-password" not in text
+    assert "sk-tts-secret" not in text
+    assert "user:pass" not in text
+    assert "tp-assembly-secret" not in text
+    assert "plain-assembly-password" not in text
+    assert "https://example.test/render" in text
+    assert qc.validate_report(report) is True

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -20,6 +20,8 @@ def _manifest_args(**overrides):
         "consolidate": False,
         "consolidate_asr": False,
         "review_narration": None,
+        "allow_duration_drift": False,
+        "allow_sparse_cut": False,
     }
     defaults.update(overrides)
     return Namespace(**defaults)
@@ -250,6 +252,48 @@ def test_recap_cut_mode_voiceover_uses_output_time_narration(monkeypatch, tmp_pa
 
 
 
+
+def test_recap_strict_cut_output_review_forwards_strict_evidence(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 2, "end": 5, "narration": "output。"}]),
+        encoding="utf-8",
+    )
+    (work / "clip_plan.json").write_text(json.dumps([{"start": 10, "end": 12}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut"))
+    recap._write_phase_ledger(work, clip_plan_fingerprint=recap._file_md5(work / "clip_plan.json"),
+                              edited_source_rendered=True)
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "cut.py":
+            (work / "edited_source.mp4").write_bytes(b"edited")
+        if script == "review.py":
+            (work / "narration_review.json").write_text(json.dumps({"verdict": "PASS", "findings": []}), encoding="utf-8")
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr("recap._read_video_duration_or_raise", lambda path: 10.0)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut",
+        "--require-narration-review",
+    ])
+
+    recap.main()
+
+    review_args = next(c for c in calls if c[:2] == ("video-script", "review.py"))[2]
+    assert review_args[review_args.index("--timeline") + 1] == "cut_output"
+    assert "--strict-evidence" in review_args
+
 def test_recap_manifest_fingerprint_detects_middle_only_source_changes(tmp_path):
     first = tmp_path / "a.mp4"
     second = tmp_path / "b.mp4"
@@ -372,11 +416,13 @@ def test_recap_continuation_preserves_phase_b_flags(tmp_path):
     args.jianying_no_bundle_media = False
     args.allow_partial_tts = True
     args.review_narration = False
+    args.allow_duration_drift = True
 
     cmd = recap._continuation_command(video, work, args)
 
     assert "--mimo-tts-voice" in cmd and "冰糖" in cmd
     assert "--allow-partial-tts" in cmd
+    assert "--allow-duration-drift" in cmd
     assert "--burn-subtitles" in cmd
     assert "--output-dir" in cmd and "out dir" in cmd
     assert "--export-jianying" in cmd
@@ -928,6 +974,86 @@ def test_recap_multi_video_phase_a_writes_manifest_and_pauses(monkeypatch, tmp_p
     assert "--material-library-dir" in out and "--save-materials" in out
 
 
+def test_recap_single_cut_forwards_allow_duration_drift_and_records_source(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "clip_plan.json").write_text(json.dumps([{"start": 0, "end": 1}]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args(edit_mode="cut", target_duration="10m"))
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        cli = [str(a) for a in cli_args]
+        calls.append((skill, script, cli))
+        if script == "cut.py":
+            assert "--allow-duration-drift" in cli
+            assert "--allow-sparse-cut" not in cli
+            (work / "edited_source.mp4").write_bytes(b"edited")
+            (work / "clip_plan_validated.json").write_text(json.dumps({
+                "clips": [],
+                "qc": {"target_duration": {"duration_drift_allowed_by": "--allow-duration-drift"}},
+            }), encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(video), "--work-dir", str(work), "--edit-mode", "cut",
+        "--target-duration", "10m", "--allow-duration-drift",
+    ])
+
+    recap.main()
+
+    cut_args = next(c for c in calls if c[:2] == ("video-cut", "cut.py"))[2]
+    assert "--allow-duration-drift" in cut_args
+    qc = json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["qc"]
+    assert qc["target_duration"]["duration_drift_allowed_by"] == "--allow-duration-drift"
+
+
+def test_recap_multi_cut_forwards_allow_sparse_cut_compat_and_records_source(monkeypatch, tmp_path):
+    v1 = tmp_path / "a.mp4"
+    v2 = tmp_path / "b.mp4"
+    v1.write_bytes(b"a source")
+    v2.write_bytes(b"b source")
+    work = tmp_path / "project"
+    work.mkdir()
+    args = _manifest_args(edit_mode="cut", target_duration="10m")
+    records = recap._build_multi_source_records([v1.resolve(), v2.resolve()], work, args)
+    recap._write_multi_source_manifest(work, records)
+    recap._write_project_run_manifest(work, [v1.resolve(), v2.resolve()], args, records)
+    (work / "clip_plan.json").write_text(json.dumps({
+        "clips": [{"source_id": records[0]["source_id"], "start": 0, "end": 1}]
+    }), encoding="utf-8")
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        cli = [str(a) for a in cli_args]
+        calls.append((skill, script, cli))
+        if script == "cut.py":
+            assert "--allow-sparse-cut" in cli
+            assert "--allow-duration-drift" not in cli
+            (work / "edited_source.mp4").write_bytes(b"edited")
+            (work / "clip_plan_validated.json").write_text(json.dumps({
+                "clips": [{"source_id": records[0]["source_id"], "source_path": str(v1.resolve()),
+                           "source_start": 0, "source_end": 1, "output_start": 0, "output_end": 1,
+                           "duration": 1}],
+                "qc": {"target_duration": {"duration_drift_allowed_by": "--allow-sparse-cut"}},
+            }), encoding="utf-8")
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "recap.py", str(v1), str(v2), "--work-dir", str(work), "--edit-mode", "cut",
+        "--target-duration", "10m", "--allow-sparse-cut",
+    ])
+
+    recap.main()
+
+    cut_args = next(c for c in calls if c[:2] == ("video-cut", "cut.py"))[2]
+    assert "--sources-manifest" in cut_args
+    assert "--allow-sparse-cut" in cut_args
+    qc = json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["qc"]
+    assert qc["target_duration"]["duration_drift_allowed_by"] == "--allow-sparse-cut"
+
+
 def test_recap_multi_video_phase_b_invokes_cut_with_sources_manifest(monkeypatch, tmp_path):
     v1 = tmp_path / "a.mp4"
     v2 = tmp_path / "b.mp4"
@@ -1094,3 +1220,173 @@ def test_recap_single_video_cut_pass2_rebuilds_output_brief_with_materials_enabl
     assert len(understand_calls) == 1
     assert "--brief-only" in understand_calls[0][2]
     assert (work / "agent_narration_brief.md").read_text(encoding="utf-8") == "OUTPUT-TIME BRIEF"
+
+
+def test_multi_source_briefs_include_clip_and_narration_craft(tmp_path):
+    work = tmp_path / "project"
+    work.mkdir()
+    src = work / "sources" / "src_a"
+    src.mkdir(parents=True)
+    (src / "agent_narration_brief.md").write_text("# per-source context\n", encoding="utf-8")
+    records = [{
+        "source_id": "src_a",
+        "source_name": "a.mp4",
+        "source_path": str(tmp_path / "a.mp4"),
+        "source_video_fingerprint": "a" * 64,
+        "source_work_dir": "sources/src_a",
+        "material_id": "mat-a",
+    }]
+    args = _manifest_args(edit_mode="cut", target_duration="1m")
+
+    recap._write_multi_source_clip_brief(work, records, args)
+    clip_text = (work / "agent_narration_brief.md").read_text(encoding="utf-8")
+    assert "cold-open/high-impact" in clip_text
+    assert "story spine" in clip_text
+    assert "cold_open" in clip_text and "setup" in clip_text and "turn" in clip_text and "payoff" in clip_text
+    assert "source work_dir" in clip_text and "sources/<source_id>" in clip_text
+
+    plan = work / "clip_plan_validated.json"
+    plan.write_text(json.dumps({"clips": [{
+        "source_id": "src_a", "source_path": str(tmp_path / "a.mp4"),
+        "source_start": 1, "source_end": 3, "output_start": 0, "output_end": 2,
+        "reason": "cold_open: reveal",
+    }]}), encoding="utf-8")
+    recap._write_multi_source_output_brief(work, records, plan)
+    out_text = (work / "agent_narration_brief.md").read_text(encoding="utf-8")
+    assert "OUTPUT timeline" in out_text
+    assert "BLOCKS" in out_text and "story spine" in out_text
+    assert "original-audio gaps" in out_text
+    assert "source work_dir" in out_text
+
+
+def test_cut_qc_summary_surfaces_and_blocks_failures(tmp_path, capsys):
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "qc": {
+            "status": "warning",
+            "target_duration_status": "under",
+            "total_duration": 42.0,
+            "clip_count": 3,
+            "output_geometry": {"width": 1920, "height": 1080, "fps": 30, "reason": "used_sources"},
+            "warnings": ["short"],
+        }
+    }), encoding="utf-8")
+    qc = recap._surface_cut_qc(tmp_path)
+    assert qc["target_duration_status"] == "under"
+    out = capsys.readouterr().out
+    assert "cut QC" in out and "target_duration_status=under" in out and "1920x1080" in out
+
+    (tmp_path / "clip_plan_validated.json").write_text(json.dumps({
+        "qc": {"target_duration_status": "blocking", "blocking": ["duration"]}
+    }), encoding="utf-8")
+    with pytest.raises(SystemExit, match="QC blocking/fail"):
+        recap._surface_cut_qc(tmp_path)
+
+
+def test_print_narration_review_pointer_surfaces_grounding_qc(capsys, tmp_path):
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-recap' / 'scripts'))
+    import recap
+    (tmp_path / "grounding_qc.json").write_text(json.dumps({
+        "verdict": "warn",
+        "review_coverage": {"time_ranges": [{"start": 0, "end": 1}]},
+        "warnings": ["stale mapping"],
+    }, ensure_ascii=False), encoding="utf-8")
+    recap._print_narration_review_pointer(tmp_path, review_ran=False)
+    out = capsys.readouterr().out
+    assert "Grounding QC" in out and "warn" in out and "warnings 1" in out
+
+
+def test_recap_rewrites_existing_visual_overlays_empty_when_narration_has_no_supported_overlays(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    existing = work / "visual_overlays.json"
+    existing.write_text(json.dumps({
+        "schema_version": 1,
+        "overlays": [{"type": "top_title", "text": "stale", "start": 0.0, "end": 1.0}],
+    }, ensure_ascii=False), encoding="utf-8")
+    narration = work / "narration.json"
+    narration.write_text(json.dumps([{
+        "start": 0.0,
+        "end": 2.0,
+        "narration": "没有受支持的贴片。",
+        "visual_overlays": [
+            {"type": "platform_card", "text": "unsupported", "start": 0.0, "end": 1.0}
+        ],
+    }]), encoding="utf-8")
+
+    assert recap._write_canonical_visual_overlays(work, narration) == existing
+
+    assert json.loads(existing.read_text(encoding="utf-8")) == {"schema_version": 1, "overlays": []}
+
+
+def test_recap_rerun_overwrites_prior_visual_overlays_to_empty_for_current_narration(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    overlays_path = work / "visual_overlays.json"
+    first_narration = work / "narration.first.json"
+    first_narration.write_text(json.dumps([{
+        "start": 0.0,
+        "end": 2.0,
+        "narration": "开场标题。",
+        "visual_overlays": [
+            {"type": "top_title", "text": "上一版标题", "start": 0.0, "end": 2.0}
+        ],
+    }]), encoding="utf-8")
+    second_narration = work / "narration.json"
+    second_narration.write_text(json.dumps([{
+        "start": 0.0,
+        "end": 2.0,
+        "narration": "这一版没有支持的贴片。",
+    }]), encoding="utf-8")
+
+    assert recap._write_canonical_visual_overlays(work, first_narration) == overlays_path
+    assert json.loads(overlays_path.read_text(encoding="utf-8"))["overlays"]
+
+    assert recap._write_canonical_visual_overlays(work, second_narration) == overlays_path
+
+    assert json.loads(overlays_path.read_text(encoding="utf-8")) == {"schema_version": 1, "overlays": []}
+
+
+def test_recap_writes_canonical_visual_overlays_before_assemble(monkeypatch, tmp_path):
+    """Recap/packaging owns the canonical visual_overlays.json input; assemble should not
+    infer overlays from ad-hoc platform artifacts."""
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(json.dumps([{
+        "start": 0.0,
+        "end": 2.0,
+        "narration": "开场标题。",
+        "visual_overlays": [
+            {"type": "top_title", "text": "今日回顾", "start": 0.0, "end": 2.0},
+            {"type": "inline_label_or_callout", "text": "关键人物", "start": 1.0, "end": 2.0, "anchor": "center"},
+        ],
+    }]), encoding="utf-8")
+    recap._write_run_manifest(work, video.resolve(), _manifest_args())
+
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "assemble.py":
+            overlays_path = work / "visual_overlays.json"
+            assert overlays_path.exists(), "visual_overlays.json must exist before assemble runs"
+            payload = json.loads(overlays_path.read_text(encoding="utf-8"))
+            assert payload["schema_version"] == 1
+            overlays = payload["overlays"]
+            assert [item["type"] for item in overlays] == ["top_title", "inline_label_or_callout"]
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    assemble_call = next(call for call in calls if call[:2] == ("video-assemble", "assemble.py"))
+    assert "--visual-overlays" not in assemble_call[2]  # assemble reads work_dir/visual_overlays.json by contract

--- a/tests/orchestrator/test_io_fixes.py
+++ b/tests/orchestrator/test_io_fixes.py
@@ -992,7 +992,6 @@ def test_recap_single_cut_forwards_allow_duration_drift_and_records_source(monke
             (work / "edited_source.mp4").write_bytes(b"edited")
             (work / "clip_plan_validated.json").write_text(json.dumps({
                 "clips": [],
-                "qc": {"target_duration": {"duration_drift_allowed_by": "--allow-duration-drift"}},
             }), encoding="utf-8")
 
     monkeypatch.setattr("recap._run", fake_run)
@@ -1005,8 +1004,6 @@ def test_recap_single_cut_forwards_allow_duration_drift_and_records_source(monke
 
     cut_args = next(c for c in calls if c[:2] == ("video-cut", "cut.py"))[2]
     assert "--allow-duration-drift" in cut_args
-    qc = json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["qc"]
-    assert qc["target_duration"]["duration_drift_allowed_by"] == "--allow-duration-drift"
 
 
 def test_recap_multi_cut_forwards_allow_sparse_cut_compat_and_records_source(monkeypatch, tmp_path):
@@ -1036,7 +1033,6 @@ def test_recap_multi_cut_forwards_allow_sparse_cut_compat_and_records_source(mon
                 "clips": [{"source_id": records[0]["source_id"], "source_path": str(v1.resolve()),
                            "source_start": 0, "source_end": 1, "output_start": 0, "output_end": 1,
                            "duration": 1}],
-                "qc": {"target_duration": {"duration_drift_allowed_by": "--allow-sparse-cut"}},
             }), encoding="utf-8")
 
     monkeypatch.setattr("recap._run", fake_run)
@@ -1050,8 +1046,6 @@ def test_recap_multi_cut_forwards_allow_sparse_cut_compat_and_records_source(mon
     cut_args = next(c for c in calls if c[:2] == ("video-cut", "cut.py"))[2]
     assert "--sources-manifest" in cut_args
     assert "--allow-sparse-cut" in cut_args
-    qc = json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["qc"]
-    assert qc["target_duration"]["duration_drift_allowed_by"] == "--allow-sparse-cut"
 
 
 def test_recap_multi_video_phase_b_invokes_cut_with_sources_manifest(monkeypatch, tmp_path):

--- a/tests/orchestrator/test_mimo_qc_adapter.py
+++ b/tests/orchestrator/test_mimo_qc_adapter.py
@@ -106,7 +106,10 @@ def test_no_secret_persistence_in_report(tmp_path):
     assert "sk-config-secret" not in text
     assert "tp-config-secret" not in text
     assert "tp-video-secret" not in text
-    assert "api_key_configured" in text
+    # key_present must survive redaction as a real boolean (keys ARE configured here);
+    # the old "api_key_configured" name matched the secret-key regex and was blanked to "<redacted>".
+    assert '"key_present": true' in text
+    assert "api_key_configured" not in text
     assert qc.validate_report(json.loads(text)) is True
 
 

--- a/tests/orchestrator/test_mimo_qc_adapter.py
+++ b/tests/orchestrator/test_mimo_qc_adapter.py
@@ -1,0 +1,165 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-recap" / "scripts"))
+
+import mimo_qc  # noqa: E402
+import qc_contract as qc  # noqa: E402
+
+
+def _write_json(path, value):
+    path.write_text(json.dumps(value, ensure_ascii=False), encoding="utf-8")
+
+
+def test_collects_lightweight_evidence_prefers_validated_plan(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    _write_json(work / "narration.json", [{"start": 0, "end": 1, "narration": "hello"}])
+    _write_json(work / "visual_overlays.json", {"overlays": [{"text": "title"}]})
+    _write_json(work / "clip_plan.json", [{"start": 0, "end": 2, "secret_token": "tp-should-redact"}])
+    _write_json(work / "clip_plan_validated.json", {"clips": [{"source_start": 0, "source_end": 2}]})
+    _write_json(work / "assembly_manifest.json", {"final_output": "output.mp4"})
+    _write_json(work / "tts_meta.json", {"segments": [{"index": 0}]})
+    _write_json(work / "storyboard.json", {"frames": ["f1.jpg"]})
+    (work / "subtitles.srt").write_text("1\n00:00:00,000 --> 00:00:01,000\nhello\n", encoding="utf-8")
+    (work / "output.mp4").write_bytes(b"mp4")
+
+    evidence = mimo_qc.collect_evidence(work)
+
+    assert "narration.json" in evidence["artifacts"]
+    assert "visual_overlays.json" in evidence["artifacts"]
+    assert "clip_plan_validated.json" in evidence["artifacts"]
+    assert "clip_plan.json" not in evidence["artifacts"]
+    assert "assembly_manifest.json" in evidence["artifacts"]
+    assert "tts_meta.json" in evidence["artifacts"]
+    assert "subtitles.srt" in evidence["asr_subtitles"]
+    assert "storyboard.json" in evidence["visual_metadata"]
+    assert evidence["final_output"]["candidates"][0]["exists"] is True
+    assert "tp-should-redact" not in json.dumps(evidence)
+    assert len(evidence["fingerprint"]) == 64
+
+
+def test_fixture_normalizes_to_advisory_nonblocking_valid_report(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    _write_json(work / "narration.json", [{"narration": "hook"}])
+    fixture = {
+        "observations": [
+            {
+                "code": "weak_hook",
+                "message": "Opening hook may be too flat.",
+                "category": "semantic",
+                "confidence": "medium",
+                "sample_policy": "semantic",
+                "evidence": {"span": "narration[0]"},
+            },
+            {
+                "code": "busy_overlay",
+                "message": "Overlay looks crowded.",
+                "category": "aesthetic",
+                "confidence": "high",
+                "sample_policy": "aesthetic",
+            },
+        ]
+    }
+
+    result = mimo_qc.run(work, fixture=fixture, config={"mimo_video_model": "mimo-test", "api_key": "sk-secret"})
+    report = result["report"]
+
+    assert Path(result["path"]).name == "mimo_qc.json"
+    assert qc.validate_report(report) is True
+    assert report["artifact"] == "mimo_qc.json"
+    assert report["stage"] == "pre_assemble"
+    assert report["ok"] is True
+    assert report["blocker_count"] == 0
+    assert [f["severity"] for f in report["findings"]] == ["advisory", "advisory"]
+    assert [f["blocking"] for f in report["findings"]] == [False, False]
+    assert [f["deterministic"] for f in report["findings"]] == [False, False]
+    assert {f["next_action"] for f in report["findings"]} == {"human_review"}
+    assert {f["model_used"] for f in report["findings"]} == {"mimo-test"}
+    assert report["findings"][1]["category"] == "mimo_aesthetic"
+    assert report["metadata"]["pipeline_blocking"] is False
+    assert report["metadata"]["auto_repair"] is False
+
+
+def test_no_secret_persistence_in_report(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    _write_json(work / "narration.json", {"api_key": "sk-file-secret", "text": "safe"})
+    fixture = {"observations": [{"message": "uses fixture", "evidence": {"token": "tp-fixture-secret"}}]}
+
+    result = mimo_qc.run(
+        work,
+        fixture=fixture,
+        config={
+            "api_key": "sk-config-secret",
+            "mimo_api_key": "tp-config-secret",
+            "mimo_video_api_key": "tp-video-secret",
+            "mimo_video_model": "mimo-test",
+        },
+    )
+    text = Path(result["path"]).read_text(encoding="utf-8")
+
+    assert "sk-file-secret" not in text
+    assert "tp-fixture-secret" not in text
+    assert "sk-config-secret" not in text
+    assert "tp-config-secret" not in text
+    assert "tp-video-secret" not in text
+    assert "api_key_configured" in text
+    assert qc.validate_report(json.loads(text)) is True
+
+
+def test_safe_mimo_config_strips_url_credentials_query_and_fragment():
+    cfg = mimo_qc.safe_mimo_config({
+        "mimo_api_url": "https://user:pass@mimo.example.test/v1/chat?api_key=sk-url-secret#frag",
+        "mimo_video_api_url": "https://video_user:tp-url-password@video.example.test/v2/judge?token=tp-query-secret",
+        "mimo_video_model": "mimo-test",
+    })
+    text = json.dumps(cfg, ensure_ascii=False)
+
+    assert "user:pass" not in text
+    assert "video_user" not in text
+    assert "tp-url-password" not in text
+    assert "sk-url-secret" not in text
+    assert "tp-query-secret" not in text
+    assert "frag" not in text
+    assert cfg["mimo_api_url"] == "https://mimo.example.test/v1/chat"
+    assert cfg["mimo_video_api_url"] == "https://video.example.test/v2/judge"
+
+
+def test_dry_run_writes_valid_evidence_only_report_with_caller_stage(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    _write_json(work / "tts_meta.json", {"segments": []})
+
+    result = mimo_qc.run(work, stage="post_tts", dry_run=True)
+    report = json.loads((work / "mimo_qc.json").read_text(encoding="utf-8"))
+
+    assert result["report"]["finding_count"] == 0
+    assert report["stage"] == "post_tts"
+    assert report["ok"] is True
+    assert report["metadata"]["mode"] == "dry_run"
+    assert qc.validate_report(report) is True
+
+
+def test_injected_judge_payload_and_report_validation(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    _write_json(work / "narration.json", [{"narration": "line"}])
+    seen = {}
+
+    def judge(payload):
+        seen.update(payload)
+        return {"observations": [{"code": "sampled_frame_issue", "message": "sampled concern", "sample_policy": "sampled"}]}
+
+    result = mimo_qc.run(work, judge=judge, config={"mimo_video_model": "mimo-judge"})
+
+    assert seen["artifact"] == "mimo_qc.json"
+    assert "instructions" in seen
+    assert len(seen["payload_fingerprint"]) == 64
+    finding = result["report"]["findings"][0]
+    assert finding["sample_policy"]["type"] == "sampled"
+    assert finding["severity"] == "advisory"
+    assert finding["blocking"] is False
+    assert qc.validate_report(result["report"]) is True

--- a/tests/orchestrator/test_shift_left_qc_contract.py
+++ b/tests/orchestrator/test_shift_left_qc_contract.py
@@ -1,0 +1,423 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-recap" / "scripts"))
+
+import qc_contract as qc  # noqa: E402
+
+
+def _deterministic_blocker(**overrides):
+    data = {
+        "id": "f1",
+        "stage": "post_render",
+        "severity": "blocker",
+        "confidence": "objective",
+        "sample_policy": "deterministic",
+        "category": "missing_artifact",
+        "code": "missing_final_mp4",
+        "message": "final mp4 is missing",
+        "source": {"artifact": "output.mp4"},
+        "location": {"timecode": 12.3, "source_span": [10.0, 14.0]},
+        "evidence": {"path": "output.mp4"},
+    }
+    data.update(overrides)
+    return qc.build_finding(**data)
+
+
+def test_required_fields_and_value_domains():
+    finding = qc.build_finding(
+        id="adv1",
+        stage="post_tts",
+        severity="advisory",
+        confidence="medium",
+        sample_policy="semantic",
+        category="semantic",
+        code="weak_hook",
+        message="hook may be weak",
+        deterministic=False,
+        source={"artifact": "mimo_qc.json"},
+        location={"timecode": 1.0, "source_span": [0.0, 2.0]},
+        evidence={"note": "model critique"},
+    )
+    assert set(qc._REQUIRED_FINDING_FIELDS) <= set(finding)
+    report = qc.build_report(artifact="mimo_qc.json", stage="post_tts", findings=[finding])
+    assert report["schema_version"] == 1
+    assert report["artifact"] in qc.SUPPORTED_ARTIFACTS
+    assert qc.validate_report(report) is True
+
+    with pytest.raises(qc.QCContractError, match="unsupported severity"):
+        qc.build_finding(**{**finding, "severity": "fatal"})
+
+
+def test_deterministic_blocking_passes():
+    finding = _deterministic_blocker()
+    report = qc.build_report(artifact="final_qc.json", stage="post_render", findings=[finding])
+
+    assert report["ok"] is False
+    assert report["blocker_count"] == 1
+    assert qc.validate_report(report) is True
+
+
+def test_mimo_semantic_default_advisory_non_blocking():
+    finding = qc.build_finding(
+        id="m1",
+        stage="post_tts",
+        severity="advisory",
+        confidence="low",
+        sample_policy="semantic",
+        category="mimo_semantic",
+        code="pacing_flat",
+        message="semantic pacing concern",
+        deterministic=False,
+        source={"artifact": "mimo_qc.json"},
+        evidence={"summary": "subjective review"},
+    )
+    report = qc.build_report(artifact="mimo_qc.json", stage="post_tts", findings=[finding])
+
+    assert finding["blocking"] is False
+    assert report["ok"] is True
+    assert report["blocker_count"] == 0
+
+
+def test_non_deterministic_blocking_without_rule_table_allowance_rejected():
+    with pytest.raises(qc.QCContractError, match="non-deterministic blocking"):
+        qc.build_finding(
+            id="m2",
+            stage="post_tts",
+            severity="blocker",
+            confidence="medium",
+            sample_policy="semantic",
+            category="semantic",
+            code="bad_taste",
+            message="subjective issue tries to block",
+            deterministic=False,
+            blocking=True,
+            source={"artifact": "mimo_qc.json"},
+            evidence={"summary": "subjective"},
+        )
+
+
+def test_non_deterministic_blocking_with_rule_table_requires_corroboration():
+    rules = {
+        "schema_version": qc.SCHEMA_VERSION,
+        "non_deterministic_blocking_allow": [{"category": "semantic", "code": "claim_contradiction"}],
+    }
+    with pytest.raises(qc.QCContractError, match="objective_corroboration"):
+        qc.build_finding(
+            id="m3",
+            stage="post_tts",
+            severity="blocker",
+            confidence="high",
+            sample_policy="semantic",
+            category="semantic",
+            code="claim_contradiction",
+            message="claim appears contradicted",
+            deterministic=False,
+            blocking=True,
+            source={"artifact": "mimo_qc.json"},
+            evidence={"summary": "model found contradiction"},
+            rule_table=rules,
+        )
+
+    finding = qc.build_finding(
+        id="m4",
+        stage="post_tts",
+        severity="blocker",
+        confidence="high",
+        sample_policy="semantic",
+        category="semantic",
+        code="claim_contradiction",
+        message="claim is objectively contradicted by subtitle span",
+        deterministic=False,
+        blocking=True,
+        source={"artifact": "mimo_qc.json"},
+        evidence={"summary": "model found contradiction"},
+        objective_corroboration={"type": "subtitle_span", "evidence": "asr_result[3]"},
+        rule_table=rules,
+    )
+    assert finding["blocking"] is True
+    assert qc.build_report(artifact="mimo_qc.json", stage="post_tts", findings=[finding], rule_table=rules)["ok"] is False
+
+
+def test_non_deterministic_blocking_rule_table_requires_matching_schema_version():
+    base = dict(
+        id="m5",
+        stage="post_tts",
+        severity="blocker",
+        confidence="high",
+        sample_policy="semantic",
+        category="semantic",
+        code="claim_contradiction",
+        message="claim is objectively contradicted by subtitle span",
+        deterministic=False,
+        blocking=True,
+        source={"artifact": "mimo_qc.json"},
+        evidence={"summary": "model found contradiction"},
+        objective_corroboration={"type": "subtitle_span", "evidence": "asr_result[3]"},
+    )
+    for rules in (
+        {"non_deterministic_blocking_allow": [{"category": "semantic", "code": "claim_contradiction"}]},
+        {"schema_version": qc.SCHEMA_VERSION + 1, "non_deterministic_blocking_allow": [{"category": "semantic", "code": "claim_contradiction"}]},
+    ):
+        with pytest.raises(qc.QCContractError, match="non-deterministic blocking"):
+            qc.build_finding(**base, rule_table=rules)
+
+
+def test_qc_contract_redacts_metadata_keys_values_and_urls():
+    report = qc.build_report(
+        artifact="preflight_qc.json",
+        stage="pre_tts",
+        findings=[],
+        metadata={
+            "api_key": "plain-password-value",
+            "note": "token sk-synthetic-secret should be hidden",
+            "endpoint": "https://user:pass@example.test/path/to/judge?token=tp-url-secret#frag",
+        },
+    )
+    text = json.dumps(report, ensure_ascii=False)
+
+    assert "plain-password-value" not in text
+    assert "sk-synthetic-secret" not in text
+    assert "user:pass" not in text
+    assert "tp-url-secret" not in text
+    assert "https://example.test/path/to/judge" in text
+    assert report["metadata"]["api_key"] == qc.REDACTED
+
+
+def test_artifact_fingerprint_stable(tmp_path):
+    artifact = tmp_path / "final_qc.json"
+    artifact.write_text(json.dumps({"ok": True}, sort_keys=True), encoding="utf-8")
+
+    first = qc.artifact_fingerprint(artifact)
+    second = qc.artifact_fingerprint(artifact)
+
+    assert first == second
+    assert len(first) == 64
+
+
+def test_pre_cut_null_timecode_source_span_valid():
+    finding = qc.build_finding(
+        id="pc1",
+        stage="pre_cut",
+        severity="blocker",
+        confidence="objective",
+        sample_policy="deterministic",
+        category="schema_invalid",
+        code="missing_clip_plan",
+        message="clip plan missing before time mapping exists",
+        deterministic=True,
+        source={"artifact": "clip_plan.json"},
+        location={"timecode": None, "source_span": None},
+        evidence={"path": "clip_plan.json"},
+    )
+
+    assert finding["location"] == {"timecode": None, "source_span": None}
+    assert qc.validate_report(qc.build_report(artifact="golden_eval.json", stage="pre_cut", findings=[finding])) is True
+
+
+def test_unknown_schema_version_and_missing_required_fields_validation_errors():
+    report = qc.build_report(artifact="final_qc.json", stage="golden", findings=[])
+
+    with pytest.raises(qc.QCContractError, match="unsupported schema_version"):
+        qc.validate_report({**report, "schema_version": 999})
+
+    missing_artifact = dict(report)
+    missing_artifact.pop("artifact")
+    with pytest.raises(qc.QCContractError, match="missing required fields"):
+        qc.validate_report(missing_artifact)
+
+    bad_finding = _deterministic_blocker()
+    bad_finding.pop("location")
+    with pytest.raises(qc.QCContractError, match="finding missing required fields"):
+        qc.validate_report({**report, "findings": [bad_finding], "finding_count": 1, "blocker_count": 1, "ok": False})
+
+
+def test_load_rule_table_default_has_no_blocking_nondeterministic_allowances():
+    table = qc.load_rule_table()
+    assert table["schema_version"] == 1
+    assert table["non_deterministic_blocking_allow"] == []
+
+
+def test_stage_names_match_approved_gate_matrix_exactly():
+    assert qc.STAGES == frozenset({
+        "pre_cut",
+        "post_cut",
+        "pre_tts",
+        "post_tts",
+        "pre_assemble",
+        "post_render",
+        "golden",
+    })
+    for old_stage in (
+        "pre_voiceover",
+        "post_voiceover",
+        "pre_export",
+        "post_export",
+        "final",
+        "golden_eval",
+        "mimo_qc",
+    ):
+        with pytest.raises(qc.QCContractError, match="unsupported stage"):
+            qc.build_report(artifact="final_qc.json", stage=old_stage, findings=[])
+
+
+def test_sample_policy_is_object_with_valid_type():
+    finding = _deterministic_blocker(sample_policy={"type": "deterministic", "basis": "full_scan"})
+    assert finding["sample_policy"]["type"] == "deterministic"
+
+    with pytest.raises(qc.QCContractError, match="unsupported sample_policy.type"):
+        _deterministic_blocker(sample_policy={"type": "random_guess"})
+
+    bad = _deterministic_blocker()
+    bad["sample_policy"] = "deterministic"
+    with pytest.raises(qc.QCContractError, match="sample_policy must be an object"):
+        qc.validate_report(qc.build_report(artifact="final_qc.json", stage="post_render", findings=[])
+                           | {"findings": [bad], "finding_count": 1, "blocker_count": 1, "ok": False})
+
+
+def test_canonical_required_fields_include_runtime_decision_fields():
+    finding = _deterministic_blocker(
+        finding_id="canonical-1",
+        model_used="local_rules_v1",
+        artifact_fingerprints={"output.mp4": "0" * 64},
+        next_action="regenerate_output",
+    )
+    assert finding["finding_id"] == "canonical-1"
+    assert finding["id"] == "canonical-1"  # backward-compatible alias only
+    assert finding["rule_id"] == "missing_final_mp4"
+    assert finding["decision_reason"] == "final mp4 is missing"
+    assert finding["model_used"] == "local_rules_v1"
+    assert finding["artifact_fingerprints"] == {"output.mp4": "0" * 64}
+    assert finding["next_action"] == "regenerate_output"
+
+    for required in ("model_used", "artifact_fingerprints", "next_action"):
+        bad = dict(finding)
+        bad.pop(required)
+        with pytest.raises(qc.QCContractError, match="finding missing required fields"):
+            qc.validate_report(qc.build_report(artifact="final_qc.json", stage="post_render", findings=[])
+                               | {"findings": [bad], "finding_count": 1, "blocker_count": 1, "ok": False})
+
+
+def test_mimo_qc_artifact_attaches_to_actual_stage_not_stage_value():
+    finding = qc.build_finding(
+        finding_id="mimo-pre-assemble",
+        stage="pre_assemble",
+        severity="advisory",
+        confidence="medium",
+        sample_policy={"type": "semantic"},
+        category="mimo_semantic",
+        code="weak_transition",
+        message="model noted a weak transition",
+        deterministic=False,
+        source={"artifact": "mimo_qc.json"},
+        evidence={"summary": "subjective model review"},
+        model_used="mimo-qc-offline-fixture",
+        artifact_fingerprints={"mimo_qc.json": "fixture"},
+        next_action="human_review",
+    )
+
+    assert qc.validate_report(qc.build_report(artifact="mimo_qc.json", stage="pre_assemble", findings=[finding])) is True
+    with pytest.raises(qc.QCContractError, match="unsupported stage"):
+        qc.build_report(artifact="mimo_qc.json", stage="mimo_qc", findings=[finding])
+
+import recap  # noqa: E402
+
+
+def test_preflight_qc_artifact_supported_without_changing_existing_artifacts():
+    assert "preflight_qc.json" in qc.SUPPORTED_ARTIFACTS
+    assert {"final_qc.json", "golden_eval.json", "mimo_qc.json"} <= qc.SUPPORTED_ARTIFACTS
+    report = qc.build_report(artifact="preflight_qc.json", stage="pre_tts", findings=[])
+    assert report["ok"] is True
+    assert qc.validate_report(report) is True
+
+
+def test_shift_left_helper_rolls_up_latest_report_per_stage(tmp_path):
+    finding = _deterministic_blocker(finding_id="post-render-blocker")
+
+    recap._write_shift_left_stage_qc(tmp_path, "pre_tts", metadata={"review_ran": True}, findings=[])
+    recap._write_shift_left_stage_qc(tmp_path, "post_tts", metadata={"tts_meta": {"segments": []}}, findings=[])
+    report = recap._write_shift_left_stage_qc(
+        tmp_path,
+        "post_render",
+        metadata={"final_output": tmp_path / "recap.mp4"},
+        findings=[finding],
+    )
+
+    path_report = json.loads((tmp_path / "preflight_qc.json").read_text(encoding="utf-8"))
+    assert path_report == report
+    assert qc.validate_report(path_report) is True
+    assert path_report["artifact"] == "preflight_qc.json"
+    assert path_report["stage"] == "post_render"
+    assert path_report["ok"] is False
+    assert path_report["blocker_count"] == 1
+    assert [f["finding_id"] for f in path_report["findings"]] == ["post-render-blocker"]
+    stages = path_report["metadata"]["stages"]
+    assert set(stages) == {"pre_tts", "post_tts", "post_render"}
+    assert stages["pre_tts"]["metadata"] == {"review_ran": True}
+    assert stages["post_tts"]["metadata"] == {"tts_meta": {"segments": []}}
+    assert stages["post_render"]["metadata"] == {"final_output": str(tmp_path / "recap.mp4")}
+    for stage_report in stages.values():
+        assert qc.validate_report(stage_report) is True
+
+
+def test_recap_full_mode_writes_shift_left_preflight_stages(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "narration.json").write_text(
+        json.dumps([{"start": 0, "end": 1, "narration": "full。"}]),
+        encoding="utf-8",
+    )
+    recap._write_run_manifest(work, video.resolve(), recap.argparse.Namespace(
+        context="",
+        scene_threshold=None,
+        style="纪录片",
+        edit_mode="full",
+        target_duration=None,
+        skip_asr=False,
+        mimo_video_overview=False,
+        consolidate=True,
+        consolidate_asr=False,
+        review_narration=None,
+        require_narration_review=False,
+        allow_duration_drift=False,
+        allow_sparse_cut=False,
+    ))
+
+    calls = []
+
+    def fake_run(skill, script, *cli_args):
+        calls.append((skill, script, [str(arg) for arg in cli_args]))
+        if script == "voiceover.py":
+            (work / "tts_segments").mkdir(exist_ok=True)
+            (work / "tts_segments" / "narr_000.wav").write_bytes(b"wav")
+            (work / "tts_meta.json").write_text(
+                json.dumps({"segments": [{"index": 0, "audio_path": "tts_segments/narr_000.wav"}]}),
+                encoding="utf-8",
+            )
+        if script == "assemble.py":
+            (work / "output.mp4").write_bytes(b"mp4")
+            (work / "assembly_manifest.json").write_text(
+                json.dumps({"final_output": str(tmp_path / "recap_video.mp4")}),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr("recap._run", fake_run)
+    monkeypatch.setattr("recap._preflight_burn_subtitles", lambda args: None)
+    monkeypatch.setattr(sys, "argv", ["recap.py", str(video), "--work-dir", str(work)])
+
+    recap.main()
+
+    report = json.loads((work / "preflight_qc.json").read_text(encoding="utf-8"))
+    assert qc.validate_report(report) is True
+    assert report["stage"] == "post_render"
+    stages = report["metadata"]["stages"]
+    assert list(stages) == ["pre_tts", "post_tts", "pre_assemble", "post_render"]
+    assert stages["post_tts"]["metadata"]["tts_meta"]["segments"][0]["index"] == 0
+    assert stages["post_tts"]["metadata"]["tts_segments"] == ["tts_segments/narr_000.wav"]
+    assert stages["post_render"]["metadata"]["final_output"] == str(tmp_path / "recap_video.mp4")
+    assert calls[0][:2] == ("video-script", "validate.py")

--- a/tests/script/test_consolidation_brief.py
+++ b/tests/script/test_consolidation_brief.py
@@ -16,3 +16,13 @@ def test_narration_brief_noop_without_consolidation(tmp_path):
     assert "Understanding index (from consolidate.py)" not in text
     written = json.loads((tmp_path / "asr_writing_chunks.json").read_text(encoding="utf-8"))
     assert written == _chunk_asr_for_writing(asr, scenes)
+
+
+def test_narration_index_prompt_fingerprint_matches_canonical_index_prompt():
+    """Narration twin of the understanding-side guard (PR #58 review). narration.py cannot
+    import consolidate (cross-skill), so this pins the fingerprint to the canonical md5 of
+    consolidate.INDEX_PROMPT. If you change INDEX_PROMPT, update the embedded copy in BOTH
+    brief.py and narration.py and refresh this hash (the video-understanding guard computes
+    the new value dynamically)."""
+    from narration import _index_prompt_fingerprint
+    assert _index_prompt_fingerprint() == "7fc5856658effc4175d188347d1bc66d"

--- a/tests/script/test_deslop_qc.py
+++ b/tests/script/test_deslop_qc.py
@@ -1,0 +1,118 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-script" / "scripts"))
+
+from deslop_qc import analyze_deslop_qc
+from narration import build_agent_brief as build_script_agent_brief, lint_narration
+
+
+def _write_deslop_requirements(work_dir, *, owner="video-script.narration", style_card_required=True):
+    (work_dir / "deslop_qc_requirements.json").write_text(json.dumps({
+        "schema_version": 1,
+        "owner": owner,
+        "style_card_required": style_card_required,
+        "packaging_plan_expected": True,
+        "deslop_qc": {
+            "report_only": True,
+            "aigc_detector": False,
+            "auto_rewrite": False,
+        },
+    }, ensure_ascii=False), encoding="utf-8")
+
+
+def test_deslop_qc_separates_objective_blockers_from_advisories(tmp_path):
+    (tmp_path / "style_card.json").write_text('{"voice":"冷静"}', encoding="utf-8")
+    report = analyze_deslop_qc([
+        {"start": 0, "end": 4, "narration": "他不是退缩而是在等证据。"},
+        {"start": 5, "end": 9, "narration": "因为秘密背后真相牵动命运，所以这意味着一场风暴像棋局一样展开。"},
+    ], work_dir=tmp_path)
+
+    assert report["ok"] is False
+    assert report["contract"].startswith("Local readability/QC report only")
+    assert {item["code"] for item in report["blockers"]} == {"negative_positive_flip"}
+    assert {item["severity"] for item in report["advisories"]} == {"advisory"}
+    assert "cliche_density" in {item["code"] for item in report["advisories"]}
+
+
+def test_lint_narration_embeds_deslop_qc_and_writes_sibling_report(tmp_path):
+    _write_deslop_requirements(tmp_path, style_card_required=True)
+    (tmp_path / "agent_narration_brief.md").write_text("Brief text no longer controls style-card gating", encoding="utf-8")
+    (tmp_path / "original_subtitles.json").write_text(
+        json.dumps([{"start": 1, "end": 2, "text": "原声台词——带破折号"}], ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    report = lint_narration([
+        {"start": 0.0, "end": 3.0, "narration": "正常解说。"},
+    ], work_dir=tmp_path)
+
+    codes = {issue["code"] for issue in report["errors"]}
+    assert {"missing_style_card", "em_dash"}.issubset(codes)
+    assert report["deslop_qc"]["style_card_required"] is True
+    assert report["deslop_qc"]["style_card_requirement_source"] == "deslop_qc_requirements.json"
+    assert (tmp_path / "deslop_qc.json").exists()
+    assert (tmp_path / "narration_lint.json").exists()
+
+
+def test_prompt_style_card_mention_without_requirements_does_not_gate(tmp_path):
+    (tmp_path / "agent_narration_brief.md").write_text("Please author style_card.json first", encoding="utf-8")
+
+    report = lint_narration([
+        {"start": 0.0, "end": 3.0, "narration": "正常解说。"},
+    ], work_dir=tmp_path)
+
+    codes = {issue["code"] for issue in report["errors"]}
+    assert "missing_style_card" not in codes
+    assert report["deslop_qc"]["style_card_required"] is False
+    assert report["deslop_qc"]["style_card_requirement_source"] == "legacy_default"
+
+
+def test_script_narration_brief_does_not_leak_hardcoded_example_entities(tmp_path):
+    scenes = [{"scene_id": 0, "start": 0.0, "end": 6.0, "description": "门口对峙"}]
+    asr = [{"start": 1.0, "end": 5.0, "text": "第一句对白。第二句反击。"}]
+    silence = [{"start": 0.0, "end": 1.0, "duration": 1.0, "has_speech": False}]
+
+    text = build_script_agent_brief(scenes, asr, silence, 6.0, tmp_path, style="纪实复盘").read_text(encoding="utf-8")
+    requirements = json.loads((tmp_path / "deslop_qc_requirements.json").read_text(encoding="utf-8"))
+
+    assert requirements == {
+        "schema_version": 1,
+        "owner": "video-script.narration",
+        "style_card_required": True,
+        "packaging_plan_expected": True,
+        "deslop_qc": {
+            "report_only": True,
+            "aigc_detector": False,
+            "auto_rewrite": False,
+        },
+    }
+    for leaked in ["范闲", "监察院", "五竹", "京都"]:
+        assert leaked not in text
+
+
+def test_deslop_qc_is_report_only_with_blocker_advisory_split(tmp_path):
+    (tmp_path / "style_card.json").write_text('{"voice":"冷静"}', encoding="utf-8")
+
+    report = analyze_deslop_qc([
+        {"start": 0, "end": 4, "narration": "他不是退缩而是在等证据。"},
+        {
+            "start": 5,
+            "end": 9,
+            "narration": "因为命运的齿轮和背后真相牵动秘密、人性、成长、救赎、时代、选择、意义，所以因此这意味着抽象总结仿佛一场风暴像棋局如同一张网。",
+        },
+    ], work_dir=tmp_path)
+
+    assert report["ok"] is False
+    assert "not an AIGC detector" in report["contract"]
+    assert "never rewrites text" in report["contract"]
+    assert report["style_card_required"] is False
+    assert {item["code"] for item in report["blockers"]} == {"negative_positive_flip"}
+
+    advisory_codes = {item["code"] for item in report["advisories"]}
+    assert {"cliche_density", "abstract_summary", "reasoning_chain", "metaphor_markers"}.issubset(advisory_codes)
+    assert all(item["severity"] == "advisory" for item in report["advisories"])
+    assert not ({item["code"] for item in report["blockers"]} & advisory_codes)
+    assert "rewrite" not in report
+    assert "rewrites" not in report

--- a/tests/script/test_deslop_qc.py
+++ b/tests/script/test_deslop_qc.py
@@ -25,15 +25,18 @@ def _write_deslop_requirements(work_dir, *, owner="video-script.narration", styl
 def test_deslop_qc_separates_objective_blockers_from_advisories(tmp_path):
     (tmp_path / "style_card.json").write_text('{"voice":"冷静"}', encoding="utf-8")
     report = analyze_deslop_qc([
-        {"start": 0, "end": 4, "narration": "他不是退缩而是在等证据。"},
+        {"start": 0, "end": 4, "narration": "他不是退缩而是在等证据——他早有准备。"},
         {"start": 5, "end": 9, "narration": "因为秘密背后真相牵动命运，所以这意味着一场风暴像棋局一样展开。"},
     ], work_dir=tmp_path)
 
     assert report["ok"] is False
     assert report["contract"].startswith("Local readability/QC report only")
-    assert {item["code"] for item in report["blockers"]} == {"negative_positive_flip"}
+    # em-dash is an objective blocker; the idiomatic 不是…而是 is now advisory-only.
+    assert {item["code"] for item in report["blockers"]} == {"em_dash"}
     assert {item["severity"] for item in report["advisories"]} == {"advisory"}
-    assert "cliche_density" in {item["code"] for item in report["advisories"]}
+    advisory_codes = {item["code"] for item in report["advisories"]}
+    assert "negative_positive_flip" in advisory_codes
+    assert "cliche_density" in advisory_codes
 
 
 def test_lint_narration_embeds_deslop_qc_and_writes_sibling_report(tmp_path):
@@ -79,14 +82,7 @@ def test_script_narration_brief_does_not_leak_hardcoded_example_entities(tmp_pat
 
     assert requirements == {
         "schema_version": 1,
-        "owner": "video-script.narration",
-        "style_card_required": True,
-        "packaging_plan_expected": True,
-        "deslop_qc": {
-            "report_only": True,
-            "aigc_detector": False,
-            "auto_rewrite": False,
-        },
+        "style_card_required": False,
     }
     for leaked in ["范闲", "监察院", "五竹", "京都"]:
         assert leaked not in text
@@ -96,7 +92,7 @@ def test_deslop_qc_is_report_only_with_blocker_advisory_split(tmp_path):
     (tmp_path / "style_card.json").write_text('{"voice":"冷静"}', encoding="utf-8")
 
     report = analyze_deslop_qc([
-        {"start": 0, "end": 4, "narration": "他不是退缩而是在等证据。"},
+        {"start": 0, "end": 4, "narration": "他不是退缩而是在等证据——他早有准备。"},
         {
             "start": 5,
             "end": 9,
@@ -108,10 +104,10 @@ def test_deslop_qc_is_report_only_with_blocker_advisory_split(tmp_path):
     assert "not an AIGC detector" in report["contract"]
     assert "never rewrites text" in report["contract"]
     assert report["style_card_required"] is False
-    assert {item["code"] for item in report["blockers"]} == {"negative_positive_flip"}
+    assert {item["code"] for item in report["blockers"]} == {"em_dash"}
 
     advisory_codes = {item["code"] for item in report["advisories"]}
-    assert {"cliche_density", "abstract_summary", "reasoning_chain", "metaphor_markers"}.issubset(advisory_codes)
+    assert {"negative_positive_flip", "cliche_density", "abstract_summary", "reasoning_chain", "metaphor_markers"}.issubset(advisory_codes)
     assert all(item["severity"] == "advisory" for item in report["advisories"])
     assert not ({item["code"] for item in report["blockers"]} & advisory_codes)
     assert "rewrite" not in report

--- a/tests/script/test_deslop_qc.py
+++ b/tests/script/test_deslop_qc.py
@@ -22,6 +22,20 @@ def _write_deslop_requirements(work_dir, *, owner="video-script.narration", styl
     }, ensure_ascii=False), encoding="utf-8")
 
 
+def test_deslop_qc_ta_pronoun_not_placeholder_but_scaffold_copy_is():
+    """Regression: the gender-neutral pronoun 'TA' (他/她) followed by 要 (idiomatic 解说
+    suspense device) must NOT trip placeholder_leakage and hard-abort the render; only the
+    example scaffolding tokens 【主角】 / the exact phrase 'TA要赌上' should."""
+    legit = analyze_deslop_qc([{"start": 0, "end": 4, "narration": "凶手就在其中，TA要做的下一件事，就是灭口。"}])
+    assert legit["ok"] is True
+    assert legit["blocker_count"] == 0
+    legit2 = analyze_deslop_qc([{"start": 0, "end": 4, "narration": "第二天一早，TA要离开这座城市。"}])
+    assert legit2["ok"] is True
+    scaffold = analyze_deslop_qc([{"start": 0, "end": 5, "narration": "【主角】表面只是旁观者，这一次，TA要赌上全部去查清旧案真相。"}])
+    assert scaffold["ok"] is False
+    assert any(b["code"] == "placeholder_leakage" for b in scaffold["blockers"])
+
+
 def test_deslop_qc_separates_objective_blockers_from_advisories(tmp_path):
     (tmp_path / "style_card.json").write_text('{"voice":"冷静"}', encoding="utf-8")
     report = analyze_deslop_qc([

--- a/tests/script/test_pure_script.py
+++ b/tests/script/test_pure_script.py
@@ -181,7 +181,7 @@ def test_build_agent_brief_cut_pass2_is_output_timeline(monkeypatch, tmp_path):
     text = build_agent_brief(scenes, [], [], 600.0, tmp_path).read_text(encoding="utf-8")
     assert "step 2 of 2: write `narration.json` in OUTPUT time" in text
     assert "Kept clips on the OUTPUT timeline" in text
-    assert "output 0.0–10.0s ← source 10.0–20.0s" in text
+    assert "OUTPUT 0.0–10.0s ← SOURCE[0] 10.0–20.0s" in text
     assert "step 1 of 2" not in text
 
 

--- a/tests/script/test_review.py
+++ b/tests/script/test_review.py
@@ -58,7 +58,7 @@ def test_build_review_messages_includes_bounded_research_context(tmp_path):
         work_dir=tmp_path,
     )[0]["content"]
 
-    assert "背景资料（与画面/对白并列的有效依据：被其支撑的事实不算幻觉，仅与全部证据矛盾才算）" in content
+    assert "背景资料（context-only/advisory" in content
     assert "范闲卷入监察院暗线" in content
     assert "角色0：简介0" in content
     assert "角色12" not in content
@@ -172,20 +172,24 @@ def test_cut_output_review_remaps_grounding_to_output_timeline():
     assert vlm[0]["start"] == 2.0
     assert vlm[0]["end"] == 6.0
     assert vlm[0]["frame_facts"] == {"4.000": ["关键动作"]}
-    assert asr == [{"start": 3.0, "end": 5.0, "text": "这句在成片三到五秒"}]
+    assert asr[0]["start"] == 3.0 and asr[0]["end"] == 5.0 and asr[0]["text"] == "这句在成片三到五秒"
+    assert asr[0]["source_start"] == 13.0 and asr[0]["source_end"] == 15.0
 
 
 def test_review_narration_cut_output_requires_fresh_validated_clip_spans(monkeypatch, tmp_path):
     (tmp_path / "narration.json").write_text(json.dumps([{"start": 1, "end": 2, "narration": "测试。"}]), encoding="utf-8")
     monkeypatch.setattr("review.api_call", lambda payload: {"choices": [{"message": {"content": "{}"}}]})
 
+    # Advisory path fails open but writes warnings/QC; strict evidence blocks.
+    out = review.review_narration(tmp_path, timeline="cut_output")
+    assert out.get("warnings")
     with pytest.raises(SystemExit, match="clip_plan_validated"):
-        review.review_narration(tmp_path, timeline="cut_output")
+        review.review_narration(tmp_path, timeline="cut_output", strict_evidence=True)
 
     raw = [{"start": 10, "end": 20}]
     (tmp_path / "clip_plan.json").write_text(json.dumps(raw), encoding="utf-8")
-    with pytest.raises(SystemExit, match="clip_plan_validated"):
-        review.review_narration(tmp_path, timeline="cut_output")
+    out = review.review_narration(tmp_path, timeline="cut_output")
+    assert out.get("warnings")
 
     stale = {
         "raw_plan_fingerprint": "stale",
@@ -193,7 +197,7 @@ def test_review_narration_cut_output_requires_fresh_validated_clip_spans(monkeyp
     }
     (tmp_path / "clip_plan_validated.json").write_text(json.dumps(stale), encoding="utf-8")
     with pytest.raises(SystemExit, match="clip_plan_validated"):
-        review.review_narration(tmp_path, timeline="cut_output")
+        review.review_narration(tmp_path, timeline="cut_output", strict_evidence=True)
 
 
 def test_review_narration_cut_output_uses_remapped_grounding(monkeypatch, tmp_path):
@@ -218,8 +222,9 @@ def test_review_narration_cut_output_uses_remapped_grounding(monkeypatch, tmp_pa
     review.review_narration(tmp_path, timeline="cut_output")
 
     content = payloads[0]["messages"][0]["content"]
-    assert "[3-5s] 输出三到五秒对白" in content
-    assert "[场景1 2-6s] 保留片段" in content
+    assert "[OUTPUT 3.0-5.0s 对白" in content and "输出三到五秒对白" in content
+    assert "[OUTPUT 2.0-6.0s 画面" in content and "保留片段" in content
+    assert "SOURCE 13.0-15.0s" in content
 
 
 def test_parse_review_scorecard_is_advisory_and_keeps_verdict():
@@ -270,3 +275,265 @@ def test_parse_review_scorecard_marks_unscored_dimensions():
     assert r["scorecard"]["tts_pacing"] is None
     md = review.format_review_md(r)
     assert "未评分" in md and "hook_3s: 5/5" in md
+
+
+def test_coverage_policy_v1_covers_long_video_tail_and_bme():
+    scenes = [{"scene_id": i, "start": i * 10.0, "end": i * 10.0 + 8.0, "description": f"scene{i}"} for i in range(100)]
+    asr = [{"start": i * 5.0, "end": i * 5.0 + 2.0, "text": f"line{i}"} for i in range(200)]
+    narration = [{"start": 850.0, "end": 860.0, "narration": "后段关键反转。"}]
+    cov = review.coverage_policy_v1(scenes, asr, narration)
+    ranges = cov["selected_ranges"]
+    assert cov["coverage_policy_version"] == "coverage_policy_v1"
+    assert any(r["start"] <= 0 <= r["end"] for r in ranges)
+    assert any(r["start"] <= 500 <= r["end"] for r in ranges)
+    assert any(r["start"] <= 990 <= r["end"] for r in ranges)
+    assert any(r["start"] <= 855 <= r["end"] and "narration_window" in r["selection_reason"] for r in ranges)
+    assert review.coverage_policy_v1(scenes, asr, narration)["selected_ranges"] == ranges
+
+
+def test_evidence_bundle_labels_source_output_and_context_only():
+    narration = [{"start": 3, "end": 5, "narration": "测试。"}]
+    vlm = [{"scene_id": 1, "start": 2, "end": 6, "description": "保留", "source_start": 12, "source_end": 16, "output_segment_index": 0}]
+    asr = [{"start": 3, "end": 5, "text": "对白", "source_start": 13, "source_end": 15, "output_segment_index": 0}]
+    research = {"characters": {"叶轻眉": "主角之母"}, "character_details": {"叶轻眉": {"aliases": ["叶青眉"], "role": "背景人物"}}}
+    bundle = review.build_evidence_bundle(vlm, asr, narration, timeline="cut_output", research=research)
+    assert {item["clock"] for item in bundle["items"]} == {"output"}
+    assert all("source_start" in item and "source_end" in item for item in bundle["items"])
+    assert bundle["context_items"] and all(item["clock"] is None and item["support"] == "context_only" for item in bundle["context_items"])
+    rendered = review.render_evidence_bundle(bundle)
+    assert "clock=OUTPUT" in rendered and "SOURCE 12.0-16.0s" in rendered
+    assert "clock=null" in rendered
+
+
+def test_review_narration_cut_output_advisory_writes_warning_qc(monkeypatch, tmp_path):
+    (tmp_path / "narration.json").write_text(json.dumps([{"start": 1, "end": 2, "narration": "测试。"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "vlm_analysis.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "asr_result.json").write_text("[]", encoding="utf-8")
+    monkeypatch.setattr("review.api_call", lambda payload: {"choices": [{"message": {"content": '{"verdict":"PASS","summary":"ok","findings":[]}'}}]})
+    out = review.review_narration(tmp_path, timeline="cut_output")
+    assert out["warnings"]
+    qc = json.loads((tmp_path / "grounding_qc.json").read_text(encoding="utf-8"))
+    assert qc["owner"] == "video-script.review"
+    assert qc["verdict"] == "warn"
+    assert qc["coverage_policy_version"] == "coverage_policy_v1"
+    with pytest.raises(SystemExit):
+        review.review_narration(tmp_path, timeline="cut_output", strict_evidence=True)
+
+
+def test_merge_review_findings_dedup_keeps_highest_severity():
+    merged = review.merge_review_findings([
+        {"findings": [{"segment": 1, "category": "hallucination", "severity": "suggestion", "issue": "X", "fix": "a"}]},
+        {"findings": [{"segment": 1, "category": "hallucination", "severity": "error", "issue": "X", "fix": "b"}]},
+    ])
+    assert len(merged) == 1 and merged[0]["severity"] == "error" and merged[0]["fix"] == "b"
+
+
+def test_parse_review_downgrades_research_assertions_to_context_only():
+    payload = {"verdict": "PASS", "summary": "ok", "grounding_assertions": [{"segment": 0, "assertion": "最终背叛", "source": "research", "risk": "spoiler"}], "findings": []}
+    r = review.parse_review_response(json.dumps(payload, ensure_ascii=False))
+    assert r["grounding_assertions"][0]["support"] == "context_only"
+    assert r["grounding_assertions"][0]["clock"] is None
+
+
+
+def test_parse_review_downgrades_user_context_assertions_to_context_only():
+    payload = {
+        "verdict": "PASS",
+        "summary": "ok",
+        "grounding_assertions": [
+            {"segment": 0, "assertion": "用户说这是兄弟", "source": "user_context", "risk": "from prompt"}
+        ],
+        "findings": [],
+    }
+    r = review.parse_review_response(json.dumps(payload, ensure_ascii=False))
+    assertion = r["grounding_assertions"][0]
+    assert assertion["support"] == "context_only"
+    assert assertion["clock"] is None
+    assert "user_context-only" in assertion["risk"]
+
+
+def test_bundle_fingerprint_failure_is_observable_in_bundle_warning():
+    bundle = {"schema_version": 1, "clock": "source", "items": [], "context_items": []}
+    bundle["coverage"] = bundle  # circular metadata should not be swallowed invisibly
+
+    assert review._bundle_fingerprint(bundle) == ""
+    warning = bundle["metadata"]["evidence_bundle_fingerprint_warning"]
+    assert "fingerprint unavailable" in warning
+
+    chunks = review._chunk_evidence_bundle(bundle)
+    assert chunks[0]["metadata"]["evidence_bundle_fingerprint"] == ""
+    assert warning in chunks[0]["warnings"]
+
+def test_public_grounding_seams_are_api_free(tmp_path):
+    narration = [{"start": 1, "end": 3, "narration": "测试。"}]
+    vlm = [{"scene_id": 1, "start": 0, "end": 4, "description": "门口对峙", "frame_facts": {"1.0": ["男子握拳"]}}]
+    asr = [{"start": 1, "end": 2, "text": "站住"}]
+
+    ranges = review.select_coverage_ranges(vlm, asr, narration)
+    filtered = review.filter_evidence_by_ranges(vlm, asr, ranges)
+    assert [item["source"] for item in filtered["items"]] == ["visual", "asr"]
+
+    bundle = review.build_evidence_bundle(vlm, asr, narration, research={"characters": {"甲": "背景"}})
+    assert review.validate_public_evidence_contract(bundle)["valid"] is True
+    assert review.build_review_coverage_metadata(bundle)["scene_count"] == 1
+    assert "门口对峙" in review.render_evidence_for_review(bundle)
+
+    qc = review.build_grounding_qc(tmp_path, {"findings": []}, bundle)
+    assert qc["verdict"] == "pass"
+    review.write_grounding_qc(tmp_path, qc)
+    assert json.loads((tmp_path / "grounding_qc.json").read_text(encoding="utf-8"))["owner"] == "video-script.review"
+
+
+def test_validate_timeline_mapping_reports_bad_spans():
+    good = review.validate_timeline_mapping([
+        {"source_start": 10, "source_end": 20, "output_start": 0, "output_end": 10},
+        {"source_start": 30, "source_end": 35, "output_start": 10, "output_end": 15},
+    ])
+    bad = review.validate_timeline_mapping([
+        {"source_start": 1, "source_end": 1, "output_start": 0, "output_end": 1},
+    ])
+    assert good["valid"] is True and good["span_count"] == 2
+    assert bad["valid"] is False and bad["errors"]
+
+
+
+def test_review_narration_chunks_large_evidence_and_merges(monkeypatch, tmp_path):
+    narration = [{"start": 0, "end": 980, "narration": "全片复盘。"}]
+    vlm = [{"scene_id": i, "start": i * 10.0, "end": i * 10.0 + 8.0, "description": f"scene{i}"} for i in range(130)]
+    (tmp_path / "narration.json").write_text(json.dumps(narration, ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps(vlm, ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "asr_result.json").write_text("[]", encoding="utf-8")
+    payloads = []
+
+    def fake(payload):
+        payloads.append(payload)
+        idx = len(payloads) - 1
+        return {"choices": [{"message": {"content": json.dumps({
+            "verdict": "REVISE",
+            "summary": "chunk",
+            "findings": [{"segment": idx, "severity": "warning", "category": "grounding_risk", "issue": f"issue{idx}", "fix": "fix"}],
+        }, ensure_ascii=False)}}]}
+
+    monkeypatch.setattr("review.api_call", fake)
+    out = review.review_narration(tmp_path)
+    assert len(payloads) > 1
+    assert out["chunked_review"]["chunk_count"] == len(payloads)
+    assert len(out["findings"]) == len(payloads)
+    qc = json.loads((tmp_path / "grounding_qc.json").read_text(encoding="utf-8"))
+    assert qc["review_coverage"]["time_ranges"]
+
+
+def test_duplicate_source_clip_backrefs_remain_distinguishable():
+    vlm = [{"scene_id": 1, "start": 10, "end": 20, "description": "同一源片段"}]
+    asr = [{"start": 12, "end": 14, "text": "同一句对白"}]
+    spans = [
+        {"source_start": 10, "source_end": 20, "output_start": 0, "output_end": 10, "source_id": "0", "source_clip_id": "clip-a", "output_segment_index": 0},
+        {"source_start": 10, "source_end": 20, "output_start": 30, "output_end": 40, "source_id": "0", "source_clip_id": "clip-b", "output_segment_index": 1},
+    ]
+    rv, ra = review.remap_grounding_to_output_timeline(vlm, asr, spans)
+    assert len(rv) == 2 and len(ra) == 2
+    assert {x["source_clip_id"] for x in rv} == {"clip-a", "clip-b"}
+    assert {x["output_segment_index"] for x in ra} == {0, 1}
+    bundle = review.build_evidence_bundle(rv, ra, [{"start": 0, "end": 40, "narration": "测试"}], timeline="cut_output")
+    rendered = review.render_evidence_bundle(bundle)
+    assert "clip#0" in rendered and "clip#1" in rendered
+
+
+def test_research_only_assertion_stays_context_only_not_strong_fact(tmp_path):
+    parsed = review.parse_review_response(json.dumps({
+        "verdict": "PASS",
+        "summary": "ok",
+        "grounding_assertions": [{"segment": 0, "assertion": "角色已背叛", "source": "research", "risk": "spoiler"}],
+        "findings": [],
+    }, ensure_ascii=False))
+    bundle = review.build_evidence_bundle([], [], [{"start": 0, "end": 1, "narration": "他已经背叛。"}], research={"characters": {"甲": "未来剧情"}})
+    qc = review.build_grounding_qc(tmp_path, parsed, bundle)
+    assertion = parsed["grounding_assertions"][0]
+    assert assertion["support"] == "context_only" and assertion["clock"] is None
+    assert qc["research_guardrail"]["spoiler_risk_assertions"] == 1
+
+
+def test_build_review_messages_includes_style_and_deslop_artifacts_fail_open(tmp_path):
+    (tmp_path / "packaging_plan.json").write_text(
+        json.dumps({"viewer_promise": "看到反转"}, ensure_ascii=False), encoding="utf-8"
+    )
+    (tmp_path / "style_card.json").write_text(
+        json.dumps({"tone": "冷静克制", "avoid": ["空泛拔高"]}, ensure_ascii=False), encoding="utf-8"
+    )
+    (tmp_path / "deslop_qc.json").write_text(
+        json.dumps({"flags": [{"type": "template_transition", "text": "然而"}]}, ensure_ascii=False), encoding="utf-8"
+    )
+
+    content = review.build_review_messages(
+        [{"start": 0, "end": 3, "narration": "测试。"}], [], [], work_dir=tmp_path
+    )[0]["content"]
+
+    assert "packaging_plan.json" in content and "看到反转" in content
+    assert "style_card.json" in content and "冷静克制" in content and "空泛拔高" in content
+    assert "deslop_qc.json" in content and "template_transition" in content and "然而" in content
+    assert "可能为空" in content
+
+
+def test_build_review_messages_bad_style_and_deslop_json_keep_context_titles(tmp_path):
+    (tmp_path / "style_card.json").write_text("{bad json", encoding="utf-8")
+    (tmp_path / "deslop_qc.json").write_text("[bad json", encoding="utf-8")
+
+    content = review.build_review_messages(
+        [{"start": 0, "end": 1, "narration": "测试。"}], [], [], work_dir=tmp_path
+    )[0]["content"]
+
+    assert "style_card.json" in content
+    assert "deslop_qc.json" in content
+    assert content.count("(无)") >= 2
+
+
+def test_parse_review_clamps_new_craft_categories_to_warning_but_keeps_factual_errors():
+    craft_categories = [
+        "ai_flavor",
+        "weak_payoff",
+        "style_mismatch",
+        "packaging_mismatch",
+        "example_entity_leak",
+    ]
+    payload = {
+        "verdict": "FAIL",
+        "summary": "s",
+        "findings": [
+            {"segment": 0, "severity": "error", "category": category, "issue": category, "fix": "fix"}
+            for category in craft_categories
+        ] + [
+            {"segment": 1, "severity": "error", "category": "hallucination", "issue": "fact", "fix": "fix"},
+            {"segment": 2, "severity": "error", "category": "incomplete", "issue": "cut", "fix": "fix"},
+        ],
+    }
+
+    parsed = review.parse_review_response(json.dumps(payload, ensure_ascii=False))
+    severities = {item["category"]: item["severity"] for item in parsed["findings"]}
+
+    assert all(severities[category] == "warning" for category in craft_categories)
+    assert severities["hallucination"] == "error"
+    assert severities["incomplete"] == "error"
+
+
+def test_parse_review_scorecard_new_keys_and_omitted_dimensions_stay_none():
+    payload = {
+        "verdict": "PASS",
+        "summary": "ok",
+        "scorecard": {
+            "ending_payoff": 5,
+            "style_consistency": "4",
+            "ai_flavor": 2.2,
+            "packaging_consistency": 0,
+        },
+        "findings": [],
+    }
+
+    parsed = review.parse_review_response(json.dumps(payload, ensure_ascii=False))
+    scorecard = parsed["scorecard"]
+
+    assert scorecard["ending_payoff"] == 5
+    assert scorecard["style_consistency"] == 4
+    assert scorecard["ai_flavor"] == 2
+    assert scorecard["packaging_consistency"] == 1
+    assert scorecard["hook_3s"] is None
+    assert scorecard["tts_pacing"] is None

--- a/tests/understanding/test_asr_glossary.py
+++ b/tests/understanding/test_asr_glossary.py
@@ -31,6 +31,15 @@ def _write_research(work_dir, characters=None, character_details=None):
 
 # ── (a) homophone substitution of a known name is corrected ──
 
+def test_strip_reasoning_residue_removes_think_leakage():
+    """Regression: full-mode ASR must strip leaked MiMo <think> reasoning residue too (parity
+    with video-voiceover/scripts/dub.py); clean transcript text stays untouched."""
+    assert asr._strip_reasoning_residue("think>\n 真相比逃跑更狼。").strip() == "真相比逃跑更狼。"
+    assert asr._strip_reasoning_residue("<think>x\n</think>\n开门的却是个陌生男人").strip() == "开门的却是个陌生男人"
+    assert asr._strip_reasoning_residue("<think>未闭合 后续").strip() == ""
+    assert asr._strip_reasoning_residue("普通转写文本。") == "普通转写文本。"
+
+
 def test_corrects_homophone_substitution_of_known_name(tmp_path):
     _write_research(tmp_path, characters={"叶轻眉": "主角之母"})
     segments = [{"start": 0.0, "end": 3.0, "text": "她叫叶青眉"}]

--- a/tests/understanding/test_consolidate.py
+++ b/tests/understanding/test_consolidate.py
@@ -34,7 +34,8 @@ def test_parse_clean_rejects_count_mismatch_and_garbage():
 
 def test_parse_index_normalizes_to_four_list_keys():
     r = consolidate.parse_index_response('garbage no json')
-    assert r == {"characters": [], "relationships": [], "plot_points": [], "entities": []}
+    assert {k: r[k] for k in ("characters", "relationships", "plot_points", "entities")} == {"characters": [], "relationships": [], "plot_points": [], "entities": []}
+    assert r["schema_version"] == 2 and r["research_glossary"] == []
     r2 = consolidate.parse_index_response('{"characters":[{"name":"A"}],"plot_points":["p1"]}')
     assert r2["characters"][0]["name"] == "A" and r2["plot_points"] == ["p1"]
     assert r2["relationships"] == [] and r2["entities"] == []
@@ -180,3 +181,74 @@ def test_consolidate_index_recomputes_when_prompt_provenance_missing(monkeypatch
 
     assert calls["n"] == 2
     assert second["characters"][0]["name"] == "第二次"
+
+
+def test_build_index_messages_v2_includes_asr_and_research_glossary():
+    content = consolidate.build_index_messages(
+        [{"scene_id": 0, "start": 0, "end": 5, "description": "门口对峙"}],
+        asr_result=[{"start": 1, "end": 2, "text": "叶青眉留下了线索"}],
+        background_research={"character_details": {"叶轻眉": {"aliases": ["叶青眉"], "role": "主角之母"}}},
+    )[0]["content"]
+    assert "[asr:0" in content and "叶青眉留下了线索" in content
+    assert "support=context_only" in content and "叶轻眉" in content and "aliases=叶青眉" in content
+
+
+def test_parse_index_v2_keeps_old_keys_and_context_only_glossary():
+    r = consolidate.parse_index_response('{"characters":[{"name":"A"}],"research_glossary":[{"name":"叶轻眉","support":"direct"}]}')
+    assert r["schema_version"] == 2
+    assert r["characters"][0]["name"] == "A"
+    assert r["relationships"] == [] and r["plot_points"] == [] and r["entities"] == []
+    assert r["research_glossary"][0]["support"] == "context_only"
+
+
+def test_consolidate_index_cache_invalidates_on_asr_and_research(monkeypatch, tmp_path):
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps([{"scene_id": 0, "start": 0, "end": 5, "description": "d"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "asr_result.json").write_text(json.dumps([{"start": 0, "end": 1, "text": "第一版"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "background_research.json").write_text(json.dumps({"characters": {"甲": "第一版"}}, ensure_ascii=False), encoding="utf-8")
+    calls = {"n": 0}
+    def fake(payload):
+        calls["n"] += 1
+        return _fake('{"characters":[],"relationships":[],"plot_points":[],"entities":[]}')
+    monkeypatch.setattr("consolidate.api_call", fake)
+    consolidate.consolidate_index(tmp_path)
+    consolidate.consolidate_index(tmp_path)
+    assert calls["n"] == 1
+    (tmp_path / "background_research.json").write_text(json.dumps({"characters": {"甲": "第二版"}}, ensure_ascii=False), encoding="utf-8")
+    consolidate.consolidate_index(tmp_path)
+    assert calls["n"] == 2
+    (tmp_path / "asr_result.json").write_text(json.dumps([{"start": 0, "end": 1, "text": "第二版"}], ensure_ascii=False), encoding="utf-8")
+    consolidate.consolidate_index(tmp_path)
+    assert calls["n"] == 3
+    meta = json.loads((tmp_path / "understanding_index.json.meta.json").read_text(encoding="utf-8"))
+    assert meta["schema_version"] == 2 and meta["asr_md5"] and meta["research_md5"]
+
+
+
+def test_index_v2_deterministic_asr_mentions_when_llm_omits(monkeypatch, tmp_path):
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps([{"scene_id": 0, "start": 0, "end": 5, "description": "无人名画面"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "asr_result.json").write_text(json.dumps([{"start": 1, "end": 2, "text": "叶青眉留下线索"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "background_research.json").write_text(json.dumps({"character_details": {"叶轻眉": {"aliases": ["叶青眉"], "role": "关键人物"}}}, ensure_ascii=False), encoding="utf-8")
+    monkeypatch.setattr("consolidate.api_call", lambda payload: _fake('{"characters":[],"relationships":[],"plot_points":[],"entities":[],"research_glossary":[]}'))
+    idx = consolidate.consolidate_index(tmp_path)
+    char = idx["characters"][0]
+    assert char["name"] == "叶轻眉"
+    assert char["asr_mentions"][0]["evidence_id"] == "asr:0"
+    assert "asr:0" in char["evidence_ids"]
+    assert idx["research_glossary"][0]["support"] == "context_only"
+
+
+def test_index_v2_cache_invalidates_on_asr_clean(monkeypatch, tmp_path):
+    (tmp_path / "vlm_analysis.json").write_text(json.dumps([{"scene_id": 0, "start": 0, "end": 5, "description": "d"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "asr_result.json").write_text(json.dumps([{"start": 0, "end": 1, "text": "raw"}], ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "asr_clean.json").write_text(json.dumps({"segments": [{"start": 0, "end": 1, "text": "第一版"}]}, ensure_ascii=False), encoding="utf-8")
+    calls = {"n": 0}
+    def fake(payload):
+        calls["n"] += 1
+        return _fake('{"characters":[],"relationships":[],"plot_points":[],"entities":[]}')
+    monkeypatch.setattr("consolidate.api_call", fake)
+    consolidate.consolidate_index(tmp_path)
+    consolidate.consolidate_index(tmp_path)
+    assert calls["n"] == 1
+    (tmp_path / "asr_clean.json").write_text(json.dumps({"segments": [{"start": 0, "end": 1, "text": "第二版"}]}, ensure_ascii=False), encoding="utf-8")
+    consolidate.consolidate_index(tmp_path)
+    assert calls["n"] == 2

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -289,3 +289,13 @@ def test_understanding_brief_does_not_leak_hardcoded_example_entities(tmp_path):
 
     for leaked in ["范闲", "监察院", "五竹", "京都"]:
         assert leaked not in text
+
+
+def test_index_prompt_fingerprint_tracks_consolidate_source_of_truth():
+    """Regression guard for the silent index-drop bug (PR #58 review): the provenance
+    fingerprint MUST hash the exact prompt consolidate stamps into
+    understanding_index.json.meta.json. If consolidate.INDEX_PROMPT is edited without
+    updating this byte-parity copy, the guard in _load_consolidation rejects every index
+    and the narration brief silently loses all character/plot grounding."""
+    import consolidate
+    assert _index_prompt_fingerprint() == consolidate._prompt_fingerprint(consolidate.INDEX_PROMPT)

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -31,6 +31,18 @@ def test_brief_noop_without_consolidation(tmp_path):
     asr chunking uses RAW asr (byte-identical to the pre-consolidate behavior)."""
     brief_path = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path)
     text = brief_path.read_text(encoding="utf-8")
+    requirements = json.loads((tmp_path / "deslop_qc_requirements.json").read_text(encoding="utf-8"))
+    assert requirements == {
+        "schema_version": 1,
+        "owner": "video-understanding.brief",
+        "style_card_required": True,
+        "packaging_plan_expected": True,
+        "deslop_qc": {
+            "report_only": True,
+            "aigc_detector": False,
+            "auto_rewrite": False,
+        },
+    }
     assert "Understanding index (from consolidate.py)" not in text
     written = json.loads((tmp_path / "asr_writing_chunks.json").read_text(encoding="utf-8"))
     assert written == _chunk_asr_for_writing(ASR, SCENES)
@@ -243,3 +255,37 @@ def test_build_agent_brief_cut_mode_sizes_to_output(monkeypatch, tmp_path):
     assert "narration BLOCKS across the ~1min CUT OUTPUT" in text   # sized to 1min output
     assert "47 narration BLOCKS" not in text                        # NOT the source-sized (10min) count
     assert "step 1 of 2" in text           # A1: cut-first, write clip_plan only (no edited_source yet)
+
+
+def test_cut_pass1_brief_encourages_cold_open_but_preserves_story_spine(monkeypatch, tmp_path):
+    monkeypatch.setitem(CONFIG, "edit_mode", "cut")
+    monkeypatch.setitem(CONFIG, "target_duration", "1m")
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    text = build_agent_brief(SCENES, ASR, SILENCE, 60.0, tmp_path).read_text(encoding="utf-8")
+
+    assert "0–1 optional cold-open/high-impact clip" in text
+    assert "story spine, not unordered highlights" in text
+    assert "cold_open" in text and "setup" in text and "turn" in text and "payoff" in text
+    assert "not a flat highlights reel" in text
+
+
+def test_build_agent_brief_preserves_freeform_style_and_artifact_contract(tmp_path):
+    style = "悬疑冷幽默，但每句都像朋友复盘：别端着，保留东北味儿"
+
+    text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path, style=style).read_text(encoding="utf-8")
+
+    assert f"- Style (--style, freeform verbatim guidance): {style}" in text
+    assert "Do not translate `--style` into a preset, enum, switch, or fallback ladder" in text
+    assert "style_card.json" in text
+    assert "packaging_plan.json" in text
+    assert "deterministic report-only tool QC" in text
+    assert "not treat it as an AIGC detector" in text
+    assert "do not auto-rewrite" in text
+    assert "not a preset enum, fixed taxonomy" in text
+
+
+def test_understanding_brief_does_not_leak_hardcoded_example_entities(tmp_path):
+    text = build_agent_brief(SCENES, ASR, SILENCE, 6.0, tmp_path, style="纪实复盘").read_text(encoding="utf-8")
+
+    for leaked in ["范闲", "监察院", "五竹", "京都"]:
+        assert leaked not in text

--- a/tests/understanding/test_consolidation_brief.py
+++ b/tests/understanding/test_consolidation_brief.py
@@ -34,14 +34,7 @@ def test_brief_noop_without_consolidation(tmp_path):
     requirements = json.loads((tmp_path / "deslop_qc_requirements.json").read_text(encoding="utf-8"))
     assert requirements == {
         "schema_version": 1,
-        "owner": "video-understanding.brief",
-        "style_card_required": True,
-        "packaging_plan_expected": True,
-        "deslop_qc": {
-            "report_only": True,
-            "aigc_detector": False,
-            "auto_rewrite": False,
-        },
+        "style_card_required": False,
     }
     assert "Understanding index (from consolidate.py)" not in text
     written = json.loads((tmp_path / "asr_writing_chunks.json").read_text(encoding="utf-8"))

--- a/tests/understanding/test_detect_fixes.py
+++ b/tests/understanding/test_detect_fixes.py
@@ -214,3 +214,56 @@ def test_detect_silence_reextracts_audio_when_source_video_changes(monkeypatch, 
 
     assert (tmp_path / "audio.wav").read_bytes() == b"new-audio"
     assert any(any(part.endswith("audio.wav.tmp") for part in cmd) for cmd in calls)
+
+
+def test_detect_silence_records_overlap_and_ignores_coarse_grid_asr(monkeypatch, tmp_path):
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"video")
+    calls = []
+    def fake_run(cmd, **kw):
+        calls.append([str(c) for c in cmd])
+        if any(str(c).endswith("audio.wav.tmp") for c in cmd):
+            (tmp_path / "audio.wav.tmp").write_bytes(b"RIFF")
+            return _ok()
+        return _ok(stderr="silence_start: 5\nsilence_end: 8\nsilence_start: 20\nsilence_end: 24\n")
+    monkeypatch.setattr("detect.run_cmd", fake_run)
+    monkeypatch.setattr("detect.get_video_duration", lambda path: 60.0)
+    monkeypatch.setattr("detect.log", lambda msg: None)
+    asr = [{"start": 0, "end": 30, "text": "a"}, {"start": 30, "end": 60, "text": "b"}]
+    out = detect_silence_periods(video, tmp_path, asr_result=asr)
+    assert out and all(p["has_speech"] is False for p in out)
+    assert all(p["asr_granularity"] == "coarse_grid" for p in out)
+    assert all("speech_overlap_ratio" in p and "has_speech_reason" in p for p in out)
+    qc = __import__('json').loads((tmp_path / "silence_periods.qc.json").read_text(encoding="utf-8"))
+    assert qc["coarse_asr_windows"] == len(out)
+
+
+def test_detect_silence_marks_true_short_asr_overlap(monkeypatch, tmp_path):
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"video")
+    def fake_run(cmd, **kw):
+        if any(str(c).endswith("audio.wav.tmp") for c in cmd):
+            (tmp_path / "audio.wav.tmp").write_bytes(b"RIFF")
+            return _ok()
+        return _ok(stderr="silence_start: 5\nsilence_end: 9\n")
+    monkeypatch.setattr("detect.run_cmd", fake_run)
+    monkeypatch.setattr("detect.get_video_duration", lambda path: 30.0)
+    monkeypatch.setattr("detect.log", lambda msg: None)
+    out = detect_silence_periods(video, tmp_path, asr_result=[{"start": 5.2, "end": 8.8, "text": "real"}])
+    assert out[0]["has_speech"] is True
+    assert out[0]["has_speech_reason"] == "asr_overlap_high_confidence"
+    assert out[0]["speech_overlap_ratio"] >= 0.8
+
+
+def test_annotate_quiet_windows_with_asr_is_pure_helper():
+    periods = [{"start": 5.0, "end": 9.0, "duration": 4.0, "has_speech": False}]
+    annotated, qc = detect.annotate_quiet_windows_with_asr(
+        periods,
+        [{"start": 5.5, "end": 8.5, "text": "real"}],
+        video_duration=30.0,
+        configured_segment_seconds=30,
+    )
+    assert periods[0]["has_speech"] is False
+    assert annotated[0]["has_speech"] is True
+    assert annotated[0]["has_speech_reason"] == "asr_overlap_high_confidence"
+    assert qc["asr_granularity"] == "segment"

--- a/tests/voiceover/test_dub.py
+++ b/tests/voiceover/test_dub.py
@@ -9,6 +9,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "skills" / "video-v
 import dub  # noqa: E402
 
 
+def test_strip_reasoning_residue_removes_think_leakage():
+    """Regression: MiMo -asr models are not thinking-disabled, so <think> reasoning can leak
+    into the transcript in several shapes. All must be stripped; clean text is untouched."""
+    s = dub._strip_reasoning_residue
+    assert s("think>\n 真相比逃跑更狼。").strip() == "真相比逃跑更狼。"   # leading orphan residue
+    assert s("think>\n Yeah.").strip() == "Yeah."
+    assert s("<think>推理\n</think>\n开门的却是个陌生男人").strip() == "开门的却是个陌生男人"  # full block
+    assert s("<think>未闭合的推理 后续文字").strip() == ""              # unclosed/truncated
+    assert s("正常一句，没有思考标签。") == "正常一句，没有思考标签。"      # clean text untouched
+
+
 def test_atempo_chain():
     assert dub._atempo_chain(1.3) == "atempo=1.3000"
     assert dub._atempo_chain(3.0).startswith("atempo=2.0,atempo=")  # >2x is chained

--- a/tests/voiceover/test_dub.py
+++ b/tests/voiceover/test_dub.py
@@ -191,3 +191,20 @@ def test_dub_print_schema_includes_new_artifacts(capsys):
     assert "dub_lint.json" in schemas
     assert "dub_review.json" in schemas
     assert "dub_manifest.json" in schemas
+
+
+def test_p0_dub_chars_per_second_ignores_punctuation_for_density():
+    assert dub._chars_per_second("你，好！……", 1.0) == pytest.approx(2.0)
+    assert dub._chars_per_second("Hello, world!", 2.0) == pytest.approx(5.0)
+
+
+def test_p0_dub_lint_warns_near_trim_risk_before_hard_cut():
+    script = [{"start": 0.0, "end": 2.0, "zh": "这是一句中文台词需要稍微压缩"}]  # 14 effective chars / 2s = 7 cps
+    lint = dub.lint_dub_script(script, duration=3.0)
+
+    assert lint["verdict"] == "PASS"
+    codes = {issue["code"] for issue in lint["issues"]}
+    assert "fast_speech" in codes
+    assert "trim_risk" in codes
+    assert lint["summary"]["trim_risk_lines"] == [0]
+    assert lint["summary"]["max_chars_per_second"] == pytest.approx(7.0)

--- a/tests/voiceover/test_pure_voiceover.py
+++ b/tests/voiceover/test_pure_voiceover.py
@@ -111,7 +111,8 @@ def test_synthesize_segment_block_truncation_accounts_for_narration_speed(monkey
     res2 = _synthesize_segment(1, {"start": 0.0, "end": 12.0, "narration": huge, "pause_after_ms": 200},
                                [huge], tts_dir, "mimo-tts")
     assert len(calls) == 2                         # re-synthesized after truncation
-    assert len(res2["narration"]) < len(huge)
+    assert res2["narration"] == huge               # authored narration stays intact for schema stability
+    assert len(res2["spoken_text"]) < len(huge)     # rendered text is what gets shortened
 
 
 def test_synthesize_segment_rejects_cache_when_wav_bytes_change(monkeypatch, tmp_path):
@@ -522,3 +523,105 @@ def test_partial_tts_meta_records_failed_segment_details(monkeypatch, tmp_path):
         "error": "network timeout",
     }]
     assert [seg["index"] for seg in meta["segments"]] == [0]
+
+
+def test_p0_tts_segment_result_versions_authored_and_spoken_text(tmp_path):
+    authored = "作者原始长文案。第二句作为 provenance 保留。"
+    spoken = "实际合成句。"
+    result = _build_tts_segment_result(
+        0,
+        {"start": 1.0, "end": 3.0, "narration": authored},
+        spoken,
+        tmp_path / "narr.wav",
+        1.2,
+        0.05,
+    )
+
+    assert result["segment_audio_schema_version"] >= 1
+    assert result["narration"] == authored
+    assert result["spoken_text"] == spoken
+    assert result["truncated"] is True
+    assert result["truncate_reason"] in {"sentence_boundary", "none"}
+    assert result["audio_duration"] == 1.2
+    assert result["global_narration_speed"] == CONFIG.get("narration_speed")
+    assert result["effective_tempo"] <= CONFIG.get("narration_cumulative_tempo_max", 1.35)
+
+
+def test_p0_synthesize_segment_budget_uses_cumulative_tempo_cap(monkeypatch, tmp_path):
+    """Voiceover rewrite budget must match assemble's cumulative tempo cap, not old 1.2 headroom."""
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+    monkeypatch.setitem(CONFIG, "narration_speed", 1.2)
+    monkeypatch.setitem(CONFIG, "narration_cumulative_tempo_max", 1.35)
+    monkeypatch.setitem(CONFIG, "mimo_tts_model", "mimo-v2.5-tts")
+    calls = []
+
+    def fake_run_tts(engine, text, output_wav, rate="+0%", pitch="+0Hz", emotion=None):
+        calls.append((text, rate))
+        output_wav.write_text(text, encoding="utf-8")
+
+    monkeypatch.setattr("voiceover._run_tts_engine", fake_run_tts)
+    monkeypatch.setattr(
+        "voiceover._get_audio_duration",
+        lambda p: len(Path(p).read_text(encoding="utf-8")) * 0.3 if Path(p).exists() else 0.0,
+    )
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+
+    # slot 10s, pause 0s. With global speed 1.2 and cumulative cap 1.35,
+    # raw budget = 10 * 1.35 = 13.5s, not old 10*1.2*1.2=14.4s.
+    text = "情节推进。" * 10  # synthetic 15s, should be rewritten under P0 cap.
+    res = _synthesize_segment(0, {"start": 0.0, "end": 10.0, "narration": text, "pause_after_ms": 0}, [text], tts_dir, "mimo-tts")
+
+    assert len(calls) == 2
+    assert res["spoken_text"] != text
+    assert res["truncated"] is True
+    assert res["effective_tempo"] <= 1.35 + 1e-6
+
+
+def _write_constant_wav(path, amplitude, seconds=0.25, sample_rate=24000):
+    import wave
+    frames = int(seconds * sample_rate)
+    sample = int(amplitude).to_bytes(2, "little", signed=True)
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(sample * frames)
+
+
+def _wav_rms_dbfs(path):
+    import math
+    import wave
+    with wave.open(str(path), "rb") as wf:
+        data = wf.readframes(wf.getnframes())
+    samples = [int.from_bytes(data[i:i+2], "little", signed=True) for i in range(0, len(data), 2)]
+    rms = math.sqrt(sum(s * s for s in samples) / max(1, len(samples)))
+    return 20 * math.log10(max(rms, 1e-9) / 32768.0)
+
+
+def _wav_peak(path):
+    import wave
+    with wave.open(str(path), "rb") as wf:
+        data = wf.readframes(wf.getnframes())
+    return max(abs(int.from_bytes(data[i:i+2], "little", signed=True)) for i in range(0, len(data), 2)) / 32768.0
+
+
+def test_p0_tts_rms_normalization_helper_matches_blocks_without_clipping(tmp_path):
+    loud = tmp_path / "loud.wav"
+    quiet = tmp_path / "quiet.wav"
+    loud_out = tmp_path / "loud_norm.wav"
+    quiet_out = tmp_path / "quiet_norm.wav"
+    _write_constant_wav(loud, 12000)
+    _write_constant_wav(quiet, 1200)
+
+    assert hasattr(voiceover, "_normalize_tts_wav_rms"), "P0 requires a reusable TTS RMS normalization helper"
+    loud_meta = voiceover._normalize_tts_wav_rms(loud, loud_out, target_rms_dbfs=-20.0, peak_limit=0.98)
+    quiet_meta = voiceover._normalize_tts_wav_rms(quiet, quiet_out, target_rms_dbfs=-20.0, peak_limit=0.98)
+
+    assert abs(_wav_rms_dbfs(loud_out) - _wav_rms_dbfs(quiet_out)) <= 1.5
+    assert _wav_peak(loud_out) <= 0.98
+    assert _wav_peak(quiet_out) <= 0.98
+    assert loud_meta["rms_dbfs_before"] > quiet_meta["rms_dbfs_before"]
+    assert abs(loud_meta["rms_dbfs_after"] - quiet_meta["rms_dbfs_after"]) <= 1.5
+    assert loud_meta["peak_after"] <= 0.98
+    assert quiet_meta["peak_after"] <= 0.98


### PR DESCRIPTION
## 变更摘要

- 新增 QC contract，统一质量检查结果结构与落盘语义。
- 引入 shift-left preflight stages，把关键质量风险前移到更早阶段发现。
- 增加 MiMo advisory adapter，为后续模型辅助质检提供可替换适配层。
- 新增 final_qc / golden_eval 产物与流程集成。
- 补齐 docs / tests / redaction，避免敏感信息进入日志与产物。

## 验证

- `py_compile` pass。
- targeted tests：35 passed。
- orchestrator tests：129 passed。
- assemble tests：179 passed。
- `git diff --check` pass。
- long token scan pass。
- 真实视频 local QC pass。
- MiMo 真实调用因 provider quota 429 未拿到模型判断；adapter / local QC pass。

## 风险 / 说明

- MiMo provider 当前返回 quota 429，后续额度恢复后可重跑 section D 获取真实模型判断。

---

## 真机验证与修复（2026-07-09 · live MiMo / SGP cluster）

用真实 MiMo Token-Plan key 端到端跑通 **full / cut / dub** 三种模式（demo.mp4 + 《庆余年》片段），外加 44 项确定性 QC 边界探针、一次 **live-MiMo QC judge**、stale-work_dir guard、doctor、多视频 analyze，以及一个 8 候选**对抗式工作流**（2 confirmed / 6 refuted）。上面 body 里“429 未拿到模型判断”已不成立——本轮拿到了真实模型判断，advisory-by-default 门禁在真机上表现符合预期。

修复了 4 个“dumb-code 过度/不足触发”缺陷（均已复现 + 对抗式验证；改动最小化，判断权仍交给 agent）：

1. **assemble** — 解说块超出可用窗口 **0.00–0.01s** 就被整块丢弃并标 blocking。改为对 ≤50ms 的 post-atempo 尾部（release/静音）裁剪后正常放置，只有真正超限(>tol)才交 QC。修复了两次真机渲染共 **3 个被丢块**（即便刻意压低字数预算仍触发）。
2. **deslop_qc** — `PLACEHOLDER_RE` 的 `TA要` 误伤合法中性代词「TA」(他/她)+要（解说悬念惯用法），硬中断渲染。改为锚定示例脚手架短语 `TA要赌上`；`【主角】` 仍抓逐字复制。
3. **dub / asr** — MiMo `-asr` 模型不走 thinking-disable，`<think>` 推理会漏进转写（dub 的 22 个窗口里 4 个带 `think>` 残留）。两条 ASR 路径都加了稳健的推理残留清洗（block / truncated / orphan）。
4. **final_qc** — 成片门禁只看 ffprobe header，会放过「容器合法但媒体被截断」的成片（moov 在前 + mdat 被截，`+faststart` 下磁盘写满/上传中断都可能）。新增一次廉价 tail-decode 检查，ffmpeg 缺失时安全跳过。

**latent（真实 `redact_secrets` gap，但当前 pipeline 不可达 → 未阻断）**：secret-value 形状的字符串作 dict KEY / 非 http scheme 的 userinfo / 紧贴词字符的 tp-|sk- token 不被脱敏，后续可择机加固。

+6 回归测试；全量单测通过；44 项 QC 探针 + ruff 全绿。
