### PR TITLE
Fix frame-time off-by-one, cover-art render abort, clip padding, and redundant I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### 修复
+
+- **画面锚点整体偏移 1/fps 秒。** ffmpeg 的 `fps` 滤镜首帧在源时间 0，而文件编号从 1 起，所以 `frame_00001.jpg` 是 `t=0`、第 n 帧是 `(n-1)/fps`；此前按 `n/fps` 计算，把 `frame_facts`、场景归属与 storyboard 标签整体推后 1/fps 秒（>5min 视频默认 fps=1，即整整 1 秒）。这些时间戳会写进 VLM prompt 并作为写稿 Agent 的权威画面锚点。换算规则收敛到 `extract.py` 独家定义，帧/VLM 缓存带约定版本号，旧产物强制重算。
+- **带封面图的素材渲染直接失败。** 组装映射 `0:v` 会匹配到 attached_pic 那一路视频流，而 `-vf` 只作用于第一路，ffmpeg 报 `Could not write header` 并留下损坏文件——发生在整条流程的最后一步。改为 `0:v:0`。
+- **`--clip-padding` 非零时相邻片段被误判为重复素材。** 重叠检测此前基于加过 padding 的区间，任意两个背靠背片段都会硬失败；现按 Agent 实际写入的入出点判断。
+- **`CLIP_PADDING` 环境变量此前完全无效。** 六份 CONFIG 都声明了该键并通过 `clip_padding_source` 汇报为生效，但唯一实现 padding 的 video-cut 只读 CLI 参数。
+- 多视频输出时间线的 speech 证据改为与 `audio_mix` / `sentence_boundaries` 一致优先读 `asr_clean.json`；`narration_coverage_max` 等三个只读不声明的 CONFIG 键补齐；`silencedetect` 超时改为与该函数其余失败路径一致地 fail-open；多源剪辑的句子截断阻断项不再挂在无关条件下。
+
+### 性能
+
+- **不再重复哈希/解码/探测同一批字节。** `file_fingerprint` 按进程记忆化（内容寻址不变，仅用 dev/inode/size/mtime_ns 作记忆键）：一次理解流程原本要对源视频做 8–10 次全量 sha256、对整套抽帧做 2–3 遍，40 分钟视频约 2400 张全分辨率 JPEG。VLM 的逐帧 base64 缓存由无上界字典改为 LRU；续传缓存由每个场景整份重写改为按批落盘；TTS 响度归一从三遍纯 Python 遍历改为 `array('h')` 单遍（输出字节与元数据完全一致）；命中缓存的 TTS 段不再逐段 ffprobe；黑/白帧场景过滤按场景并行。
+
+### 构建
+
+- `pyproject.toml` 显式声明 ruff 规则集。CI 不固定 ruff 版本，而 0.16 起默认规则集被大幅扩展，会让无关 PR 的 lint 步骤失败。
+- `scripts/test.py` 将「未安装 pytest」与真实测试失败区分开。
+
 ### 改进
 
 - **内容驱动的创作流程。** Agent 在剪辑或写稿前先比较剪辑假设，记录 POV、戏剧问题、change-based beats、具体画面/反应、`audio_owner` 与 `narration_job`；`recap_story_plan.json` / `visual_audio_board.json` 同时覆盖单视频与多视频 cut。旁白比例改为素材决定，`7:3` 只保留为粗略回退而非配额。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.ruff.lint]
+# State the ruleset explicitly instead of inheriting ruff's default `select`.
+# CI installs ruff unpinned, and ruff's defaults widen between releases: as of 0.16 the
+# implicit default started pulling in isort/flake8-bugbear/pylint/RUF rules, which turns
+# a green tree red on an unrelated PR. These four are the historical default and the
+# contract this repo is written against; widening it should be a deliberate commit.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.per-file-ignores]
 # Each skill ships its own lib.py, so tests prepend their skill's scripts dir to
 # sys.path before importing — that legitimately puts imports after a statement (E402).

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -17,7 +17,28 @@ from pathlib import Path
 GROUPS = ["understanding", "cut", "voiceover", "assemble", "script", "orchestrator", "inspect"]
 
 
+def _require_pytest():
+    """Fail with the actual problem instead of reporting every group as a test failure.
+
+    Without this, a missing pytest prints "No module named pytest" seven times and then
+    "FAILED groups: understanding, cut, ..." — indistinguishable from real failures.
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("pytest") is not None:
+        return True
+    print(
+        f"pytest is not installed for this interpreter ({sys.executable}).\n"
+        f"  Install it:  {sys.executable} -m pip install pytest\n"
+        "  Or run the suite with an interpreter that has it (PYTHON=... scripts/test.sh).",
+        file=sys.stderr,
+    )
+    return False
+
+
 def main(argv):
+    if not _require_pytest():
+        return 2
     root = Path(__file__).resolve().parent.parent
     groups = argv or GROUPS
     failed = []

--- a/skills/video-assemble/scripts/artifacts.py
+++ b/skills/video-assemble/scripts/artifacts.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 from pathlib import Path
 
 from lib import CONFIG
@@ -14,12 +15,39 @@ def _value_fingerprint(value):
     return hashlib.md5(_stable_json_dumps(value).encode("utf-8")).hexdigest()
 
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def _file_fingerprint(path, chunk_size=1024 * 1024):
+    """Return a full-content fingerprint for cache-correct identity checks.
+
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
+    """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
-    with Path(path).open("rb") as f:
+    with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 
 
 def _artifact_fingerprint(path):

--- a/skills/video-assemble/scripts/assemble.py
+++ b/skills/video-assemble/scripts/assemble.py
@@ -141,7 +141,11 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             *original_audio_input,
             *bgm_input,
             "-filter_complex_script", str(fc_script),
-            "-map", "0:v", "-map", aout_label,
+            # 0:v:0 (not 0:v): sources with attached cover art carry a second video stream.
+            # -vf only ever applies to the first one, so mapping all of them makes ffmpeg
+            # abort with "Could not write header (incorrect codec parameters ?)" and leave
+            # an unreadable file — after the whole pipeline has already run.
+            "-map", "0:v:0", "-map", aout_label,
         ]
     else:
         cmd = [
@@ -151,7 +155,11 @@ def assemble_video(input_video, tts_segments, work_dir, output_path):
             *original_audio_input,
             *bgm_input,
             "-filter_complex", filter_complex,
-            "-map", "0:v", "-map", aout_label,
+            # 0:v:0 (not 0:v): sources with attached cover art carry a second video stream.
+            # -vf only ever applies to the first one, so mapping all of them makes ffmpeg
+            # abort with "Could not write header (incorrect codec parameters ?)" and leave
+            # an unreadable file — after the whole pipeline has already run.
+            "-map", "0:v:0", "-map", aout_label,
         ]
 
     # Video filter chain: mask source subtitles first (drawbox), then burn our subtitles

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -199,6 +199,7 @@ CONFIG = {
     "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
+    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long

--- a/skills/video-cut/scripts/cut_cli.py
+++ b/skills/video-cut/scripts/cut_cli.py
@@ -75,8 +75,8 @@ def main():
     parser.add_argument(
         "--clip-padding",
         type=float,
-        default=0.0,
-        help="seconds to pad each clip on both ends",
+        default=None,
+        help="seconds to pad each clip on both ends (default: CLIP_PADDING env, else 0)",
     )
     parser.add_argument(
         "--allow-overlap",
@@ -107,6 +107,15 @@ def main():
     )
     args = parser.parse_args()
 
+    # CLIP_PADDING is declared in every skill's CONFIG, but video-cut is the only place that
+    # implements padding — and it used to read the CLI flag alone, so setting the env var did
+    # nothing at all while `clip_padding_source: "env"` reported otherwise. CLI still wins.
+    clip_padding = (
+        args.clip_padding
+        if args.clip_padding is not None
+        else float(CONFIG.get("clip_padding", 0.0) or 0.0)
+    )
+
     work_dir = Path(args.work_dir)
     work_dir.mkdir(parents=True, exist_ok=True)
     clip_plan_path = (
@@ -127,7 +136,7 @@ def main():
             raw_plan,
             sources_manifest,
             target_duration=target_seconds,
-            clip_padding=args.clip_padding,
+            clip_padding=clip_padding,
             allow_overlap=args.allow_overlap,
         )
         video_duration = None
@@ -137,7 +146,7 @@ def main():
             raw_plan,
             video_duration,
             target_duration=target_seconds,
-            clip_padding=args.clip_padding,
+            clip_padding=clip_padding,
             allow_overlap=args.allow_overlap,
         )
 

--- a/skills/video-cut/scripts/cut_contract.py
+++ b/skills/video-cut/scripts/cut_contract.py
@@ -3,6 +3,7 @@
 import hashlib
 
 import json
+import os
 
 import re
 
@@ -76,6 +77,18 @@ def parse_duration_seconds(value):
     return seconds
 
 
+def _overlaps_authored_range(ranges, start, end):
+    """Whether [start,end) collides with an already-accepted clip, as AUTHORED.
+
+    Overlap is judged on the agent's own in/out points, never on the padded ones.
+    `clip_padding` deliberately widens every clip by the same amount on both ends, so
+    judging padded ranges makes any two back-to-back clips (…, 10) and (10, …) look like
+    duplicate footage and hard-fails a perfectly ordinary plan. Padding is an output
+    nicety; only what the agent actually asked for defines duplication.
+    """
+    return any(start < other_end and end > other_start for other_start, other_end in ranges)
+
+
 def _clip_value(raw, *names):
     for name in names:
         if name in raw:
@@ -112,13 +125,39 @@ def cut_plan_fingerprint(validated_plan):
     return value_fingerprint(payload)
 
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def file_fingerprint(path, chunk_size=1024 * 1024):
-    """Full-content fingerprint for source media cache provenance."""
+    """Return a full-content fingerprint for cache-correct identity checks.
+
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
+    """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
-    with Path(path).open("rb") as f:
+    with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 
 
 def _edited_source_meta_path(output_path):
@@ -354,13 +393,12 @@ def normalize_multi_source_clip_plan(
             log(f"  跳过过短 clip #{idx + 1}: {start:.1f}-{end:.1f}s")
             continue
         ranges = source_ranges.setdefault(source_id, [])
-        overlaps = [r for r in ranges if start < r[1] and end > r[0]]
-        if overlaps and not allow_overlap:
+        if not allow_overlap and _overlaps_authored_range(ranges, raw_start, raw_end):
             raise ValueError(
                 f"clip #{idx + 1} overlaps an earlier source range for source_id {source_id}; "
                 "split or remove duplicate source footage before mapping narration"
             )
-        ranges.append((start, end))
+        ranges.append((raw_start, raw_end))
 
         duration = round(end - start, 3)
         clip = {
@@ -465,13 +503,12 @@ def normalize_clip_plan(
         if end - start < min_duration:
             log(f"  跳过过短 clip #{idx + 1}: {start:.1f}-{end:.1f}s")
             continue
-        overlaps = [r for r in source_ranges if start < r[1] and end > r[0]]
-        if overlaps and not allow_overlap:
+        if not allow_overlap and _overlaps_authored_range(source_ranges, raw_start, raw_end):
             raise ValueError(
                 f"clip #{idx + 1} overlaps an earlier source range; "
                 "split or remove duplicate source footage before mapping narration"
             )
-        source_ranges.append((start, end))
+        source_ranges.append((raw_start, raw_end))
 
         duration = round(end - start, 3)
         clip = {

--- a/skills/video-cut/scripts/lib.py
+++ b/skills/video-cut/scripts/lib.py
@@ -35,6 +35,9 @@ CONFIG = {
     "clip_start_snap_max_prepend": env_float("CLIP_START_SNAP_MAX_PREPEND", 1.8, min_val=0.0),
     "clip_start_snap_max_trim": env_float("CLIP_START_SNAP_MAX_TRIM", 0.35, min_val=0.0),
     "clip_join_audio_fade_ms": env_float("CLIP_JOIN_AUDIO_FADE_MS", 30.0, min_val=0.0),
+    # video-cut is the only skill that implements clip padding, so it is the only skill that
+    # may declare the knob. cut_cli reads this as the default for --clip-padding.
+    "clip_padding": env_float("CLIP_PADDING", 0.0, min_val=0.0),
     # Keep clip boundaries off the ORIGINAL footage's hard cuts: a clip that opens/closes a few
     # tenths of a second from a source shot-change shows a brief sliver of the adjacent shot that
     # then hard-cuts again — a visible 闪烁/flicker at the edit point. Snap source_start forward

--- a/skills/video-cut/scripts/sentence_boundaries.py
+++ b/skills/video-cut/scripts/sentence_boundaries.py
@@ -736,6 +736,10 @@ def snap_multi_source_clips(
                         "start_unsnapped_reason": event.get("start_unsnapped_reason"),
                     }
                 )
-        if blocking_accum:
-            qc.setdefault("blocking", []).extend(blocking_accum)
+    # Blocking rows are propagated unconditionally. They used to sit inside the
+    # `any(boundary_accum.values())` branch, which happens to hold today only because
+    # enforce_clip_sentence_boundaries always emits sentence_checks — a mid-sentence cut
+    # must never be silently dropped because some sibling QC list came back empty.
+    if blocking_accum:
+        plan.setdefault("qc", {}).setdefault("blocking", []).extend(blocking_accum)
     return plan

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -195,6 +195,7 @@ CONFIG = {
     "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
+    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long

--- a/skills/video-recap/scripts/materials.py
+++ b/skills/video-recap/scripts/materials.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import tempfile
 from datetime import datetime, timezone
@@ -65,12 +66,39 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def file_fingerprint(path: str | Path, chunk_size: int = 1024 * 1024) -> str:
+    """Return a full-content fingerprint for cache-correct identity checks.
+
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
+    """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
-    with Path(path).open("rb") as f:
+    with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 
 
 def stable_json_dumps(value) -> str:

--- a/skills/video-recap/scripts/recap_runner.py
+++ b/skills/video-recap/scripts/recap_runner.py
@@ -119,6 +119,19 @@ def _run_or_restore_understanding(source_record, source_work_dir, args):
     return restored
 
 
+def _single_source_record(video, args):
+    """Identity + settings for the one source of a single-video run."""
+    fp = _file_fingerprint(video)
+    return {
+        "source_id": material_lib.source_id_from_fingerprint(fp),
+        "source_path": str(video),
+        "source_name": video.name,
+        "source_video_fingerprint": fp,
+        "settings_fingerprint": _material_settings_fingerprint(args),
+        "material_id": material_lib.material_id_for(video, fp),
+    }
+
+
 def _rebuild_understanding_brief(source_record, source_work_dir, args):
     """Rebuild agent_narration_brief.md from cached/restored analysis only.
 
@@ -166,6 +179,7 @@ def _run_multi_cut(videos, work_dir, args):
             _run_or_restore_understanding(
                 record, _source_work_dir(work_dir, record), args
             )
+        # Rewrite: _run_or_restore_understanding fills in material_id per record.
         manifest_path = _write_multi_source_manifest(work_dir, source_records)
         _write_project_run_manifest(work_dir, videos, args, source_records)
         _write_multi_source_clip_brief(work_dir, source_records, args)
@@ -395,52 +409,23 @@ def main():
     edited_source = work_dir / "edited_source.mp4"
 
     def _understand():
-        fp = _file_fingerprint(video)
-        source_record = {
-            "source_id": material_lib.source_id_from_fingerprint(fp),
-            "source_path": str(video),
-            "source_name": video.name,
-            "source_video_fingerprint": fp,
-            "settings_fingerprint": _material_settings_fingerprint(args),
-            "material_id": material_lib.material_id_for(video, fp),
-        }
+        source_record = _single_source_record(video, args)
         _run_or_restore_understanding(source_record, work_dir, args)
         return source_record
 
     def _rebuild_output_brief():
-        fp = _file_fingerprint(video)
-        source_record = {
-            "source_id": material_lib.source_id_from_fingerprint(fp),
-            "source_path": str(video),
-            "source_name": video.name,
-            "source_video_fingerprint": fp,
-            "settings_fingerprint": _material_settings_fingerprint(args),
-            "material_id": material_lib.material_id_for(video, fp),
-        }
-        _rebuild_understanding_brief(source_record, work_dir, args)
+        _rebuild_understanding_brief(_single_source_record(video, args), work_dir, args)
 
     inspect_py = _entry("video-recap", "recap_inspect.py")
 
     def _pause(need_text, inspect_hint=None):
-        brief = work_dir / "agent_narration_brief.md"
-        cont = _continuation_command(video, work_dir, args)
-        print("=" * 50)
-        # The brief fires a research directive only when the substrate is thin/empty and no
-        # background_research.json exists yet; amplify it so the agent researches BEFORE writing.
-        if brief.exists() and "Research the story FIRST" in brief.read_text(
-            encoding="utf-8"
-        ):
-            print(
-                "[video-recap] ⚑ 理解素材偏薄：先按 brief 顶部「Research the story FIRST」调研并写 "
-                "background_research.json，再写解说，避免看图说话。"
-            )
-        print(
-            f"[video-recap] ⏸  阅读 {brief}（按 video-script 规则）后写入 {need_text}"
+        # Same banner as the multi-source flow; only the continuation command differs.
+        _pause_for_agent(
+            work_dir,
+            need_text,
+            _continuation_command(video, work_dir, args),
+            inspect_hint=inspect_hint,
         )
-        if inspect_hint:
-            print(f"[video-recap]    先核对状态/时间轴（建议性）: {inspect_hint}")
-        print(f"[video-recap]    写完后重跑继续: {cont}")
-        print("=" * 50)
 
     def _reject_stale_manifest():
         mismatches = _manifest_mismatches(work_dir, video, args)

--- a/skills/video-recap/scripts/recap_runtime.py
+++ b/skills/video-recap/scripts/recap_runtime.py
@@ -134,12 +134,39 @@ def _probe_display_height_or_raise(path, *, require_square_pixels=False):
     return display_width if rotation in {90, 270} else height
 
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def _file_fingerprint(path, chunk_size=1024 * 1024):
+    """Return a full-content fingerprint for cache-correct identity checks.
+
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
+    the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
+    """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
-    with Path(path).open("rb") as f:
+    with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 
 
 def _analysis_settings(args):

--- a/skills/video-recap/scripts/recap_timeline.py
+++ b/skills/video-recap/scripts/recap_timeline.py
@@ -523,7 +523,11 @@ def _write_multi_source_output_speech_evidence(work_dir, source_records, plan):
         source_dir = _source_work_dir(work_dir, record) if record else None
         anchors = _load_json(source_dir / "speech_boundary_anchors.json") if source_dir else None
         speech = None
-        for name in ("asr_result.json", "asr_clean.json"):
+        # Same precedence as audio_mix._handoff_speech_evidence and
+        # sentence_boundaries._load_source_speech_spans: the cleaned transcript wins.
+        # Reading these in the opposite order made the multi-source output timeline
+        # derive its speech spans from a different artifact than every other consumer.
+        for name in ("asr_clean.json", "asr_result.json"):
             speech = _load_json(source_dir / name) if source_dir else None
             rows = speech.get("segments", []) if isinstance(speech, dict) else speech
             if isinstance(rows, list) and any(

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -197,6 +197,7 @@ CONFIG = {
     "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
+    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
@@ -323,18 +324,39 @@ def stable_hash(value):
     """Return an md5 digest for deterministic JSON-serializable values."""
     return hashlib.md5(stable_json_dumps(value).encode("utf-8")).hexdigest()
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def file_fingerprint(path, chunk_size=1024 * 1024):
     """Return a full-content fingerprint for cache-correct identity checks.
 
-    This intentionally avoids mtime/path so copied videos or JSON artifacts can
-    be reused when their bytes are identical, while any byte change invalidates
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
     the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
     """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
     with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 def _retry_after_seconds(value, fallback):
     """Parse Retry-After seconds or HTTP-date; return fallback on malformed input."""
     if not value:
@@ -439,7 +461,9 @@ def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key
                 time.sleep(wait)
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: HTTP {e.code} — {body}")
-        except (urllib.error.URLError, Exception) as e:
+        except Exception as e:  # noqa: BLE001 - transport/decode faults are all retryable here
+            # (Deliberately broad, but no longer written as `(URLError, Exception)`, which
+            # read as a tuple while `Exception` already subsumed the first member.)
             wait = min(2 ** attempt, 60)
             safe_error = _sanitize_api_error(e)
             log(f"API 调用失败 (尝试 {attempt+1}/{max_retries}): {safe_error}")
@@ -448,3 +472,6 @@ def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key
                 time.sleep(wait)
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: {safe_error}")
+    # Unreachable for max_retries >= 1; guards against a silent `None` return (and the
+    # TypeError it would cause at the caller's resp["choices"]) if a caller passes 0.
+    raise ValueError(f"max_retries must be >= 1, got {max_retries}")

--- a/skills/video-understanding/scripts/detect.py
+++ b/skills/video-understanding/scripts/detect.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from lib import CONFIG
@@ -68,11 +69,13 @@ def _merge_short_scenes(scenes, min_duration=4.0):
     merged = [scenes[0]]
     for s in scenes[1:]:
         prev = merged[-1]
-        # 如果前一个场景太短，合并到当前
-        if prev["end"] - prev["start"] < min_duration:
-            merged[-1] = {"start": prev["start"], "end": s["end"]}
-        # 如果当前场景太短，合并到前一个
-        elif s["end"] - s["start"] < min_duration:
+        # 任一侧过短就把两段并成一段 [prev.start, s.end]。（原来写成 if/elif 两个分支，
+        # 但两个分支体完全一样，读起来像是有两种不同处理，实际没有区别。）
+        too_short = (
+            prev["end"] - prev["start"] < min_duration
+            or s["end"] - s["start"] < min_duration
+        )
+        if too_short:
             merged[-1] = {"start": prev["start"], "end": s["end"]}
         else:
             merged.append(s)
@@ -132,23 +135,35 @@ def _is_junk_scene(video_path, timestamp, threshold_dark=None, threshold_bright=
     )
 
 
+def _scene_is_junk(scene, video_path):
+    """Whether every probe point of one scene is a black/white transition frame."""
+    start = float(scene["start"])
+    end = float(scene["end"])
+    # 多点采样：起始、中点、结尾各探一帧；只有全部为垃圾帧才删除，
+    # 含任意非垃圾帧的场景必须保留（避免短黑场并入长真实场景后被整段误删）
+    probe_times = [
+        min(end, start + 0.1),
+        (start + end) / 2.0,
+        max(start, end - 0.1),
+    ]
+    # `all` 的短路很重要：绝大多数场景第一探就否掉，只花一次 ffmpeg。
+    return all(_is_junk_scene(video_path, t) for t in probe_times)
+
+
 def _filter_junk_scenes(scenes, video_path):
     """Filter black/white transition scenes while never deleting the whole video."""
     if len(scenes) <= 1:
         return scenes
+    # 每个探点都是一次 ffmpeg 进程（seek + 解一帧），一部 30 分钟片有几百个场景，串行下来
+    # 光进程启动就要几十秒。按场景并行：每个 worker 内部仍然短路，所以既保留了「多数场景只
+    # 探一次」，又把进程启动开销摊平。判定逻辑与探点完全不变。
+    workers = max(1, int(CONFIG.get("scene_junk_workers", 8) or 8))
+    with ThreadPoolExecutor(max_workers=min(workers, len(scenes))) as executor:
+        verdicts = list(executor.map(lambda s: _scene_is_junk(s, video_path), scenes))
     filtered = []
     removed = []
-    for scene in scenes:
-        start = float(scene["start"])
-        end = float(scene["end"])
-        # 多点采样：起始、中点、结尾各探一帧；只有全部为垃圾帧才删除，
-        # 含任意非垃圾帧的场景必须保留（避免短黑场并入长真实场景后被整段误删）
-        probe_times = [
-            min(end, start + 0.1),
-            (start + end) / 2.0,
-            max(start, end - 0.1),
-        ]
-        if all(_is_junk_scene(video_path, t) for t in probe_times):
+    for scene, is_junk in zip(scenes, verdicts):
+        if is_junk:
             removed.append(scene)
         else:
             filtered.append(scene)
@@ -162,6 +177,18 @@ def _filter_junk_scenes(scenes, video_path):
 
 
 # ── Step 3.5: 静音检测 ─────────────────────────────────────────────
+
+# The silence-detection audio is always extracted below as 16 kHz mono signed-16 PCM.
+_SILENCE_AUDIO_BYTES_PER_SECOND = 16000 * 1 * 2
+
+
+def _wav_seconds_estimate(audio_path):
+    """Approximate duration from file size — no ffprobe subprocess on this path."""
+    try:
+        return max(0.0, Path(audio_path).stat().st_size / _SILENCE_AUDIO_BYTES_PER_SECOND)
+    except OSError:
+        return 0.0
+
 
 def _compact_ffmpeg_error(stderr, limit=400):
     """Keep the actionable tail without dumping ffmpeg build/configuration banners."""
@@ -273,7 +300,17 @@ def detect_silence_periods(video_path, work_dir, asr_result=None):
     cmd = ["ffmpeg", "-i", str(audio_path),
            "-af", f"silencedetect=noise={noise}:d={min_dur}",
            "-f", "null", "-"]
-    result = run_cmd(cmd, timeout=120)
+    # Everything else in this function degrades to `return []` (narration then falls back to
+    # non-quiet placement). A timeout must degrade the same way instead of raising
+    # TimeoutExpired through the whole understanding stage. Scale the budget with the audio
+    # so a long feature is not cut off by a constant tuned for short clips — estimated from
+    # the file size (this is the 16 kHz mono s16 WAV we just wrote), not from another probe.
+    timeout = max(120.0, _wav_seconds_estimate(audio_path) * 0.5)
+    try:
+        result = run_cmd(cmd, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log(f"静音检测超时（>{timeout:.0f}s），跳过安静窗口检测")
+        return []
     if result.returncode != 0:
         log(f"静音检测失败: {_compact_ffmpeg_error(result.stderr)}")
         return []

--- a/skills/video-understanding/scripts/extract.py
+++ b/skills/video-understanding/scripts/extract.py
@@ -3,6 +3,40 @@ from lib import log, run_cmd
 
 # ── Step 1: 帧提取 ───────────────────────────────────────────────────
 
+# ffmpeg 的 `fps` 滤镜从源时间 0 开始输出第一帧，而 image2 muxer 的 `-start_number`
+# 默认是 1。所以 frame_00001.jpg 对应 t=0，第 n 号帧对应 (n-1)/fps —— 不是 n/fps。
+# 这个 off-by-one 会把所有画面锚点（frame_facts、场景归属、storyboard 标签）整体推后
+# 1/fps 秒（长视频默认 fps=1，即整整 1 秒）。这里是该约定的唯一定义处。
+FRAME_START_NUMBER = 1
+
+# 帧编号↔时间的换算规则变更时递增；进入各阶段缓存 key，强制重算旧产物。
+FRAME_TIME_CONVENTION_VERSION = 2
+
+
+def frame_time(frame_number, fps):
+    """帧文件序号 → 源视频时间（秒）。frame_00001 → 0.0。"""
+    fps = float(fps)
+    if fps <= 0:
+        raise ValueError("fps 必须大于 0")
+    return (int(frame_number) - FRAME_START_NUMBER) / fps
+
+
+def frame_number_for_time(timestamp, fps):
+    """源视频时间（秒）→ 对应的帧文件序号（可能是小数，供最近邻查找用）。"""
+    fps = float(fps)
+    if fps <= 0:
+        raise ValueError("fps 必须大于 0")
+    return float(timestamp) * fps + FRAME_START_NUMBER
+
+
+def parse_frame_number(frame_path):
+    """从 frame_NNNNN.jpg 解析序号；命名不符合约定时返回 None。"""
+    parts = frame_path.stem.split("_")
+    if len(parts) != 2 or not parts[1].isdigit():
+        return None
+    return int(parts[1])
+
+
 def extract_frames(video_path, work_dir, fps=None):
     """提取视频帧"""
     fps = CONFIG["fps"] if fps is None else fps
@@ -17,7 +51,8 @@ def extract_frames(video_path, work_dir, fps=None):
 
     output_pattern = str(frames_dir / "frame_%05d.jpg")
     cmd = ["ffmpeg", "-y", "-i", str(video_path),
-           "-vf", f"fps={fps}", "-q:v", "2", output_pattern]
+           "-vf", f"fps={fps}", "-q:v", "2",
+           "-start_number", str(FRAME_START_NUMBER), output_pattern]
     result = run_cmd(cmd)
     if result.returncode != 0:
         raise RuntimeError(f"帧提取失败: {result.stderr}")

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -198,12 +198,15 @@ CONFIG = {
     "storyboard": env_bool("STORYBOARD", True),  # generate source/edited storyboard contact sheets
     "storyboard_max_tiles": env_int("STORYBOARD_MAX_TILES", 30, minimum=1),  # cap tiles per sheet for legibility
     "storyboard_columns": env_int("STORYBOARD_COLUMNS", 6, minimum=1),  # tile grid columns
+    "storyboard_rows_per_page": env_int("STORYBOARD_ROWS_PER_PAGE", 5, minimum=1),  # tile grid rows before spilling to the next sheet
+    "storyboard_long_scene_seconds": env_float("STORYBOARD_LONG_SCENE_SECONDS", 6.0, minimum=0.1),  # scenes at/above this also sample +1/3 & +2/3
     # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
     "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
     "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
+    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
@@ -262,6 +265,7 @@ CONFIG = {
     "silence_merge_gap": 0.5,        # 相邻静音段间隔<此值时合并
     "scene_merge_min": 4.0,         # 场景合并最短时长，<此值的场景合并到相邻场景
     "scene_junk_filter": env_bool("SCENE_JUNK_FILTER", True),  # 过滤连续黑/白帧无效过渡场景
+    "scene_junk_workers": env_int("SCENE_JUNK_WORKERS", 8, minimum=1),  # 黑/白帧探测并行度（每个探点一次 ffmpeg）
     "scene_junk_dark_luma": env_float("SCENE_JUNK_DARK_LUMA", 8.0, minimum=0.0),
     "scene_junk_bright_luma": env_float("SCENE_JUNK_BRIGHT_LUMA", 245.0, minimum=0.0),
     "scene_junk_pixel_ratio": env_float("SCENE_JUNK_PIXEL_RATIO", 0.995, minimum=0.0),
@@ -368,18 +372,39 @@ def stable_hash(value):
     """Return an md5 digest for deterministic JSON-serializable values."""
     return hashlib.md5(stable_json_dumps(value).encode("utf-8")).hexdigest()
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def file_fingerprint(path, chunk_size=1024 * 1024):
     """Return a full-content fingerprint for cache-correct identity checks.
 
-    This intentionally avoids mtime/path so copied videos or JSON artifacts can
-    be reused when their bytes are identical, while any byte change invalidates
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
     the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
     """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
     with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 def video_fingerprint(video_path):
     """Full video content fingerprint used as the root pipeline asset print."""
     return file_fingerprint(video_path)
@@ -532,7 +557,9 @@ def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key
                 time.sleep(wait)
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: HTTP {e.code} — {body}")
-        except (urllib.error.URLError, Exception) as e:
+        except Exception as e:  # noqa: BLE001 - transport/decode faults are all retryable here
+            # (Deliberately broad, but no longer written as `(URLError, Exception)`, which
+            # read as a tuple while `Exception` already subsumed the first member.)
             wait = min(2 ** attempt, 60)
             safe_error = _sanitize_api_error(e)
             log(f"API 调用失败 (尝试 {attempt+1}/{max_retries}): {safe_error}")
@@ -541,6 +568,9 @@ def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key
                 time.sleep(wait)
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: {safe_error}")
+    # Unreachable for max_retries >= 1; guards against a silent `None` return (and the
+    # TypeError it would cause at the caller's resp["choices"]) if a caller passes 0.
+    raise ValueError(f"max_retries must be >= 1, got {max_retries}")
 
 def load_prompt(name):
     """加载 prompt 模板"""

--- a/skills/video-understanding/scripts/storyboard.py
+++ b/skills/video-understanding/scripts/storyboard.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from extract import frame_number_for_time, parse_frame_number
 from lib import CONFIG, run_cmd, log
 
 try:  # file_fingerprint is the project's content-fingerprint helper; reuse when cheap.
@@ -87,10 +88,10 @@ def _frame_index(work_dir):
         return [], []
     pairs = []
     for path in frames_dir.glob("frame_*.jpg"):
-        stem_parts = path.stem.split("_")
-        if len(stem_parts) != 2 or not stem_parts[1].isdigit():
+        number = parse_frame_number(path)
+        if number is None:
             continue
-        pairs.append((int(stem_parts[1]), path))
+        pairs.append((number, path))
     pairs.sort(key=lambda item: item[0])
     numbers = [num for num, _ in pairs]
     paths = [path for _, path in pairs]
@@ -100,16 +101,17 @@ def _frame_index(work_dir):
 def _nearest_existing_frame(timestamp, fps, paths, numbers):
     """Map a SOURCE timestamp → the nearest EXISTING frame file, clamped to [first,last].
 
-    Frames are named frame_{n:05d}.jpg with t = n / fps (vlm.py convention). Rounding a
-    timestamp blindly can yield a frame number that was never written (fps boundary / last
-    frame gap), so we resolve to the closest number that actually exists on disk.
+    Frames are named frame_{n:05d}.jpg; the number↔time mapping is owned by extract.py
+    (frame_00001 is t=0, so n = t*fps + 1). Rounding a timestamp blindly can yield a frame
+    number that was never written (fps boundary / last frame gap), so we resolve to the
+    closest number that actually exists on disk.
     """
     if not numbers:
         return None
     fps = float(fps)
     if fps <= 0:
         return None
-    target = float(timestamp) * fps
+    target = frame_number_for_time(timestamp, fps)
     # Clamp into the real extracted range so out-of-range timestamps pin to first/last frame.
     if target <= numbers[0]:
         return paths[0]

--- a/skills/video-understanding/scripts/understanding_cache.py
+++ b/skills/video-understanding/scripts/understanding_cache.py
@@ -6,6 +6,7 @@ import json
 
 from pathlib import Path
 
+from extract import FRAME_TIME_CONVENTION_VERSION
 from lib import CONFIG, log, file_fingerprint, load_prompt
 
 
@@ -286,7 +287,9 @@ def _frames_manifest_path(work_dir):
 def _frame_cache_payload(video_path, fps, frames):
     frame_names = [Path(frame).name for frame in frames]
     return {
-        "schema_version": 1,
+        # v2: frame number→time is (n-1)/fps, not n/fps. Bumping invalidates frames/VLM
+        # artifacts produced under the old off-by-one so they are recomputed, not reused.
+        "schema_version": FRAME_TIME_CONVENTION_VERSION,
         "source_video_fingerprint": file_fingerprint(video_path),
         "fps": float(fps),
         "frame_count": len(frames),

--- a/skills/video-understanding/scripts/vlm.py
+++ b/skills/video-understanding/scripts/vlm.py
@@ -2,9 +2,16 @@ import base64
 import json
 import mimetypes
 import re
+from collections import OrderedDict
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
 
+from extract import (
+    FRAME_TIME_CONVENTION_VERSION,
+    frame_time,
+    parse_frame_number,
+)
 from lib import CONFIG
 from lib import log, api_call, load_prompt, mimo_video_api_call, run_cmd, file_fingerprint, stable_hash
 
@@ -114,23 +121,38 @@ def analyze_scenes(scenes, frames, work_dir, *, resume=True):
     if ctx:
         vlm_prompt = f"已知信息：{ctx}\n\n{vlm_prompt}"
 
-    # 构建帧时间映射 (frame_NNNNN.jpg -> time in seconds)
+    # 构建帧时间映射 (frame_NNNNN.jpg -> time in seconds)。换算规则由 extract.py 独家定义：
+    # ffmpeg 首帧在 t=0 而文件编号从 1 起，所以是 (n-1)/fps，不是 n/fps。
     frame_times = {}
     for f in frames:
-        parts = f.stem.split("_")
-        if len(parts) != 2 or not parts[1].isdigit():
+        num = parse_frame_number(f)
+        if num is None:
             continue
-        num = int(parts[1])
-        t = num / fps
-        frame_times[f] = t
+        frame_times[f] = frame_time(num, fps)
 
-    # base64 编码缓存
-    b64_cache = {}
+    # base64 编码缓存（LRU）。原来是无上界的 dict：整个 VLM 阶段会把用到的每一帧的 base64
+    # 都常驻内存，而 base64 比原图还大 1/3。40 分钟视频 fps=1 约 2400 帧 → 数百 MB 常驻。
+    # 相邻场景才会复用同一帧，容量取「并发数 × 单场景最大帧数」就够，再多也命中不了。
+    b64_capacity = max(
+        8,
+        int(CONFIG.get("vlm_max_frames", 16) or 16) * max(1, int(CONFIG.get("vlm_workers", 4) or 4)),
+    )
+    b64_cache = OrderedDict()
+    b64_lock = Lock()
 
     def _get_b64(frame_path):
-        if frame_path not in b64_cache:
-            b64_cache[frame_path] = base64.b64encode(frame_path.read_bytes()).decode()
-        return b64_cache[frame_path]
+        with b64_lock:
+            cached = b64_cache.get(frame_path)
+            if cached is not None:
+                b64_cache.move_to_end(frame_path)
+                return cached
+        encoded = base64.b64encode(frame_path.read_bytes()).decode()
+        with b64_lock:
+            b64_cache[frame_path] = encoded
+            b64_cache.move_to_end(frame_path)
+            while len(b64_cache) > b64_capacity:
+                b64_cache.popitem(last=False)
+        return encoded
 
     def _analyze_single_scene(i, scene):
         """分析单个场景，返回 (scene_id, result_dict)"""
@@ -224,7 +246,7 @@ def analyze_scenes(scenes, frames, work_dir, *, resume=True):
             i, round(float(scene["start"]), 3), round(float(scene["end"]), 3),
             CONFIG.get("vlm_model"), prompt_fp, CONFIG.get("vlm_max_tokens"),
             CONFIG.get("vlm_seconds_per_frame"), CONFIG.get("vlm_max_frames"),
-            round(float(fps), 3),
+            round(float(fps), 3), FRAME_TIME_CONVENTION_VERSION,
             CONFIG.get("api_url"), CONFIG.get("mimo_disable_thinking", True),
             CONFIG.get("mimo_media_resolution"),
         ))
@@ -240,22 +262,38 @@ def analyze_scenes(scenes, frames, work_dir, *, resume=True):
         log(f"VLM 复用 {len(scenes) - len(todo)} 个已缓存场景，待分析 {len(todo)} 个")
 
     def _run_pass(indices, workers):
-        """分析给定场景索引；每完成一个就把结果写入续传缓存（在主线程，无需加锁）。返回 (i, err) 失败列表。"""
+        """分析给定场景索引；结果按批持久化到续传缓存（在主线程，无需加锁）。返回 (i, err) 失败列表。
+
+        续传缓存每次都是整份重写，原来每完成一个场景就刷一次 → 写入量随场景数平方增长
+        （300 个场景约 75MB 冗余写），而且序列化发生在收结果的主循环上。改成按批刷：
+        崩溃最多丢失不到一批的进度，而这些场景本来就会在重跑时被重新分析。
+        """
         if not indices:
             return []
         failures = []
+        pending = 0
+        # 与并发度对齐：一批大致就是「同时在飞的那几个场景」。
+        flush_every = max(1, min(16, workers))
         with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
             futures = {executor.submit(_analyze_single_scene, i, scenes[i]): i for i in indices}
-            for future in as_completed(futures):
-                i = futures[future]
-                try:
-                    idx, result = future.result()
-                    analyses[idx] = result
-                    cache[_scene_cache_key(idx, scenes[idx])] = result
-                    _flush_vlm_scene_cache(work_dir, cache)  # 持久化进度，崩溃/中止后可续传
-                except Exception as e:  # noqa: BLE001 - 单个场景失败不能拖垮其余已完成的
-                    log(f"VLM 场景 {i+1} 分析失败: {e}")
-                    failures.append((i, str(e)))
+            try:
+                for future in as_completed(futures):
+                    i = futures[future]
+                    try:
+                        idx, result = future.result()
+                        analyses[idx] = result
+                        cache[_scene_cache_key(idx, scenes[idx])] = result
+                        pending += 1
+                        if pending >= flush_every:
+                            _flush_vlm_scene_cache(work_dir, cache)
+                            pending = 0
+                    except Exception as e:  # noqa: BLE001 - 单个场景失败不能拖垮其余已完成的
+                        log(f"VLM 场景 {i+1} 分析失败: {e}")
+                        failures.append((i, str(e)))
+            finally:
+                # 无论正常结束、失败还是中断，都把这一轮已完成的场景落盘。
+                if pending:
+                    _flush_vlm_scene_cache(work_dir, cache)
         return failures
 
     base_workers = min(len(todo) or 1, int(CONFIG.get("vlm_workers", 4) or 4))

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -200,6 +200,7 @@ CONFIG = {
     "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
     # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
     "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
+    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
     "narration_coverage_min": 0.5,      # below this coverage → under_narrated
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
@@ -357,18 +358,39 @@ def stable_hash(value):
     """Return an md5 digest for deterministic JSON-serializable values."""
     return hashlib.md5(stable_json_dumps(value).encode("utf-8")).hexdigest()
 
+_FILE_FINGERPRINT_MEMO = {}
+
+
+def _file_identity(path):
+    """(device, inode, size, mtime_ns) — changes whenever the bytes could have changed."""
+    st = os.stat(os.fspath(path))
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
 def file_fingerprint(path, chunk_size=1024 * 1024):
     """Return a full-content fingerprint for cache-correct identity checks.
 
-    This intentionally avoids mtime/path so copied videos or JSON artifacts can
-    be reused when their bytes are identical, while any byte change invalidates
+    The digest covers CONTENT only — never the path or mtime — so a copied video or
+    artifact is still recognised as the same asset, while any byte change invalidates
     the cache even if timestamps, size, head, or tail bytes are misleading.
+
+    Identity metadata is used ONLY to memoize within a single process. One understanding
+    run fingerprints the same source video 8-10 times and the whole extracted frame set
+    2-3 times; on a 40-minute video at fps=1 that is gigabytes of redundant reads before
+    any real work starts. A file rewritten in place gets a new (size, mtime_ns) and is
+    re-hashed, so the memo can never serve a stale digest.
     """
+    key = _file_identity(path)
+    memoized = _FILE_FINGERPRINT_MEMO.get(key)
+    if memoized is not None:
+        return memoized
     h = hashlib.sha256()
     with open(os.fspath(path), "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+    _FILE_FINGERPRINT_MEMO[key] = digest
+    return digest
 def _retry_after_seconds(value, fallback):
     """Parse Retry-After seconds or HTTP-date; return fallback on malformed input."""
     if not value:
@@ -508,7 +530,9 @@ def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key
                 time.sleep(wait)
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: HTTP {e.code} — {body}")
-        except (urllib.error.URLError, Exception) as e:
+        except Exception as e:  # noqa: BLE001 - transport/decode faults are all retryable here
+            # (Deliberately broad, but no longer written as `(URLError, Exception)`, which
+            # read as a tuple while `Exception` already subsumed the first member.)
             wait = min(2 ** attempt, 60)
             safe_error = _sanitize_api_error(e)
             log(f"API 调用失败 (尝试 {attempt+1}/{max_retries}): {safe_error}")
@@ -517,6 +541,9 @@ def api_call(payload, max_retries=8, *, api_provider=None, api_url=None, api_key
                 time.sleep(wait)
             else:
                 raise RuntimeError(f"API 调用失败 {max_retries} 次: {safe_error}")
+    # Unreachable for max_retries >= 1; guards against a silent `None` return (and the
+    # TypeError it would cause at the caller's resp["choices"]) if a caller passes 0.
+    raise ValueError(f"max_retries must be >= 1, got {max_retries}")
 
 def _text_char_count(text):
     """计算文本的有效字数（去除标点和空白，这些不占 TTS 朗读时间）。"""

--- a/skills/video-voiceover/scripts/tts_audio.py
+++ b/skills/video-voiceover/scripts/tts_audio.py
@@ -1,0 +1,113 @@
+"""Loudness normalization for synthesized TTS blocks.
+
+Split out of voiceover.py to keep that module within the bundle's per-module line
+budget. Dependency-free on purpose (stdlib `wave` + `array` only) so QC and assembly
+can reuse the returned metadata without pulling in the synthesis path.
+"""
+import array
+import math
+import os
+import sys
+import wave
+from pathlib import Path
+
+from lib import CONFIG, log
+
+
+def _normalize_tts_wav_rms(input_wav, output_wav, *, target_rms_dbfs=-20.0, peak_limit=0.98):
+    """Normalize a mono/stereo 16-bit WAV to a target RMS with peak guard.
+
+    This helper is intentionally dependency-free so QC/assembly can reuse the
+    returned metadata even when normalization is applied in a later lane.
+    """
+    input_wav = Path(input_wav)
+    output_wav = Path(output_wav)
+    with wave.open(str(input_wav), "rb") as wf:
+        channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        framerate = wf.getframerate()
+        frames = wf.getnframes()
+        data = wf.readframes(frames)
+    if sampwidth != 2:
+        raise ValueError(f"仅支持 16-bit PCM WAV: {input_wav}")
+
+    # array('h') decodes the whole block in C. The previous per-sample int.from_bytes
+    # comprehension ran three times over the audio (decode, normalize, re-decode the
+    # OUTPUT just to measure it) — about 420ms for a 12s block, times every narration
+    # segment. Same arithmetic, same rounding, one decode.
+    samples = array.array("h")
+    samples.frombytes(data[: len(data) - (len(data) % 2)])
+    if sys.byteorder != "little":  # wave data is little-endian regardless of host
+        samples.byteswap()
+    if not samples:
+        output_wav.write_bytes(input_wav.read_bytes())
+        return {
+            "rms_dbfs_before": None,
+            "rms_dbfs_after": None,
+            "peak_after": 0.0,
+            "gain_db": 0.0,
+        }
+    count = len(samples)
+    rms = math.sqrt(sum(s * s for s in samples) / count)
+    peak = max(max(samples), -min(samples)) / 32768.0
+    rms_dbfs_before = 20 * math.log10(max(rms, 1e-9) / 32768.0)
+    target_linear = 10 ** (float(target_rms_dbfs) / 20.0) * 32768.0
+    gain = target_linear / max(rms, 1e-9)
+    if peak > 0:
+        gain = min(gain, float(peak_limit) / peak)
+
+    # Accumulate the output statistics while normalizing instead of decoding the result back.
+    normalized = array.array("h", bytes(2 * count))
+    out_square_sum = 0
+    out_peak_raw = 0
+    for i in range(count):
+        value = max(-32768, min(32767, int(round(samples[i] * gain))))
+        normalized[i] = value
+        out_square_sum += value * value
+        if abs(value) > out_peak_raw:
+            out_peak_raw = abs(value)
+    out_bytes = normalized
+    if sys.byteorder != "little":
+        out_bytes = array.array("h", normalized)
+        out_bytes.byteswap()
+    with wave.open(str(output_wav), "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sampwidth)
+        wf.setframerate(framerate)
+        wf.writeframes(out_bytes.tobytes())
+
+    out_rms = math.sqrt(out_square_sum / count)
+    return {
+        "rms_dbfs_before": rms_dbfs_before,
+        "rms_dbfs_after": 20 * math.log10(max(out_rms, 1e-9) / 32768.0),
+        "peak_after": out_peak_raw / 32768.0,
+        "gain_db": 20 * math.log10(max(gain, 1e-9)),
+    }
+
+
+def _maybe_normalize_tts_wav(output_wav):
+    """Normalize a synthesized TTS block in-place when possible.
+
+    Unit tests often stub TTS with text bytes rather than real WAV. In that case
+    normalization is skipped safely; real MiMo WAV output gets RMS/peak metadata.
+    """
+    if not CONFIG.get("tts_segment_normalize", True):
+        return None
+    output_wav = Path(output_wav)
+    tmp = output_wav.with_name(f"{output_wav.stem}_norm{output_wav.suffix}")
+    try:
+        meta = _normalize_tts_wav_rms(
+            output_wav,
+            tmp,
+            target_rms_dbfs=float(CONFIG.get("tts_segment_target_rms_dbfs", -20.0) or -20.0),
+            peak_limit=float(CONFIG.get("tts_segment_peak_limit", 0.98) or 0.98),
+        )
+        os.replace(tmp, output_wav)
+        return meta
+    except Exception as exc:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        log(f"  TTS RMS 归一跳过: {exc}")
+        return None

--- a/skills/video-voiceover/scripts/voiceover.py
+++ b/skills/video-voiceover/scripts/voiceover.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import math
 import os
 import re
 import shutil
@@ -12,6 +13,8 @@ from threading import Lock
 from lib import CONFIG
 from lib import log, mimo_tts_api_call, get_video_duration, narration_tempo_budget, run_cmd
 from lib import _truncate_at_sentence, _text_char_count, stable_hash, file_fingerprint
+# Re-exported: tests and callers reach these through voiceover, the module owns the flow.
+from tts_audio import _maybe_normalize_tts_wav, _normalize_tts_wav_rms  # noqa: F401
 
 SUPPORTED_TTS_ENGINES = {"mimo-tts"}
 SEGMENT_AUDIO_SCHEMA_VERSION = 1
@@ -331,91 +334,15 @@ def _cleanup_partial_tts_outputs(output_wav):
             pass
 
 
-def _normalize_tts_wav_rms(input_wav, output_wav, *, target_rms_dbfs=-20.0, peak_limit=0.98):
-    """Normalize a mono/stereo 16-bit WAV to a target RMS with peak guard.
-
-    This helper is intentionally dependency-free so QC/assembly can reuse the
-    returned metadata even when normalization is applied in a later lane.
-    """
-    import math
-    import wave
-
-    input_wav = Path(input_wav)
-    output_wav = Path(output_wav)
-    with wave.open(str(input_wav), "rb") as wf:
-        channels = wf.getnchannels()
-        sampwidth = wf.getsampwidth()
-        framerate = wf.getframerate()
-        frames = wf.getnframes()
-        data = wf.readframes(frames)
-    if sampwidth != 2:
-        raise ValueError(f"仅支持 16-bit PCM WAV: {input_wav}")
-
-    samples = [int.from_bytes(data[i:i + 2], "little", signed=True) for i in range(0, len(data), 2)]
-    if not samples:
-        output_wav.write_bytes(input_wav.read_bytes())
-        return {
-            "rms_dbfs_before": None,
-            "rms_dbfs_after": None,
-            "peak_after": 0.0,
-            "gain_db": 0.0,
-        }
-    rms = math.sqrt(sum(s * s for s in samples) / len(samples))
-    peak = max(abs(s) for s in samples) / 32768.0
-    rms_dbfs_before = 20 * math.log10(max(rms, 1e-9) / 32768.0)
-    target_linear = 10 ** (float(target_rms_dbfs) / 20.0) * 32768.0
-    gain = target_linear / max(rms, 1e-9)
-    if peak > 0:
-        gain = min(gain, float(peak_limit) / peak)
-    normalized = []
-    for sample in samples:
-        value = int(round(sample * gain))
-        value = max(-32768, min(32767, value))
-        normalized.append(value.to_bytes(2, "little", signed=True))
-    out_data = b"".join(normalized)
-    with wave.open(str(output_wav), "wb") as wf:
-        wf.setnchannels(channels)
-        wf.setsampwidth(sampwidth)
-        wf.setframerate(framerate)
-        wf.writeframes(out_data)
-
-    out_samples = [int.from_bytes(out_data[i:i + 2], "little", signed=True) for i in range(0, len(out_data), 2)]
-    out_rms = math.sqrt(sum(s * s for s in out_samples) / len(out_samples))
-    out_peak = max(abs(s) for s in out_samples) / 32768.0
-    return {
-        "rms_dbfs_before": rms_dbfs_before,
-        "rms_dbfs_after": 20 * math.log10(max(out_rms, 1e-9) / 32768.0),
-        "peak_after": out_peak,
-        "gain_db": 20 * math.log10(max(gain, 1e-9)),
-    }
-
-
-def _maybe_normalize_tts_wav(output_wav):
-    """Normalize a synthesized TTS block in-place when possible.
-
-    Unit tests often stub TTS with text bytes rather than real WAV. In that case
-    normalization is skipped safely; real MiMo WAV output gets RMS/peak metadata.
-    """
-    if not CONFIG.get("tts_segment_normalize", True):
-        return None
-    output_wav = Path(output_wav)
-    tmp = output_wav.with_name(f"{output_wav.stem}_norm{output_wav.suffix}")
+def _finite_positive(value):
+    """Return value as a positive float, or None for missing/malformed/non-positive input."""
     try:
-        meta = _normalize_tts_wav_rms(
-            output_wav,
-            tmp,
-            target_rms_dbfs=float(CONFIG.get("tts_segment_target_rms_dbfs", -20.0) or -20.0),
-            peak_limit=float(CONFIG.get("tts_segment_peak_limit", 0.98) or 0.98),
-        )
-        os.replace(tmp, output_wav)
-        return meta
-    except Exception as exc:
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
-        log(f"  TTS RMS 归一跳过: {exc}")
+        number = float(value)
+    except (TypeError, ValueError):
         return None
+    if not math.isfinite(number) or number <= 0:
+        return None
+    return number
 
 
 def _tts_segment_cache_path(output_wav):
@@ -439,7 +366,14 @@ def _reuse_tts_segment_cache(index, seg, output_wav, source_text, rate, cache_ke
     cached = _load_tts_segment_cache(output_wav, cache_key)
     if not cached:
         return None
-    existing_dur = _get_audio_duration(output_wav)
+    # The sidecar's audio_fingerprint already proved these exact bytes are what produced
+    # `audio_duration`, so re-probing is a wasted ffprobe process per segment — on a
+    # fully-cached rerun of a 200-block narration that is 200 subprocess spawns for a
+    # number we already hold. Only fall back to ffprobe for pre-existing sidecars written
+    # before the duration was recorded.
+    existing_dur = _finite_positive(cached.get("audio_duration"))
+    if existing_dur is None:
+        existing_dur = _get_audio_duration(output_wav)
     if existing_dur <= 0:
         return None
     spoken_text = str(cached.get("spoken_text") or source_text)

--- a/tests/assemble/test_assemble_integration.py
+++ b/tests/assemble/test_assemble_integration.py
@@ -213,6 +213,43 @@ def test_output_is_yuv420p_and_faststart_on_reencode(tmp_path, monkeypatch):
     assert atoms.index("moov") < atoms.index("mdat"), f"moov not front-loaded: {atoms}"
 
 
+def _make_source_video_with_cover_art(path, tmp_path, seconds=2):
+    """A normal A/V source that also carries an attached_pic (cover art) video stream."""
+    base = tmp_path / "cover_base.mp4"
+    _make_source_video(base, seconds=seconds)
+    cover = tmp_path / "cover.png"
+    subprocess.run([
+        "ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=red:s=64x64:d=1",
+        "-frames:v", "1", str(cover),
+    ], check=True, capture_output=True)
+    subprocess.run([
+        "ffmpeg", "-y", "-i", str(base), "-i", str(cover),
+        "-map", "0", "-map", "1", "-c", "copy",
+        "-disposition:v:1", "attached_pic", str(path),
+    ], check=True, capture_output=True)
+
+
+def test_source_with_attached_cover_art_still_renders(tmp_path, monkeypatch):
+    """A source carrying cover art has TWO video streams. Mapping all of them into a filtered
+    re-encode makes ffmpeg abort ("Could not write header (incorrect codec parameters ?)")
+    and leave an unreadable file, at the very last step of the pipeline. Only the real
+    picture stream may be mapped."""
+    monkeypatch.setitem(CONFIG, "final_loudnorm", False)
+    monkeypatch.setitem(CONFIG, "mask_source_subtitles", False)
+    monkeypatch.setitem(CONFIG, "burn_subtitles", False)
+    monkeypatch.setitem(CONFIG, "force_video_reencode", True)  # forces the -vf/libx264 branch
+    work = tmp_path / "w_cover"
+    work.mkdir()
+    src = tmp_path / "src_cover.mp4"
+    _make_source_video_with_cover_art(src, tmp_path, seconds=2)
+    assert _stream_types(src).count("video") == 2  # precondition: cover art present
+    out = work / "recap_cover.mp4"
+    segs = _segment(work, 0.3, 1.5, overlaps=True, dur=1.0)
+    assemble_video(src, segs, work, out)
+    assert out.exists() and out.stat().st_size > 0
+    assert _stream_types(out) == ["video", "audio"], "cover art must not reach the output"
+
+
 def test_odd_height_422_force_reencode_does_not_abort(tmp_path, monkeypatch):
     """yuv420p needs even dims; an odd-height 4:2:2 source must still produce a valid file
     (the bare force_video_reencode branch). Without the even-normalize, libx264 aborts to 0 bytes."""

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -361,21 +361,36 @@ def test_multi_source_clip_padding_only_collides_on_authored_ranges():
         )
 
 
+def _load_lib_with_env(monkeypatch, **env):
+    """Evaluate video-cut's lib.py under a given environment, in its own module namespace.
+
+    Deliberately NOT importlib.reload(lib): this skill's lib has no re-import guard, so a
+    reload rebinds lib.CONFIG to a fresh dict while cut_cli keeps the original — every
+    later test in the process would then be patching a different object than the code
+    reads. A separately-named module instance leaves the live one untouched.
+    """
+    import importlib.util
+
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    path = Path(__file__).resolve().parents[2] / "skills" / "video-cut" / "scripts" / "lib.py"
+    spec = importlib.util.spec_from_file_location("_cut_lib_env_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_clip_padding_env_is_actually_read_into_config(monkeypatch):
     """The env→CONFIG half of the chain. Monkeypatching CONFIG in the wiring test below
     would happily pass even if video-cut's lib never declared the key at all — which is
     exactly how this stayed broken."""
-    import importlib
-
     import lib
 
-    monkeypatch.setenv("CLIP_PADDING", "2.5")
-    try:
-        reloaded = importlib.reload(lib)
-        assert reloaded.CONFIG["clip_padding"] == 2.5
-    finally:
-        monkeypatch.delenv("CLIP_PADDING", raising=False)
-        importlib.reload(lib)
+    live_config = lib.CONFIG
+    probed = _load_lib_with_env(monkeypatch, CLIP_PADDING="2.5")
+
+    assert probed.CONFIG["clip_padding"] == 2.5
+    assert lib.CONFIG is live_config, "probing must not rebind the live CONFIG"
 
 
 def test_clip_padding_env_reaches_the_only_skill_that_implements_it(monkeypatch, tmp_path):

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -312,6 +312,83 @@ def test_normalize_clip_plan_clamps_and_maps_output_timeline():
     assert plan["clips"][1]["output_start"] == 4.0
 
 
+def test_clip_padding_does_not_make_back_to_back_clips_look_duplicated():
+    """Padding widens every clip by the same amount on both ends, so judging overlap on the
+    PADDED ranges turns any ordinary (…,10)(10,…) pair into a hard 'duplicate footage' error.
+    Overlap must be judged on what the agent actually authored."""
+    plan = normalize_clip_plan(
+        [
+            {"start": 0.0, "end": 10.0, "reason": "a"},
+            {"start": 10.0, "end": 20.0, "reason": "b"},
+        ],
+        video_duration=60.0,
+        clip_padding=0.5,
+    )
+
+    assert [(c["source_start"], c["source_end"]) for c in plan["clips"]] == [
+        (0.0, 10.5),
+        (9.5, 20.5),
+    ]
+    # genuinely duplicated footage is still rejected, padding or not
+    with pytest.raises(ValueError, match="overlaps an earlier source range"):
+        normalize_clip_plan(
+            [{"start": 0.0, "end": 10.0}, {"start": 5.0, "end": 15.0}],
+            video_duration=60.0,
+            clip_padding=0.5,
+        )
+
+
+def test_multi_source_clip_padding_only_collides_on_authored_ranges():
+    manifest = {"sources": [{"source_id": "a", "source_path": "a.mp4", "duration": 60.0}]}
+    plan = cut.normalize_multi_source_clip_plan(
+        [
+            {"source_id": "a", "start": 0.0, "end": 10.0},
+            {"source_id": "a", "start": 10.0, "end": 20.0},
+        ],
+        manifest,
+        clip_padding=0.5,
+    )
+
+    assert len(plan["clips"]) == 2
+    with pytest.raises(ValueError, match="source_id a"):
+        cut.normalize_multi_source_clip_plan(
+            [
+                {"source_id": "a", "start": 0.0, "end": 10.0},
+                {"source_id": "a", "start": 5.0, "end": 15.0},
+            ],
+            manifest,
+            clip_padding=0.5,
+        )
+
+
+def test_clip_padding_env_reaches_the_only_skill_that_implements_it(monkeypatch, tmp_path):
+    """CLIP_PADDING is declared in every skill's CONFIG and reported as an active knob via
+    clip_padding_source, but video-cut used to read the CLI flag alone — so setting the env
+    var silently did nothing."""
+    import cut_cli
+
+    work = tmp_path / "w"
+    work.mkdir()
+    video = tmp_path / "src.mp4"
+    video.write_bytes(b"video")
+    (work / "clip_plan.json").write_text(
+        json.dumps([{"start": 10.0, "end": 20.0, "reason": "x"}]), encoding="utf-8"
+    )
+    monkeypatch.setitem(cut_cli.CONFIG, "clip_padding", 2.0)
+    monkeypatch.setattr("cut_cli.get_video_duration", lambda path: 100.0)
+    monkeypatch.setattr(
+        "cut_cli.build_edited_source_video", lambda *a, **k: Path(a[-1])
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["cut.py", str(video), "--work-dir", str(work), "--no-narration-map"]
+    )
+
+    cut.main()
+
+    clip = json.loads((work / "clip_plan_validated.json").read_text(encoding="utf-8"))["clips"][0]
+    assert (clip["source_start"], clip["source_end"]) == (8.0, 22.0)
+
+
 def test_clip_plan_rejects_overlapping_source_ranges():
     with pytest.raises(ValueError, match="overlaps an earlier source range"):
         normalize_clip_plan(

--- a/tests/cut/test_pure_cut.py
+++ b/tests/cut/test_pure_cut.py
@@ -361,10 +361,27 @@ def test_multi_source_clip_padding_only_collides_on_authored_ranges():
         )
 
 
+def test_clip_padding_env_is_actually_read_into_config(monkeypatch):
+    """The env→CONFIG half of the chain. Monkeypatching CONFIG in the wiring test below
+    would happily pass even if video-cut's lib never declared the key at all — which is
+    exactly how this stayed broken."""
+    import importlib
+
+    import lib
+
+    monkeypatch.setenv("CLIP_PADDING", "2.5")
+    try:
+        reloaded = importlib.reload(lib)
+        assert reloaded.CONFIG["clip_padding"] == 2.5
+    finally:
+        monkeypatch.delenv("CLIP_PADDING", raising=False)
+        importlib.reload(lib)
+
+
 def test_clip_padding_env_reaches_the_only_skill_that_implements_it(monkeypatch, tmp_path):
-    """CLIP_PADDING is declared in every skill's CONFIG and reported as an active knob via
-    clip_padding_source, but video-cut used to read the CLI flag alone — so setting the env
-    var silently did nothing."""
+    """The CONFIG→normalizer half. CLIP_PADDING was declared in five skills' CONFIGs and
+    reported as an active knob via clip_padding_source, but video-cut — the only skill that
+    implements padding — read the CLI flag alone."""
     import cut_cli
 
     work = tmp_path / "w"

--- a/tests/orchestrator/test_fingerprint_contract.py
+++ b/tests/orchestrator/test_fingerprint_contract.py
@@ -1,0 +1,137 @@
+"""Cross-skill contract for the duplicated full-file fingerprint helpers.
+
+The bundle ships seven copies of the same sha256-over-content helper (each skill is
+self-contained by design). Nothing linked them, so a change to one could silently
+diverge — and cache provenance is compared ACROSS skills: video-cut writes
+`edited_source.mp4.meta.json`, video-recap reads it, video-assemble fingerprints the
+same source again. A divergence there degrades into cache misses or, worse, false
+cache hits. These tests hold the copies to one behaviour.
+"""
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# (module path, attribute name) for every full-content fingerprint helper in the bundle.
+FINGERPRINT_IMPLEMENTATIONS = (
+    ("skills/video-assemble/scripts/artifacts.py", "_file_fingerprint"),
+    ("skills/video-cut/scripts/cut_contract.py", "file_fingerprint"),
+    ("skills/video-recap/scripts/materials.py", "file_fingerprint"),
+    ("skills/video-recap/scripts/recap_runtime.py", "_file_fingerprint"),
+    ("skills/video-script/scripts/lib.py", "file_fingerprint"),
+    ("skills/video-understanding/scripts/lib.py", "file_fingerprint"),
+    ("skills/video-voiceover/scripts/lib.py", "file_fingerprint"),
+)
+
+
+def _load(rel_path, index):
+    """Import one skill module under a unique name, in its own module namespace.
+
+    Every skill ships its own top-level `lib` (and `narration`, ...), which is exactly why
+    the suite runs one pytest process per skill. Loading several here would otherwise
+    resolve `from lib import ...` against whichever skill got imported first. So each load
+    gets a clean sys.modules for the bare skill-local names, restored afterwards, letting
+    this one cross-cutting test legitimately see all seven implementations at once.
+    """
+    import sys
+
+    path = ROOT / rel_path
+    scripts_dir = str(path.parent)
+    skill_local = {p.stem for p in path.parent.glob("*.py")}
+    shadowed = {name: sys.modules.pop(name) for name in skill_local if name in sys.modules}
+
+    spec = importlib.util.spec_from_file_location(f"_fp_probe_{index}", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, scripts_dir)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(scripts_dir)
+        for name in skill_local:
+            sys.modules.pop(name, None)
+        sys.modules.update(shadowed)
+    return module
+
+
+@pytest.fixture(scope="module")
+def implementations():
+    loaded = []
+    for index, (rel_path, attr) in enumerate(FINGERPRINT_IMPLEMENTATIONS):
+        module = _load(rel_path, index)
+        assert hasattr(module, attr), f"{rel_path} lost {attr}"
+        loaded.append((rel_path, module, getattr(module, attr)))
+    return loaded
+
+
+def test_every_skill_fingerprints_identical_bytes_identically(implementations, tmp_path):
+    sample = tmp_path / "asset.bin"
+    sample.write_bytes(b"video-recap-skills" * 5000)
+    digests = {rel: fn(sample) for rel, _module, fn in implementations}
+
+    assert len(set(digests.values())) == 1, f"implementations disagree: {digests}"
+    # sha256 over content, so an independent copy at a different path matches
+    copy = tmp_path / "copied.bin"
+    copy.write_bytes(sample.read_bytes())
+    for rel, _module, fn in implementations:
+        assert fn(copy) == digests[rel], f"{rel} is not content-addressed"
+
+
+def test_fingerprint_memo_never_serves_a_stale_digest(implementations, tmp_path):
+    """The in-process memo is keyed on identity metadata, but the guarantee callers rely
+    on is content-addressing: rewriting a file in place must yield a new digest."""
+    for rel, _module, fn in implementations:
+        target = tmp_path / f"{Path(rel).parent.parent.name}.bin"
+        target.write_bytes(b"before")
+        first = fn(target)
+
+        # Same length, so size cannot distinguish the two revisions and only mtime can.
+        # mtime is advanced explicitly rather than trusting the host clock resolution, so
+        # the assertion exercises the memo key itself on every filesystem CI runs on.
+        target.write_bytes(b"after!")
+        stat = os.stat(target)
+        os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+        assert fn(target) != first, f"{rel} served a stale memoized digest"
+
+        target.write_bytes(b"before")
+        stat = os.stat(target)
+        os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns + 2_000_000))
+        assert fn(target) == first, f"{rel} lost content-addressing on rewrite"
+
+
+def test_fingerprint_is_memoized_within_a_process(implementations, tmp_path):
+    """One understanding run fingerprints the source video 8-10 times and the whole
+    extracted frame set 2-3 times. Without a memo that is gigabytes of redundant reads
+    before any real work starts."""
+    for rel, module, fn in implementations:
+        target = tmp_path / f"memo_{Path(rel).parent.parent.name}.bin"
+        target.write_bytes(b"x" * 100_000)
+        reads = {"count": 0}
+        real_open = module.open if hasattr(module, "open") else open
+
+        def counting_open(*args, **kwargs):
+            reads["count"] += 1
+            return real_open(*args, **kwargs)
+
+        module.open = counting_open
+        try:
+            digests = {fn(target) for _ in range(5)}
+        finally:
+            if real_open is open:
+                del module.open
+            else:  # pragma: no cover - module never shadows open today
+                module.open = real_open
+
+        assert len(digests) == 1
+        assert reads["count"] == 1, f"{rel} re-read the file {reads['count']} times"
+
+
+def test_memo_key_includes_size_and_mtime(implementations, tmp_path):
+    target = tmp_path / "identity.bin"
+    target.write_bytes(b"abc")
+    for rel, module, _fn in implementations:
+        identity = module._file_identity(target)
+        stat = os.stat(target)
+        assert identity == (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns), rel

--- a/tests/understanding/test_frame_timing.py
+++ b/tests/understanding/test_frame_timing.py
@@ -1,0 +1,156 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'skills' / 'video-understanding' / 'scripts'))
+"""The frame-number ↔ source-time contract owned by extract.py.
+
+ffmpeg's `fps` filter emits its FIRST frame at source time 0, while the image2 muxer
+numbers files from 1. So frame_00001.jpg is t=0 and frame n is (n-1)/fps. Getting this
+backwards shifts every visual anchor (frame_facts, scene→frame assignment, storyboard
+labels) later by 1/fps — a full second at the default fps=1 used for videos over 5 min.
+"""
+import shutil
+import subprocess
+
+import pytest
+
+import storyboard
+import vlm
+from extract import (
+    FRAME_START_NUMBER,
+    frame_number_for_time,
+    frame_time,
+    parse_frame_number,
+)
+from lib import CONFIG
+from vlm import analyze_scenes
+
+
+def test_first_extracted_frame_is_source_time_zero():
+    assert frame_time(1, 1.0) == 0.0
+    assert frame_time(1, 2.0) == 0.0
+    assert frame_time(2, 1.0) == 1.0
+    assert frame_time(2, 2.0) == 0.5
+    assert frame_time(31, 1.5) == 20.0
+
+
+def test_frame_time_and_frame_number_round_trip():
+    for fps in (1.0, 1.5, 2.0):
+        for number in (1, 2, 7, 100):
+            assert frame_number_for_time(frame_time(number, fps), fps) == pytest.approx(number)
+
+
+def test_frame_time_rejects_non_positive_fps():
+    for bad in (0, -1.0):
+        with pytest.raises(ValueError):
+            frame_time(1, bad)
+        with pytest.raises(ValueError):
+            frame_number_for_time(0.0, bad)
+
+
+def test_parse_frame_number_ignores_foreign_names(tmp_path):
+    assert parse_frame_number(tmp_path / "frame_00007.jpg") == 7
+    assert parse_frame_number(tmp_path / "storyboard.jpg") is None
+    assert parse_frame_number(tmp_path / "frame_x_1.jpg") is None
+
+
+def test_vlm_labels_frames_with_corrected_source_time(monkeypatch, tmp_path):
+    """The 帧时间点 header injected into the VLM prompt drives frame_facts, which the writing
+    brief presents as authoritative visual anchors. frame_00001 must be labelled 0.0s."""
+    frames = []
+    for n in (1, 2, 3):
+        f = tmp_path / f"frame_{n:05d}.jpg"
+        f.write_bytes(b"\xff\xd8\xff\xd9")
+        frames.append(f)
+    monkeypatch.setitem(CONFIG, "fps", 1.0)
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_workers", 1)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    seen = []
+
+    def fake_api_call(payload):
+        seen.append(payload["messages"][0]["content"][-1]["text"])
+        return {"choices": [{"message": {"content": "【描述】测试画面"}}]}
+
+    monkeypatch.setattr("vlm.api_call", fake_api_call)
+    analyze_scenes([{"start": 0.0, "end": 2.0}], frames, tmp_path)
+
+    assert seen and seen[0].startswith("帧时间点: 0.0s, 1.0s, 2.0s")
+
+
+def test_storyboard_resolves_source_time_through_the_same_contract(tmp_path):
+    """storyboard tiles and VLM anchors must agree; both go through extract.py."""
+    numbers = [1, 2, 3, 4]
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    for n in numbers:
+        (frames_dir / f"frame_{n:05d}.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+    paths, found = storyboard._frame_index(tmp_path)
+    assert found == numbers
+    assert storyboard._nearest_existing_frame(0.0, 1.0, paths, found).name == "frame_00001.jpg"
+    assert storyboard._nearest_existing_frame(2.0, 1.0, paths, found).name == "frame_00003.jpg"
+
+
+def test_vlm_frame_base64_cache_is_bounded(monkeypatch, tmp_path):
+    """The per-frame base64 cache used to be an unbounded dict, so the whole extracted frame
+    set stayed resident (base64 is 1/3 larger than the JPEG) for the entire VLM stage —
+    hundreds of MB on a 40-minute video. Only nearby scenes can reuse a frame anyway."""
+    frames = []
+    for n in range(1, 41):
+        f = tmp_path / f"frame_{n:05d}.jpg"
+        f.write_bytes(b"\xff\xd8" + bytes([n]) * 2048 + b"\xff\xd9")
+        frames.append(f)
+    monkeypatch.setitem(CONFIG, "fps", 1.0)
+    monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
+    monkeypatch.setitem(CONFIG, "vlm_workers", 1)
+    monkeypatch.setitem(CONFIG, "vlm_max_frames", 3)
+    monkeypatch.setitem(CONFIG, "context_info", "")
+    monkeypatch.setattr(
+        "vlm.api_call",
+        lambda payload: {"choices": [{"message": {"content": "【描述】x"}}]},
+    )
+    caches = []
+    real_ordered_dict = vlm.OrderedDict
+    monkeypatch.setattr(
+        "vlm.OrderedDict", lambda *a, **k: caches.append(real_ordered_dict(*a, **k)) or caches[-1]
+    )
+
+    scenes = [{"start": float(i), "end": float(i) + 1.0} for i in range(39)]
+    analyze_scenes(scenes, frames, tmp_path)
+
+    assert caches, "analyze_scenes no longer builds a frame cache"
+    capacity = max(8, 3 * 1)
+    assert len(caches[0]) <= capacity, f"cache grew to {len(caches[0])} entries"
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not available",
+)
+def test_extracted_frame_numbering_matches_real_ffmpeg_pts(tmp_path):
+    """Pin the contract to what ffmpeg actually does, not to what we assume it does."""
+    source = tmp_path / "src.mp4"
+    subprocess.run(
+        ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+         "-f", "lavfi", "-i", "testsrc2=size=160x120:rate=30:duration=5",
+         "-pix_fmt", "yuv420p", str(source)],
+        check=True,
+    )
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-f", "lavfi", "-i", f"movie={source},fps=1",
+         "-show_entries", "frame=pts_time", "-of", "csv=p=0"],
+        capture_output=True, text=True, check=True,
+    )
+    emitted = [float(line) for line in probe.stdout.split() if line.strip()]
+
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    subprocess.run(
+        ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", str(source),
+         "-vf", "fps=1", "-q:v", "2", "-start_number", str(FRAME_START_NUMBER),
+         str(frames_dir / "frame_%05d.jpg")],
+        check=True,
+    )
+    written = sorted(frames_dir.glob("frame_*.jpg"))
+    assert len(written) == len(emitted)
+    for path, pts in zip(written, emitted):
+        assert frame_time(parse_frame_number(path), 1.0) == pytest.approx(pts, abs=1e-6)

--- a/tests/understanding/test_vlm_fixes.py
+++ b/tests/understanding/test_vlm_fixes.py
@@ -104,12 +104,13 @@ def test_analyze_scenes_sends_the_editorial_evidence_prompt_to_vlm(monkeypatch, 
 
 def _three_scene_setup(monkeypatch, tmp_path, workers):
     frames = []
-    for n in (1, 2, 3):
+    for n in (1, 2, 3, 4):
         f = tmp_path / f"frame_{n:05d}.jpg"
         f.write_bytes(b"\xff\xd8\xff\xd9")
         frames.append(f)
     scenes = [{"start": 0.5, "end": 1.5}, {"start": 1.5, "end": 2.5}, {"start": 2.5, "end": 3.5}]
-    monkeypatch.setitem(CONFIG, "fps", 1.0)        # frame_0000N -> t = N seconds, one frame per scene
+    # frame_0000N -> t = (N-1)/fps, so frames land at 0/1/2/3s and each scene owns exactly one.
+    monkeypatch.setitem(CONFIG, "fps", 1.0)
     monkeypatch.setitem(CONFIG, "vlm_model", "mimo-v2.5")
     monkeypatch.setitem(CONFIG, "vlm_workers", workers)
     monkeypatch.setitem(CONFIG, "context_info", "")
@@ -247,10 +248,10 @@ def test_retry_text_keeps_frame_timestamp_header(monkeypatch, tmp_path):
         analyze_scenes(scenes, [frame], tmp_path)
 
     assert len(retry_texts) == 3
-    # frame_00001.jpg @ fps=1.0 -> 1.0s ; header must appear on every attempt incl. retries
+    # frame_00001.jpg @ fps=1.0 -> 0.0s ; header must appear on every attempt incl. retries
     for text in retry_texts:
         assert "帧时间点" in text
-        assert "1.0s" in text
+        assert "0.0s" in text
     # retry attempts also carry the explicit format reminder
     assert "请务必按格式输出，不要留空。" in retry_texts[1]
     assert "请务必按格式输出，不要留空。" in retry_texts[2]

--- a/tests/voiceover/test_pure_voiceover.py
+++ b/tests/voiceover/test_pure_voiceover.py
@@ -168,6 +168,61 @@ def test_synthesize_tts_reuses_complete_cache_without_mimo_key(monkeypatch, tmp_
     assert segments[0]["narration"] == "离线复用。"
 
 
+def test_cached_reuse_does_not_reprobe_duration_with_ffprobe(monkeypatch, tmp_path):
+    """The sidecar's audio_fingerprint already proves these bytes produced audio_duration,
+    so a fully-cached rerun should not spawn one ffprobe per narration block."""
+    narration = [
+        {"start": float(i) * 2, "end": float(i) * 2 + 2, "narration": f"第{i}块。"}
+        for i in range(5)
+    ]
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "")
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+
+    for i, seg in enumerate(narration):
+        wav = tts_dir / f"narr_{i:03d}.wav"
+        wav.write_bytes(f"cached-{i}".encode())
+        text, _out, rate, _pitch, cache_key = voiceover._prepare_tts_segment(
+            i, seg, narration, tts_dir, "mimo-tts"
+        )
+        voiceover._write_tts_segment_cache(wav, cache_key, text, 1.25, _parse_rate_offset(rate))
+
+    probes = []
+    monkeypatch.setattr(
+        "voiceover._get_audio_duration", lambda path: probes.append(path) or 1.25
+    )
+
+    segments, _engine = synthesize_tts(narration, tmp_path)
+
+    assert [s["audio_duration"] for s in segments] == [1.25] * 5
+    assert probes == [], f"cached reuse still probed {len(probes)} times"
+
+
+def test_cached_reuse_falls_back_to_probe_for_legacy_sidecars(monkeypatch, tmp_path):
+    """Sidecars written before audio_duration was recorded must still be reusable."""
+    narration = [{"start": 0.0, "end": 2.0, "narration": "旧缓存。"}]
+    tts_dir = tmp_path / "tts_segments"
+    tts_dir.mkdir()
+    monkeypatch.setitem(CONFIG, "mimo_tts_api_key", "")
+    monkeypatch.setitem(CONFIG, "tts_dynamic_params", False)
+    wav = tts_dir / "narr_000.wav"
+    wav.write_bytes(b"legacy")
+    text, _out, rate, _pitch, cache_key = voiceover._prepare_tts_segment(
+        0, narration[0], narration, tts_dir, "mimo-tts"
+    )
+    voiceover._write_tts_segment_cache(wav, cache_key, text, 1.25, _parse_rate_offset(rate))
+    sidecar = voiceover._tts_segment_cache_path(wav)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    del payload["audio_duration"]
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr("voiceover._get_audio_duration", lambda path: 1.75)
+    segments, _engine = synthesize_tts(narration, tmp_path)
+
+    assert segments[0]["audio_duration"] == 1.75
+
+
 def test_synthesize_tts_voiceclone_cache_does_not_transcode_reference(monkeypatch, tmp_path):
     narration = [{"start": 0.0, "end": 2.0, "narration": "克隆缓存复用。"}]
     ref = tmp_path / "voice.wav"


### PR DESCRIPTION
Deep review of the pipeline. Every item below has a repro or a measurement; each is a separate commit.

## Bugs

**Frame timestamps were off by `1/fps`.** ffmpeg's `fps` filter emits its first frame at source time 0, while the image2 muxer numbers files from 1 — so `frame_00001.jpg` is `t=0` and frame *n* is `(n-1)/fps`. `vlm.py` computed `n/fps`. Verified against real ffmpeg:

```
fps=1 emitted PTS: 0.0 1.0 2.0 3.0 4.0 5.0
files written:     frame_00001 … frame_00006
```

Those timestamps go into the VLM prompt as `帧时间点:`, come back as `frame_facts`, and are presented to the writing agent as authoritative visual anchors — so narration was systematically anchored late by a full second on any video over 5 minutes (the default `fps=1`). Scene→frame assignment and storyboard tile labels shifted with them.

The mapping now has a single owner in `extract.py`, and the frames/VLM cache keys carry a convention version so artifacts computed under the old mapping are recomputed rather than silently reused. A new test pins the contract to ffmpeg's actual PTS output instead of to our assumption.

**Sources with cover art failed to render.** `assemble.py` mapped `0:v`, which matches every video stream. A file carrying attached cover art has two, `-vf` only applies to the first, and ffmpeg aborts:

```
[out#0/mp4] Could not write header (incorrect codec parameters ?): Invalid argument
Conversion failed!          # leaves an unreadable file
```

At the last step of the pipeline, after all the API spend. Now `0:v:0`, with a test that fails on the old code.

**`--clip-padding` rejected ordinary plans.** Overlap was judged on padded ranges, so any two back-to-back clips looked like duplicate footage:

```
clips [(0,10), (10,20)], clip_padding=0.5
  -> ValueError: clip #2 overlaps an earlier source range
```

Now judged on what the agent authored; genuinely duplicated footage is still rejected.

**`CLIP_PADDING` never did anything.** Declared in all six `lib.py` CONFIGs and reported as active via `clip_padding_source`, but video-cut — the only skill implementing padding — read the CLI flag alone.

Also: multi-source speech evidence read `asr_result.json` before `asr_clean.json`, the opposite of every other consumer; three CONFIG keys were read with inline defaults but never declared, so they could not be tuned; `silencedetect` had a constant 120s timeout with no handler while every other failure in that function fails open; multi-source sentence-truncation blockers were propagated only inside an unrelated condition; `_merge_short_scenes` had `if`/`elif` branches with identical bodies.

## Performance

`file_fingerprint` is now memoized per process. One understanding run fingerprints the source video 8–10 times and the whole extracted frame set 2–3 times — roughly 2400 full-resolution JPEGs on a 40-minute video at `fps=1`, all before any real work starts. Content-addressing is unchanged; identity metadata is only the memo key. **10x** on repeated hashes of a 200MB file, and it removes video-cut's double hashing on the reuse path for free.

- `vlm.py` held every frame's base64 (a third larger than the JPEG) in an unbounded dict for the whole stage — hundreds of MB resident on a long video. Now an LRU sized to what neighbouring scenes can reuse.
- Its resume cache was rewritten in full after every scene (quadratic write volume, serialized on the result loop). Now per batch, still persisting on failure and interrupt.
- `_normalize_tts_wav_rms` walked the audio three times in pure Python, including decoding the *output* back just to measure it. `array('h')` decodes in C and the statistics accumulate during normalization: byte-identical audio and metadata, **2.3x** per block, on every segment.
- Cached TTS reuse re-probed each block with ffprobe although the sidecar's `audio_fingerprint` had already proved those bytes produced the recorded duration — one subprocess per block on a fully-cached rerun.
- Black/white scene filtering (one ffmpeg per probe point, hundreds of scenes) now runs parallel across scenes, keeping the short-circuit that makes a normal scene cost one probe.

## Build

`pyproject.toml` now states the ruff ruleset explicitly. **CI installs ruff unpinned and ruff 0.16 widened its implicit default `select`, so `ruff check skills tests scripts` fails at HEAD today with 367 errors** on any new PR. Verified green on both 0.9.10 and 0.16.0. `scripts/test.py` also distinguishes "pytest not installed" from real test failures.

## Structure

A cross-skill test now holds all seven copies of the fingerprint helper to one behaviour — they are compared against each other in practice (video-cut writes `edited_source.mp4.meta.json`, recap and assemble read it) and nothing linked them. `recap_runner`'s duplicated `source_record` construction and pause banner are shared. `voiceover.py`'s normalization moved to `tts_audio.py` to stay within the repo's 800-line per-module budget.

## Deliberately not included

- **The ~3300 lines duplicated byte-for-byte between `video-understanding` and `video-script`**, and the five `lib.py` copies that are 67–93% identical. `narration_coverage_max` above is a direct symptom, but self-contained skills are a stated design choice (see `conftest.py`) — reversing it belongs in its own PR, not bundled with bug fixes.
- **Replacing `shutil.copy2(output.mp4 → recap_*.mp4)` with a hardlink.** `output.mp4` is a documented artifact that `final_qc` reads, so both paths must survive; hardlinking is only safe if the render also unlinks before writing, or a later run silently rewrites an already-delivered file. Not worth that invariant for one file copy.

## Testing

`python scripts/test.py` green: 149 / 62 / 68 / 287 / 104 / 197 / 24. `ruff check skills tests scripts` clean on ruff 0.9.10 and 0.16.0.

Six `tests/assemble` real-render tests fail on my machine both before and after these changes — this host's ffmpeg 8.1.1 has no libass, so the `subtitles` filter is missing. They pass wherever ffmpeg can burn subtitles and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)