### PR TITLE
Declare each config knob only in the skill that reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project are documented here. This project adheres to
 - **`CLIP_PADDING` 环境变量此前完全无效。** 六份 CONFIG 都声明了该键并通过 `clip_padding_source` 汇报为生效，但唯一实现 padding 的 video-cut 只读 CLI 参数。
 - 多视频输出时间线的 speech 证据改为与 `audio_mix` / `sentence_boundaries` 一致优先读 `asr_clean.json`；`narration_coverage_max` 等三个只读不声明的 CONFIG 键补齐；`silencedetect` 超时改为与该函数其余失败路径一致地 fail-open；多源剪辑的句子截断阻断项不再挂在无关条件下。
 
+### 变更
+
+- **每个配置旋钮只声明在读它的技能里。** 六份 `lib.py` 中有五份此前携带所有技能配置的并集（各 155–173 个键，其中 95–132 个该技能从不读取）；`video-cut` 一直是反例（8 个键，全部使用）。现在各技能只声明自己读取的键，删除 583 条无效声明。保留集由运行时插桩实测得出（按调用栈把 parity 测试的读取与生产代码的读取区分开），而非静态匹配——这也是发现下列两处问题的方式。
+  - `zone_fade_seconds` 在五份副本中均有声明，但**全仓库无任何读取点**，此前仅靠「副本之间取值一致」的断言存活。
+  - `CLIP_PADDING` 在 `video-cut` 中依然无效：该技能的 `lib.py` 从未声明此键，查表始终落到内联默认值。
+- **音频策略一致性断言改为按实际声明范围校验。** 此前断言五份副本对约 30 个音频键取值一致，而多数技能并不读取它们——这种一致性是复制行为自身造成的循环要求。新增不变量：**任何技能不得声明自身从不读取的配置**，从结构上杜绝上述两类问题复现。
+
 ### 性能
 
 - **不再重复哈希/解码/探测同一批字节。** `file_fingerprint` 按进程记忆化（内容寻址不变，仅用 dev/inode/size/mtime_ns 作记忆键）：一次理解流程原本要对源视频做 8–10 次全量 sha256、对整套抽帧做 2–3 遍，40 分钟视频约 2400 张全分辨率 JPEG。VLM 的逐帧 base64 缓存由无上界字典改为 LRU；续传缓存由每个场景整份重写改为按批落盘；TTS 响度归一从三遍纯 Python 遍历改为 `array('h')` 单遍（输出字节与元数据完全一致）；命中缓存的 TTS 段不再逐段 ffprobe；黑/白帧场景过滤按场景并行。

--- a/skills/video-assemble/scripts/lib.py
+++ b/skills/video-assemble/scripts/lib.py
@@ -86,26 +86,6 @@ def env_float(name, default, *, minimum=None):
 # (MIMO_VIDEO_API_KEY / MIMO_TTS_API_KEY / MIMO_ASR_API_KEY and their *_API_URL forms)
 # are optional and fall back to MIMO_API_KEY / MIMO_API_URL. Token-Plan keys (tp-*) auto-
 # route to the Token-Plan cluster base URL; pay-as-you-go keys use api.xiaomimimo.com.
-_mimo_api_key = os.environ.get("MIMO_API_KEY", "")
-_mimo_video_api_key = os.environ.get("MIMO_VIDEO_API_KEY", "") or _mimo_api_key
-_mimo_tts_api_key = os.environ.get("MIMO_TTS_API_KEY", "") or _mimo_api_key
-_mimo_asr_api_key = os.environ.get("MIMO_ASR_API_KEY", "") or _mimo_api_key
-_raw_api_url = os.environ.get("MIMO_API_URL") or default_mimo_api_url(_mimo_api_key)
-_raw_mimo_video_api_url = (
-    os.environ.get("MIMO_VIDEO_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_video_api_key)
-)
-_raw_mimo_tts_api_url = (
-    os.environ.get("MIMO_TTS_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_tts_api_key)
-)
-_raw_mimo_asr_api_url = (
-    os.environ.get("MIMO_ASR_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_asr_api_key)
-)
 
 # Cross-language source: when the original audio is in a language the narration is NOT in
 # (e.g. a Japanese drama recapped in Chinese), the original speech bleeding under the narration
@@ -116,100 +96,8 @@ _foreign_source_audio = env_bool("FOREIGN_SOURCE_AUDIO", False)
 _foreign_under_narration_volume = 0.05  # original volume under narration when source audio is foreign
 
 CONFIG = {
-    "api_provider": "mimo",
-    "api_provider_source": "default",
-    "api_url": normalize_api_url(_raw_api_url),
-    "api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
-    "api_key": _mimo_api_key,
-    "api_key_source": "MIMO_API_KEY",
-    "mimo_api_url": normalize_api_url(_raw_api_url),
-    "mimo_api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
-    "mimo_api_key": _mimo_api_key,
-    "mimo_api_key_source": "MIMO_API_KEY",
-    "mimo_video_api_url": normalize_api_url(_raw_mimo_video_api_url),
-    "mimo_video_api_url_source": "env" if (
-        os.environ.get("MIMO_VIDEO_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_video_api_key": _mimo_video_api_key,
-    "mimo_video_api_key_source": "MIMO_VIDEO_API_KEY" if os.environ.get("MIMO_VIDEO_API_KEY") else "MIMO_API_KEY",
-    "mimo_tts_api_url": normalize_api_url(_raw_mimo_tts_api_url),
-    "mimo_tts_api_url_source": "env" if (
-        os.environ.get("MIMO_TTS_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_tts_api_key": _mimo_tts_api_key,
-    "mimo_tts_api_key_source": "MIMO_TTS_API_KEY" if os.environ.get("MIMO_TTS_API_KEY") else "MIMO_API_KEY",
-    "mimo_asr_api_url": normalize_api_url(_raw_mimo_asr_api_url),
-    "mimo_asr_api_url_source": "env" if (
-        os.environ.get("MIMO_ASR_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_asr_api_key": _mimo_asr_api_key,
-    "mimo_asr_api_key_source": "MIMO_ASR_API_KEY" if os.environ.get("MIMO_ASR_API_KEY") else "MIMO_API_KEY",
-    "mimo_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
-    "mimo_video_model": os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_video_model_source": "env" if (
-        os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL")
-    ) else "default",
-    "vlm_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "vlm_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
-    "mimo_asr_model": os.environ.get("MIMO_ASR_MODEL", DEFAULT_MIMO_ASR_MODEL),
-    "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
-    "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
-    "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
-    # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
-    # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
-    "scene_threshold": 0.1,
-    "scene_threshold_source": "default",
-    "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),
-    "mimo_tts_model_source": "env" if os.environ.get("MIMO_TTS_MODEL") else "default",
-    "mimo_tts_voice": os.environ.get("MIMO_TTS_VOICE", "冰糖"),
-    "mimo_tts_voice_source": "env" if os.environ.get("MIMO_TTS_VOICE") else "default",
-    "mimo_tts_style": os.environ.get(
-        "MIMO_TTS_STYLE",
-        "自然、清晰、有感染力，像在给观众讲故事；随剧情起伏，该紧张时紧张、该动情时动情，不平铺直叙。",
-    ),
-    "mimo_tts_style_source": "env" if os.environ.get("MIMO_TTS_STYLE") else "default",
-    "mimo_media_resolution": os.environ.get("MIMO_MEDIA_RESOLUTION", "default"),
-    "mimo_media_resolution_source": "env" if os.environ.get("MIMO_MEDIA_RESOLUTION") else "default",
-    "mimo_video_overview": env_bool("MIMO_VIDEO_OVERVIEW", False),  # opt-in (--mimo-video-overview / =1); when on it becomes the PRIMARY per-scene description, frames stay the anchor/fallback
-    "mimo_video_overview_source": "env" if os.environ.get("MIMO_VIDEO_OVERVIEW") else "default",
-    "mimo_video_fps": env_float("MIMO_VIDEO_FPS", 3.0, minimum=0.1),
-    "mimo_video_fps_source": "env" if os.environ.get("MIMO_VIDEO_FPS") else "default",
-    "mimo_video_chunk_max_seconds": env_float("MIMO_VIDEO_CHUNK_MAX_SECONDS", 20.0, minimum=1.0),
-    "mimo_video_chunk_min_seconds": env_float("MIMO_VIDEO_CHUNK_MIN_SECONDS", 1.0, minimum=0.2),
-    "mimo_video_chunk_timeout": env_int("MIMO_VIDEO_CHUNK_TIMEOUT", 180, minimum=1),
-    "mimo_video_base64_max_mb": env_float("MIMO_VIDEO_BASE64_MAX_MB", 45.0, minimum=1.0),
-    # Per-scene frame VLM sampling — scale frames with scene length instead of a hard cap of 6
-    "vlm_seconds_per_frame": env_float("VLM_SECONDS_PER_FRAME", 4.0, minimum=0.5),
-    "vlm_max_frames": env_int("VLM_MAX_FRAMES", 16, minimum=3),
-    "vlm_max_tokens": env_int("VLM_MAX_TOKENS", 1500, minimum=200),
-    "mimo_video_prompt": os.environ.get(
-        "MIMO_VIDEO_PROMPT",
-        "请用中文分析这个视频分片的主要人物、场景变化、关键动作、情绪走向和剧情冲突，"
-        "重点提取适合写短视频解说的故事线索。不要泛泛复述画面，要标出对后续写稿有用的信息。",
-    ),
-    "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
-    "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
-    "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
-    # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
-    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
-    # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
-    "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
-    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
-    "narration_coverage_min": 0.5,      # below this coverage → under_narrated
-    "narration_block_seconds": 9.0,     # block cadence used to derive target block count
-    "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
-    "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
     "fade_ms": env_int("FADE_MS", 120, minimum=0),  # 每段 TTS 淡入淡出(ms)；过大会让紧凑的句子一顿一顿，120ms 防爆音又不发闷
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
-    # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
-    "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
-    "min_segments_per_minute": 6.24,     # legacy single-pass cut mapping report only
-    "max_narration_gap_seconds": 11.0,   # legacy single-pass cut mapping report only
     "ducking_mode": "fixed",  # fixed | sidechaincompress | none
     "ducking_threshold": 0.15,
     "ducking_ratio": 3,
@@ -219,10 +107,11 @@ CONFIG = {
     "ducking_makeup": 1.2,
     "ducking_narr_weight": 1.5,
     "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
-    "foreign_source_audio": _foreign_source_audio,  # 原声语言≠解说语言：解说下原声压到近静音(消除"怪音"双语重叠)
+    # Derived report of the FOREIGN_SOURCE_AUDIO knob this skill implements: it selects the
+    # ducking volumes below. Declared so callers can see which policy is in effect.
+    "foreign_source_audio": _foreign_source_audio,
     "zone_ducking_volume": env_float("ZONE_DUCKING_VOLUME",
         _foreign_under_narration_volume if _foreign_source_audio else 0.12, minimum=0.0),  # 解说时原声压低到的音量
-    "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
     "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说块之间的"原声块"音量：默认满音量(1.0)，让精彩原声整段放出来，不被压低（用户要求解说成块、原声也成块）
     "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 解说块/原声块切换的淡入淡出(秒)，略放宽到 0.3 让满音量↔压低的过渡更顺
     "duck_bridge_seconds": env_float("DUCK_BRIDGE_SECONDS", 1.5, minimum=0.0),  # 仅把间隔小于此值的相邻解说窗口并成一段压低；超过则视为作者特意留的"原声块"，原声放回满音量。默认 1.5s：解说块内部连续压低，块与块之间的留白放出满音量原声。该值只控制短间隔合并，不设定旁白/原声配额。调大→更连续铺底、原声块更少；调小→更碎
@@ -256,42 +145,8 @@ CONFIG = {
     "narration_max_pull_seconds": env_float("NARRATION_MAX_PULL_SECONDS", 1.2, minimum=0.0),  # 收紧时一句最多比作者标注提前的秒数（漂移上限，越小越贴画面）
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断
     "quiet_overlap_min_ratio": 0.8,  # 解说段至少多少比例落在安静窗口内才标记为非对白重叠
-    "visual_beat_max_seconds": 18.0,  # 单段解说超过该时长且跨多个帧锚点时给 lint 提醒
-    "visual_beat_max_facts": 3,  # 单段解说最多建议覆盖的 frame_facts 锚点数量
-    "asr_chunk_min_chars": env_int("ASR_CHUNK_MIN_CHARS", 500, minimum=1),  # brief 中 ASR 写作分块最小字数/词数
-    "asr_chunk_max_chars": env_int("ASR_CHUNK_MAX_CHARS", 800, minimum=1),  # brief 中 ASR 写作分块最大字数/词数
     "speech_ducking_volume": env_float("SPEECH_DUCKING_VOLUME",
         _foreign_under_narration_volume if _foreign_source_audio else 0.2, minimum=0.0),    # 解说与对白重叠时原声音量
-    "silence_noise_threshold": "-25dB",  # ffmpeg silencedetect 噪声阈值
-    "silence_min_duration": 0.3,     # 静音最短持续秒数
-    "quiet_window_min": 1.0,         # 可放解说的安静窗口最短秒数
-    "silence_merge_gap": 0.5,        # 相邻静音段间隔<此值时合并
-    "scene_merge_min": 4.0,         # 场景合并最短时长，<此值的场景合并到相邻场景
-    "scene_junk_filter": env_bool("SCENE_JUNK_FILTER", True),  # 过滤连续黑/白帧无效过渡场景
-    "scene_junk_dark_luma": env_float("SCENE_JUNK_DARK_LUMA", 8.0, minimum=0.0),
-    "scene_junk_bright_luma": env_float("SCENE_JUNK_BRIGHT_LUMA", 245.0, minimum=0.0),
-    "scene_junk_pixel_ratio": env_float("SCENE_JUNK_PIXEL_RATIO", 0.995, minimum=0.0),
-    "context_info": "",              # 额外上下文（节目名、角色名等）
-    "context_info_source": "default",
-    "fps_source": "default",
-    "style": "纪录片",               # 解说风格（resume 时随 run_settings 持久化/恢复）
-    "style_source": "default",
-    "tts_dynamic_params": True,  # 启用动态语速调节
-    "vlm_workers": env_int("VLM_WORKERS", 8, minimum=1),  # VLM 并行分析线程数
-    "tts_workers": env_int("TTS_WORKERS", 4, minimum=1),  # TTS 并行合成线程数
-    "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
-    "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
-    "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
-    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
-    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
-    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
-    "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
-    "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
-    "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
-    "target_duration_source": "env" if os.environ.get("TARGET_DURATION") else "default",
-    "clip_padding": env_float("CLIP_PADDING", 0.0, minimum=0.0),  # cut 模式片段两端扩展秒数
-    "clip_padding_source": "env" if os.environ.get("CLIP_PADDING") else "default",
-    "allow_clip_overlap": env_bool("ALLOW_CLIP_OVERLAP", False),  # cut 模式是否允许重复/重叠使用原片
     "burn_subtitles": env_bool("BURN_SUBTITLES", True),  # 烧录解说字幕（默认开；遮挡原字幕后需自带字幕，否则字幕区空白）
     "subtitle_original_in_gaps": env_bool("SUBTITLE_ORIGINAL_IN_GAPS", True),  # 原声留白处补烧原声台词字幕（来自 ASR）
     "force_video_reencode": env_bool("FORCE_VIDEO_REENCODE", False),  # 组装时重编码视频，修复部分容器时间戳问题

--- a/skills/video-recap/scripts/lib.py
+++ b/skills/video-recap/scripts/lib.py
@@ -110,187 +110,36 @@ _raw_mimo_asr_api_url = (
 
 CONFIG = {
     "api_provider": "mimo",
-    "api_provider_source": "default",
     "api_url": normalize_api_url(_raw_api_url),
     "api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
     "api_key": _mimo_api_key,
     "api_key_source": "MIMO_API_KEY",
-    "mimo_api_url": normalize_api_url(_raw_api_url),
-    "mimo_api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
-    "mimo_api_key": _mimo_api_key,
-    "mimo_api_key_source": "MIMO_API_KEY",
     "mimo_video_api_url": normalize_api_url(_raw_mimo_video_api_url),
-    "mimo_video_api_url_source": "env" if (
-        os.environ.get("MIMO_VIDEO_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
     "mimo_video_api_key": _mimo_video_api_key,
-    "mimo_video_api_key_source": "MIMO_VIDEO_API_KEY" if os.environ.get("MIMO_VIDEO_API_KEY") else "MIMO_API_KEY",
     "mimo_tts_api_url": normalize_api_url(_raw_mimo_tts_api_url),
     "mimo_tts_api_url_source": "env" if (
         os.environ.get("MIMO_TTS_API_URL") or os.environ.get("MIMO_API_URL")
     ) else "default",
     "mimo_tts_api_key": _mimo_tts_api_key,
-    "mimo_tts_api_key_source": "MIMO_TTS_API_KEY" if os.environ.get("MIMO_TTS_API_KEY") else "MIMO_API_KEY",
     "mimo_asr_api_url": normalize_api_url(_raw_mimo_asr_api_url),
     "mimo_asr_api_url_source": "env" if (
         os.environ.get("MIMO_ASR_API_URL") or os.environ.get("MIMO_API_URL")
     ) else "default",
     "mimo_asr_api_key": _mimo_asr_api_key,
     "mimo_asr_api_key_source": "MIMO_ASR_API_KEY" if os.environ.get("MIMO_ASR_API_KEY") else "MIMO_API_KEY",
-    "mimo_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
     "mimo_video_model": os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
     "mimo_video_model_source": "env" if (
         os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL")
     ) else "default",
-    "mimo_qc_model": os.environ.get("MIMO_QC_MODEL") or os.environ.get("MIMO_VIDEO_MODEL")
-    or os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_qc_model_source": "env" if os.environ.get("MIMO_QC_MODEL") else "fallback",
     "vlm_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
     "vlm_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
     "mimo_asr_model": os.environ.get("MIMO_ASR_MODEL", DEFAULT_MIMO_ASR_MODEL),
-    "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
-    "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
-    # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
-    # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
-    "scene_threshold": 0.1,
-    "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),
     "mimo_tts_model_source": "env" if os.environ.get("MIMO_TTS_MODEL") else "default",
     "mimo_tts_voice": os.environ.get("MIMO_TTS_VOICE", "冰糖"),
     "mimo_tts_voice_source": "env" if os.environ.get("MIMO_TTS_VOICE") else "default",
-    "mimo_tts_style": os.environ.get(
-        "MIMO_TTS_STYLE",
-        "自然、清晰、有感染力，像在给观众讲故事；随剧情起伏，该紧张时紧张、该动情时动情，不平铺直叙。",
-    ),
-    "mimo_tts_style_source": "env" if os.environ.get("MIMO_TTS_STYLE") else "default",
-    "mimo_media_resolution": os.environ.get("MIMO_MEDIA_RESOLUTION", "default"),
-    "mimo_media_resolution_source": "env" if os.environ.get("MIMO_MEDIA_RESOLUTION") else "default",
-    "mimo_video_overview": env_bool("MIMO_VIDEO_OVERVIEW", False),  # opt-in (--mimo-video-overview / =1); when on it becomes the PRIMARY per-scene description, frames stay the anchor/fallback
-    "mimo_video_overview_source": "env" if os.environ.get("MIMO_VIDEO_OVERVIEW") else "default",
-    "mimo_video_fps": env_float("MIMO_VIDEO_FPS", 3.0, minimum=0.1),
-    "mimo_video_fps_source": "env" if os.environ.get("MIMO_VIDEO_FPS") else "default",
-    "mimo_video_chunk_max_seconds": env_float("MIMO_VIDEO_CHUNK_MAX_SECONDS", 20.0, minimum=1.0),
-    "mimo_video_chunk_min_seconds": env_float("MIMO_VIDEO_CHUNK_MIN_SECONDS", 1.0, minimum=0.2),
-    "mimo_video_chunk_timeout": env_int("MIMO_VIDEO_CHUNK_TIMEOUT", 180, minimum=1),
-    "mimo_video_base64_max_mb": env_float("MIMO_VIDEO_BASE64_MAX_MB", 45.0, minimum=1.0),
-    # Per-scene frame VLM sampling — scale frames with scene length instead of a hard cap of 6
-    "vlm_seconds_per_frame": env_float("VLM_SECONDS_PER_FRAME", 4.0, minimum=0.5),
-    "vlm_max_frames": env_int("VLM_MAX_FRAMES", 16, minimum=3),
-    "vlm_max_tokens": env_int("VLM_MAX_TOKENS", 1500, minimum=200),
-    "mimo_video_prompt": os.environ.get(
-        "MIMO_VIDEO_PROMPT",
-        "请用中文分析这个视频分片的主要人物、场景变化、关键动作、情绪走向和剧情冲突，"
-        "重点提取适合写短视频解说的故事线索。不要泛泛复述画面，要标出对后续写稿有用的信息。",
-    ),
-    "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
-    "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
-    "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
-    # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
-    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
-    # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
-    "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
-    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
-    "narration_coverage_min": 0.5,      # below this coverage → under_narrated
-    "narration_block_seconds": 9.0,     # block cadence used to derive target block count
-    "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
-    "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
-    "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
-    # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
-    "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
-    "min_segments_per_minute": 6.24,     # legacy single-pass cut mapping report only
-    "max_narration_gap_seconds": 11.0,   # legacy single-pass cut mapping report only
-    "ducking_mode": "fixed",  # fixed | sidechaincompress | none
-    "ducking_threshold": 0.15,
-    "ducking_ratio": 3,
-    "ducking_attack": 10,
-    "ducking_release": 300,
-    "ducking_level_sc": 2.0,
-    "ducking_makeup": 1.2,
-    "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
-    "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
-    "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
-    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
-    "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
-    "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)
-    "jianying_draft_dir": os.environ.get("JIANYING_DRAFT_DIR", "").strip(),  # 剪映草稿输出父目录(留空=work_dir)
-    "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
-    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
-    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
-    "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
-    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
-    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
-    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
-    "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
-    "narration_delay_seconds": env_float("NARRATION_DELAY_SECONDS", 0.0, minimum=0.0),  # 默认严格采用 Agent 写入的 start；旧项目可显式恢复延迟
-    "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断
-    "quiet_overlap_min_ratio": 0.8,  # 解说段至少多少比例落在安静窗口内才标记为非对白重叠
-    "visual_beat_max_seconds": 18.0,  # 单段解说超过该时长且跨多个帧锚点时给 lint 提醒
-    "visual_beat_max_facts": 3,  # 单段解说最多建议覆盖的 frame_facts 锚点数量
-    "asr_chunk_min_chars": env_int("ASR_CHUNK_MIN_CHARS", 500, minimum=1),  # brief 中 ASR 写作分块最小字数/词数
-    "asr_chunk_max_chars": env_int("ASR_CHUNK_MAX_CHARS", 800, minimum=1),  # brief 中 ASR 写作分块最大字数/词数
-    "speech_ducking_volume": env_float("SPEECH_DUCKING_VOLUME", 0.2, minimum=0.0),    # 解说与对白重叠时原声音量
-    "silence_noise_threshold": "-25dB",  # ffmpeg silencedetect 噪声阈值
-    "silence_min_duration": 0.3,     # 静音最短持续秒数
-    "quiet_window_min": 1.0,         # 可放解说的安静窗口最短秒数
-    "silence_merge_gap": 0.5,        # 相邻静音段间隔<此值时合并
-    "scene_merge_min": 4.0,         # 场景合并最短时长，<此值的场景合并到相邻场景
-    "scene_junk_filter": env_bool("SCENE_JUNK_FILTER", True),  # 过滤连续黑/白帧无效过渡场景
-    "scene_junk_dark_luma": env_float("SCENE_JUNK_DARK_LUMA", 8.0, minimum=0.0),
-    "scene_junk_bright_luma": env_float("SCENE_JUNK_BRIGHT_LUMA", 245.0, minimum=0.0),
-    "scene_junk_pixel_ratio": env_float("SCENE_JUNK_PIXEL_RATIO", 0.995, minimum=0.0),
-    "context_info": "",              # 额外上下文（节目名、角色名等）
-    "context_info_source": "default",
-    "fps_source": "default",
-    "style": "纪录片",               # 解说风格（resume 时随 run_settings 持久化/恢复）
-    "style_source": "default",
-    "tts_dynamic_params": True,  # 启用动态语速调节
     "vlm_workers": env_int("VLM_WORKERS", 8, minimum=1),  # VLM 并行分析线程数
-    "tts_workers": env_int("TTS_WORKERS", 4, minimum=1),  # TTS 并行合成线程数
-    "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
-    "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
-    "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
-    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
-    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
-    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
-    "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
-    "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
-    "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
-    "target_duration_source": "env" if os.environ.get("TARGET_DURATION") else "default",
-    "clip_padding": env_float("CLIP_PADDING", 0.0, minimum=0.0),  # cut 模式片段两端扩展秒数
-    "clip_padding_source": "env" if os.environ.get("CLIP_PADDING") else "default",
-    "allow_clip_overlap": env_bool("ALLOW_CLIP_OVERLAP", False),  # cut 模式是否允许重复/重叠使用原片
-    "burn_subtitles": env_bool("BURN_SUBTITLES", True),  # 烧录解说字幕（默认开；遮挡原字幕后需自带字幕，否则字幕区空白）
-    "force_video_reencode": env_bool("FORCE_VIDEO_REENCODE", False),  # 组装时重编码视频，修复部分容器时间戳问题
-    # 成片末端整体响度归一（默认混音偏轻，归一后更接近常见短视频响度；样片约 -11.9，默认取更安全的 -14）
-    "final_loudnorm": env_bool("FINAL_LOUDNORM", True),  # 组装末端做一次整体响度归一
-    "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
-    "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
-    "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
-    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
-    "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
-    "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
-    "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
-    "subtitle_outline_color": os.environ.get("SUBTITLE_OUTLINE_COLOR", "&H00000000"),
-    "subtitle_outline": env_float("SUBTITLE_OUTLINE", 2.0, minimum=0.0),
-    "subtitle_shadow": env_float("SUBTITLE_SHADOW", 1.0, minimum=0.0),
-    "subtitle_margin_v": env_int("SUBTITLE_MARGIN_V", 48, minimum=0),
-    "subtitle_margin_l": env_int("SUBTITLE_MARGIN_L", 40, minimum=0),
-    "subtitle_margin_r": env_int("SUBTITLE_MARGIN_R", 40, minimum=0),
-    "subtitle_alignment": env_int("SUBTITLE_ALIGNMENT", 2, minimum=1),
-    "subtitle_max_chars": env_int("SUBTITLE_MAX_CHARS", 20, minimum=6),
-    "subtitle_play_res_x": env_int("SUBTITLE_PLAY_RES_X", 1280, minimum=1),
-    "subtitle_play_res_y": env_int("SUBTITLE_PLAY_RES_Y", 720, minimum=1),
 }
 
 def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):

--- a/skills/video-script/scripts/lib.py
+++ b/skills/video-script/scripts/lib.py
@@ -94,103 +94,33 @@ def env_float(name, default, *, minimum=None):
 # route to the Token-Plan cluster base URL; pay-as-you-go keys use api.xiaomimimo.com.
 _mimo_api_key = os.environ.get("MIMO_API_KEY", "")
 _mimo_video_api_key = os.environ.get("MIMO_VIDEO_API_KEY", "") or _mimo_api_key
-_mimo_tts_api_key = os.environ.get("MIMO_TTS_API_KEY", "") or _mimo_api_key
-_mimo_asr_api_key = os.environ.get("MIMO_ASR_API_KEY", "") or _mimo_api_key
 _raw_api_url = os.environ.get("MIMO_API_URL") or default_mimo_api_url(_mimo_api_key)
 _raw_mimo_video_api_url = (
     os.environ.get("MIMO_VIDEO_API_URL")
     or os.environ.get("MIMO_API_URL")
     or default_mimo_api_url(_mimo_video_api_key)
 )
-_raw_mimo_tts_api_url = (
-    os.environ.get("MIMO_TTS_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_tts_api_key)
-)
-_raw_mimo_asr_api_url = (
-    os.environ.get("MIMO_ASR_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_asr_api_key)
-)
 
 CONFIG = {
-    "api_provider": "mimo",
-    "api_provider_source": "default",
     "api_url": normalize_api_url(_raw_api_url),
-    "api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
     "api_key": _mimo_api_key,
     "api_key_source": "MIMO_API_KEY",
-    "mimo_api_url": normalize_api_url(_raw_api_url),
-    "mimo_api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
-    "mimo_api_key": _mimo_api_key,
-    "mimo_api_key_source": "MIMO_API_KEY",
     "mimo_video_api_url": normalize_api_url(_raw_mimo_video_api_url),
-    "mimo_video_api_url_source": "env" if (
-        os.environ.get("MIMO_VIDEO_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_video_api_key": _mimo_video_api_key,
-    "mimo_video_api_key_source": "MIMO_VIDEO_API_KEY" if os.environ.get("MIMO_VIDEO_API_KEY") else "MIMO_API_KEY",
-    "mimo_tts_api_url": normalize_api_url(_raw_mimo_tts_api_url),
-    "mimo_tts_api_url_source": "env" if (
-        os.environ.get("MIMO_TTS_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_tts_api_key": _mimo_tts_api_key,
-    "mimo_tts_api_key_source": "MIMO_TTS_API_KEY" if os.environ.get("MIMO_TTS_API_KEY") else "MIMO_API_KEY",
-    "mimo_asr_api_url": normalize_api_url(_raw_mimo_asr_api_url),
-    "mimo_asr_api_url_source": "env" if (
-        os.environ.get("MIMO_ASR_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_asr_api_key": _mimo_asr_api_key,
-    "mimo_asr_api_key_source": "MIMO_ASR_API_KEY" if os.environ.get("MIMO_ASR_API_KEY") else "MIMO_API_KEY",
     "mimo_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
     "mimo_video_model": os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_video_model_source": "env" if (
-        os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL")
-    ) else "default",
     "vlm_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "vlm_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
-    "mimo_asr_model": os.environ.get("MIMO_ASR_MODEL", DEFAULT_MIMO_ASR_MODEL),
-    "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
-    "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
-    "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
-    # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
-    # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
-    "scene_threshold": 0.1,
-    "scene_threshold_source": "default",
-    "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),
-    "mimo_tts_model_source": "env" if os.environ.get("MIMO_TTS_MODEL") else "default",
-    "mimo_tts_voice": os.environ.get("MIMO_TTS_VOICE", "冰糖"),
-    "mimo_tts_voice_source": "env" if os.environ.get("MIMO_TTS_VOICE") else "default",
-    "mimo_tts_style": os.environ.get(
-        "MIMO_TTS_STYLE",
-        "自然、清晰、有感染力，像在给观众讲故事；随剧情起伏，该紧张时紧张、该动情时动情，不平铺直叙。",
-    ),
-    "mimo_tts_style_source": "env" if os.environ.get("MIMO_TTS_STYLE") else "default",
     "mimo_media_resolution": os.environ.get("MIMO_MEDIA_RESOLUTION", "default"),
-    "mimo_media_resolution_source": "env" if os.environ.get("MIMO_MEDIA_RESOLUTION") else "default",
     "mimo_video_overview": env_bool("MIMO_VIDEO_OVERVIEW", False),  # opt-in (--mimo-video-overview / =1); when on it becomes the PRIMARY per-scene description, frames stay the anchor/fallback
-    "mimo_video_overview_source": "env" if os.environ.get("MIMO_VIDEO_OVERVIEW") else "default",
     "mimo_video_fps": env_float("MIMO_VIDEO_FPS", 3.0, minimum=0.1),
-    "mimo_video_fps_source": "env" if os.environ.get("MIMO_VIDEO_FPS") else "default",
     "mimo_video_chunk_max_seconds": env_float("MIMO_VIDEO_CHUNK_MAX_SECONDS", 20.0, minimum=1.0),
     "mimo_video_chunk_min_seconds": env_float("MIMO_VIDEO_CHUNK_MIN_SECONDS", 1.0, minimum=0.2),
-    "mimo_video_chunk_timeout": env_int("MIMO_VIDEO_CHUNK_TIMEOUT", 180, minimum=1),
     "mimo_video_base64_max_mb": env_float("MIMO_VIDEO_BASE64_MAX_MB", 45.0, minimum=1.0),
-    # Per-scene frame VLM sampling — scale frames with scene length instead of a hard cap of 6
-    "vlm_seconds_per_frame": env_float("VLM_SECONDS_PER_FRAME", 4.0, minimum=0.5),
-    "vlm_max_frames": env_int("VLM_MAX_FRAMES", 16, minimum=3),
-    "vlm_max_tokens": env_int("VLM_MAX_TOKENS", 1500, minimum=200),
     "mimo_video_prompt": os.environ.get(
         "MIMO_VIDEO_PROMPT",
         "请用中文分析这个视频分片的主要人物、场景变化、关键动作、情绪走向和剧情冲突，"
         "重点提取适合写短视频解说的故事线索。不要泛泛复述画面，要标出对后续写稿有用的信息。",
     ),
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
-    "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
-    "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
     # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
     # 生成解说时使用 speech_rate * safety_margin 作为约束
     "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
@@ -202,97 +132,17 @@ CONFIG = {
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
     "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
-    # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
-    "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
-    "min_segments_per_minute": 6.24,     # legacy single-pass cut mapping report only
-    "max_narration_gap_seconds": 11.0,   # legacy single-pass cut mapping report only
-    "ducking_mode": "fixed",  # fixed | sidechaincompress | none
-    "ducking_threshold": 0.15,
-    "ducking_ratio": 3,
-    "ducking_attack": 10,
-    "ducking_release": 300,
-    "ducking_level_sc": 2.0,
-    "ducking_makeup": 1.2,
-    "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
-    "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
-    "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
-    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
-    "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
-    "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)
-    "jianying_draft_dir": os.environ.get("JIANYING_DRAFT_DIR", "").strip(),  # 剪映草稿输出父目录(留空=work_dir)
-    "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
-    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
-    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
     "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
-    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
-    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
-    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
-    "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
-    "narration_delay_seconds": env_float("NARRATION_DELAY_SECONDS", 0.0, minimum=0.0),  # 默认严格采用 Agent 写入的 start；旧项目可显式恢复延迟
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断
     "quiet_overlap_min_ratio": 0.8,  # 解说段至少多少比例落在安静窗口内才标记为非对白重叠
     "visual_beat_max_seconds": 18.0,  # 单段解说超过该时长且跨多个帧锚点时给 lint 提醒
     "visual_beat_max_facts": 3,  # 单段解说最多建议覆盖的 frame_facts 锚点数量
     "asr_chunk_min_chars": env_int("ASR_CHUNK_MIN_CHARS", 500, minimum=1),  # brief 中 ASR 写作分块最小字数/词数
     "asr_chunk_max_chars": env_int("ASR_CHUNK_MAX_CHARS", 800, minimum=1),  # brief 中 ASR 写作分块最大字数/词数
-    "speech_ducking_volume": env_float("SPEECH_DUCKING_VOLUME", 0.2, minimum=0.0),    # 解说与对白重叠时原声音量
-    "silence_noise_threshold": "-25dB",  # ffmpeg silencedetect 噪声阈值
-    "silence_min_duration": 0.3,     # 静音最短持续秒数
-    "quiet_window_min": 1.0,         # 可放解说的安静窗口最短秒数
-    "silence_merge_gap": 0.5,        # 相邻静音段间隔<此值时合并
-    "scene_merge_min": 4.0,         # 场景合并最短时长，<此值的场景合并到相邻场景
-    "scene_junk_filter": env_bool("SCENE_JUNK_FILTER", True),  # 过滤连续黑/白帧无效过渡场景
-    "scene_junk_dark_luma": env_float("SCENE_JUNK_DARK_LUMA", 8.0, minimum=0.0),
-    "scene_junk_bright_luma": env_float("SCENE_JUNK_BRIGHT_LUMA", 245.0, minimum=0.0),
-    "scene_junk_pixel_ratio": env_float("SCENE_JUNK_PIXEL_RATIO", 0.995, minimum=0.0),
     "context_info": "",              # 额外上下文（节目名、角色名等）
-    "context_info_source": "default",
-    "fps_source": "default",
-    "style": "纪录片",               # 解说风格（resume 时随 run_settings 持久化/恢复）
-    "style_source": "default",
-    "tts_dynamic_params": True,  # 启用动态语速调节
-    "vlm_workers": env_int("VLM_WORKERS", 8, minimum=1),  # VLM 并行分析线程数
-    "tts_workers": env_int("TTS_WORKERS", 4, minimum=1),  # TTS 并行合成线程数
-    "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
-    "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
-    "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
-    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
-    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
-    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
-    "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
-    "target_duration_source": "env" if os.environ.get("TARGET_DURATION") else "default",
-    "clip_padding": env_float("CLIP_PADDING", 0.0, minimum=0.0),  # cut 模式片段两端扩展秒数
-    "clip_padding_source": "env" if os.environ.get("CLIP_PADDING") else "default",
-    "allow_clip_overlap": env_bool("ALLOW_CLIP_OVERLAP", False),  # cut 模式是否允许重复/重叠使用原片
-    "burn_subtitles": env_bool("BURN_SUBTITLES", True),  # 烧录解说字幕（默认开；遮挡原字幕后需自带字幕，否则字幕区空白）
-    "force_video_reencode": env_bool("FORCE_VIDEO_REENCODE", False),  # 组装时重编码视频，修复部分容器时间戳问题
-    # 成片末端整体响度归一（默认混音偏轻，归一后更接近常见短视频响度；样片约 -11.9，默认取更安全的 -14）
-    "final_loudnorm": env_bool("FINAL_LOUDNORM", True),  # 组装末端做一次整体响度归一
-    "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
-    "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
-    "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
-    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
-    "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
-    "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
-    "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
-    "subtitle_outline_color": os.environ.get("SUBTITLE_OUTLINE_COLOR", "&H00000000"),
-    "subtitle_outline": env_float("SUBTITLE_OUTLINE", 2.0, minimum=0.0),
-    "subtitle_shadow": env_float("SUBTITLE_SHADOW", 1.0, minimum=0.0),
-    "subtitle_margin_v": env_int("SUBTITLE_MARGIN_V", 48, minimum=0),
-    "subtitle_margin_l": env_int("SUBTITLE_MARGIN_L", 40, minimum=0),
-    "subtitle_margin_r": env_int("SUBTITLE_MARGIN_R", 40, minimum=0),
-    "subtitle_alignment": env_int("SUBTITLE_ALIGNMENT", 2, minimum=1),
-    "subtitle_max_chars": env_int("SUBTITLE_MAX_CHARS", 20, minimum=6),
-    "subtitle_play_res_x": env_int("SUBTITLE_PLAY_RES_X", 1280, minimum=1),
-    "subtitle_play_res_y": env_int("SUBTITLE_PLAY_RES_Y", 720, minimum=1),
 }
 
 def narration_tempo_budget(tts_rate_offset=0.0, *, config=None):

--- a/skills/video-understanding/scripts/lib.py
+++ b/skills/video-understanding/scripts/lib.py
@@ -96,18 +96,12 @@ def env_float(name, default, *, minimum=None):
 # route to the Token-Plan cluster base URL; pay-as-you-go keys use api.xiaomimimo.com.
 _mimo_api_key = os.environ.get("MIMO_API_KEY", "")
 _mimo_video_api_key = os.environ.get("MIMO_VIDEO_API_KEY", "") or _mimo_api_key
-_mimo_tts_api_key = os.environ.get("MIMO_TTS_API_KEY", "") or _mimo_api_key
 _mimo_asr_api_key = os.environ.get("MIMO_ASR_API_KEY", "") or _mimo_api_key
 _raw_api_url = os.environ.get("MIMO_API_URL") or default_mimo_api_url(_mimo_api_key)
 _raw_mimo_video_api_url = (
     os.environ.get("MIMO_VIDEO_API_URL")
     or os.environ.get("MIMO_API_URL")
     or default_mimo_api_url(_mimo_video_api_key)
-)
-_raw_mimo_tts_api_url = (
-    os.environ.get("MIMO_TTS_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_tts_api_key)
 )
 _raw_mimo_asr_api_url = (
     os.environ.get("MIMO_ASR_API_URL")
@@ -116,44 +110,20 @@ _raw_mimo_asr_api_url = (
 )
 
 CONFIG = {
-    "api_provider": "mimo",
-    "api_provider_source": "default",
     "api_url": normalize_api_url(_raw_api_url),
-    "api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
     "api_key": _mimo_api_key,
     "api_key_source": "MIMO_API_KEY",
     "mimo_api_url": normalize_api_url(_raw_api_url),
-    "mimo_api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
     "mimo_api_key": _mimo_api_key,
-    "mimo_api_key_source": "MIMO_API_KEY",
     "mimo_video_api_url": normalize_api_url(_raw_mimo_video_api_url),
-    "mimo_video_api_url_source": "env" if (
-        os.environ.get("MIMO_VIDEO_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
     "mimo_video_api_key": _mimo_video_api_key,
-    "mimo_video_api_key_source": "MIMO_VIDEO_API_KEY" if os.environ.get("MIMO_VIDEO_API_KEY") else "MIMO_API_KEY",
-    "mimo_tts_api_url": normalize_api_url(_raw_mimo_tts_api_url),
-    "mimo_tts_api_url_source": "env" if (
-        os.environ.get("MIMO_TTS_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_tts_api_key": _mimo_tts_api_key,
-    "mimo_tts_api_key_source": "MIMO_TTS_API_KEY" if os.environ.get("MIMO_TTS_API_KEY") else "MIMO_API_KEY",
     "mimo_asr_api_url": normalize_api_url(_raw_mimo_asr_api_url),
-    "mimo_asr_api_url_source": "env" if (
-        os.environ.get("MIMO_ASR_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
     "mimo_asr_api_key": _mimo_asr_api_key,
     "mimo_asr_api_key_source": "MIMO_ASR_API_KEY" if os.environ.get("MIMO_ASR_API_KEY") else "MIMO_API_KEY",
     "mimo_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
     "mimo_video_model": os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_video_model_source": "env" if (
-        os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL")
-    ) else "default",
     "vlm_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "vlm_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
     "mimo_asr_model": os.environ.get("MIMO_ASR_MODEL", DEFAULT_MIMO_ASR_MODEL),
-    "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
     "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
     "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
     # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
@@ -161,22 +131,9 @@ CONFIG = {
     # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
     "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
     "scene_threshold": 0.1,
-    "scene_threshold_source": "default",
-    "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),
-    "mimo_tts_model_source": "env" if os.environ.get("MIMO_TTS_MODEL") else "default",
-    "mimo_tts_voice": os.environ.get("MIMO_TTS_VOICE", "冰糖"),
-    "mimo_tts_voice_source": "env" if os.environ.get("MIMO_TTS_VOICE") else "default",
-    "mimo_tts_style": os.environ.get(
-        "MIMO_TTS_STYLE",
-        "自然、清晰、有感染力，像在给观众讲故事；随剧情起伏，该紧张时紧张、该动情时动情，不平铺直叙。",
-    ),
-    "mimo_tts_style_source": "env" if os.environ.get("MIMO_TTS_STYLE") else "default",
     "mimo_media_resolution": os.environ.get("MIMO_MEDIA_RESOLUTION", "default"),
-    "mimo_media_resolution_source": "env" if os.environ.get("MIMO_MEDIA_RESOLUTION") else "default",
     "mimo_video_overview": env_bool("MIMO_VIDEO_OVERVIEW", False),  # opt-in (--mimo-video-overview / =1); when on it becomes the PRIMARY per-scene description, frames stay the anchor/fallback
-    "mimo_video_overview_source": "env" if os.environ.get("MIMO_VIDEO_OVERVIEW") else "default",
     "mimo_video_fps": env_float("MIMO_VIDEO_FPS", 3.0, minimum=0.1),
-    "mimo_video_fps_source": "env" if os.environ.get("MIMO_VIDEO_FPS") else "default",
     "mimo_video_chunk_max_seconds": env_float("MIMO_VIDEO_CHUNK_MAX_SECONDS", 20.0, minimum=1.0),
     "mimo_video_chunk_min_seconds": env_float("MIMO_VIDEO_CHUNK_MIN_SECONDS", 1.0, minimum=0.2),
     "mimo_video_chunk_timeout": env_int("MIMO_VIDEO_CHUNK_TIMEOUT", 180, minimum=1),
@@ -191,7 +148,6 @@ CONFIG = {
         "重点提取适合写短视频解说的故事线索。不要泛泛复述画面，要标出对后续写稿有用的信息。",
     ),
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
-    "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
     "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
     # Storyboard contact sheets are advisory and generated locally where frames/fps are owned.
     # Keep these keys only in the stage that consumes them; other stages do not read storyboard_*.
@@ -211,46 +167,14 @@ CONFIG = {
     "narration_block_seconds": 9.0,     # block cadence used to derive target block count
     "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
     "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
-    # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
-    "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
-    "min_segments_per_minute": 6.24,     # legacy single-pass cut mapping report only
-    "max_narration_gap_seconds": 11.0,   # legacy single-pass cut mapping report only
-    "ducking_mode": "fixed",  # fixed | sidechaincompress | none
-    "ducking_threshold": 0.15,
-    "ducking_ratio": 3,
-    "ducking_attack": 10,
-    "ducking_release": 300,
-    "ducking_level_sc": 2.0,
-    "ducking_makeup": 1.2,
-    "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
-    "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
-    "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
-    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
-    "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
-    "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)
-    "jianying_draft_dir": os.environ.get("JIANYING_DRAFT_DIR", "").strip(),  # 剪映草稿输出父目录(留空=work_dir)
-    "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
-    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
-    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
     "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
-    "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
-    "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
-    "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
-    "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
-    "narration_delay_seconds": env_float("NARRATION_DELAY_SECONDS", 0.0, minimum=0.0),  # 默认严格采用 Agent 写入的 start；旧项目可显式恢复延迟
     "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断
     "quiet_overlap_min_ratio": 0.8,  # 解说段至少多少比例落在安静窗口内才标记为非对白重叠
     "visual_beat_max_seconds": 18.0,  # 单段解说超过该时长且跨多个帧锚点时给 lint 提醒
     "visual_beat_max_facts": 3,  # 单段解说最多建议覆盖的 frame_facts 锚点数量
     "asr_chunk_min_chars": env_int("ASR_CHUNK_MIN_CHARS", 500, minimum=1),  # brief 中 ASR 写作分块最小字数/词数
     "asr_chunk_max_chars": env_int("ASR_CHUNK_MAX_CHARS", 800, minimum=1),  # brief 中 ASR 写作分块最大字数/词数
-    "speech_ducking_volume": env_float("SPEECH_DUCKING_VOLUME", 0.2, minimum=0.0),    # 解说与对白重叠时原声音量
     "silence_noise_threshold": "-25dB",  # ffmpeg silencedetect 噪声阈值
     # Short acoustic pauses are not quiet windows; they are sentence-boundary candidates.
     # A looser threshold plus ASR-punctuation alignment lets the writer enter after a full
@@ -270,47 +194,9 @@ CONFIG = {
     "scene_junk_bright_luma": env_float("SCENE_JUNK_BRIGHT_LUMA", 245.0, minimum=0.0),
     "scene_junk_pixel_ratio": env_float("SCENE_JUNK_PIXEL_RATIO", 0.995, minimum=0.0),
     "context_info": "",              # 额外上下文（节目名、角色名等）
-    "context_info_source": "default",
-    "fps_source": "default",
-    "style": "纪录片",               # 解说风格（resume 时随 run_settings 持久化/恢复）
-    "style_source": "default",
-    "tts_dynamic_params": True,  # 启用动态语速调节
     "vlm_workers": env_int("VLM_WORKERS", 8, minimum=1),  # VLM 并行分析线程数
-    "tts_workers": env_int("TTS_WORKERS", 4, minimum=1),  # TTS 并行合成线程数
-    "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
-    "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
-    "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
-    "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
-    "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
-    "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
     "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
-    "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
     "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
-    "target_duration_source": "env" if os.environ.get("TARGET_DURATION") else "default",
-    "clip_padding": env_float("CLIP_PADDING", 0.0, minimum=0.0),  # cut 模式片段两端扩展秒数
-    "clip_padding_source": "env" if os.environ.get("CLIP_PADDING") else "default",
-    "allow_clip_overlap": env_bool("ALLOW_CLIP_OVERLAP", False),  # cut 模式是否允许重复/重叠使用原片
-    "burn_subtitles": env_bool("BURN_SUBTITLES", True),  # 烧录解说字幕（默认开；遮挡原字幕后需自带字幕，否则字幕区空白）
-    "force_video_reencode": env_bool("FORCE_VIDEO_REENCODE", False),  # 组装时重编码视频，修复部分容器时间戳问题
-    # 成片末端整体响度归一（默认混音偏轻，归一后更接近常见短视频响度；样片约 -11.9，默认取更安全的 -14）
-    "final_loudnorm": env_bool("FINAL_LOUDNORM", True),  # 组装末端做一次整体响度归一
-    "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
-    "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
-    "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
-    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
-    "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
-    "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
-    "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
-    "subtitle_outline_color": os.environ.get("SUBTITLE_OUTLINE_COLOR", "&H00000000"),
-    "subtitle_outline": env_float("SUBTITLE_OUTLINE", 2.0, minimum=0.0),
-    "subtitle_shadow": env_float("SUBTITLE_SHADOW", 1.0, minimum=0.0),
-    "subtitle_margin_v": env_int("SUBTITLE_MARGIN_V", 48, minimum=0),
-    "subtitle_margin_l": env_int("SUBTITLE_MARGIN_L", 40, minimum=0),
-    "subtitle_margin_r": env_int("SUBTITLE_MARGIN_R", 40, minimum=0),
-    "subtitle_alignment": env_int("SUBTITLE_ALIGNMENT", 2, minimum=1),
-    "subtitle_max_chars": env_int("SUBTITLE_MAX_CHARS", 20, minimum=6),
-    "subtitle_play_res_x": env_int("SUBTITLE_PLAY_RES_X", 1280, minimum=1),
-    "subtitle_play_res_y": env_int("SUBTITLE_PLAY_RES_Y", 720, minimum=1),
 }
 
 SCRIPT_DIR = Path(__file__).parent

--- a/skills/video-voiceover/scripts/lib.py
+++ b/skills/video-voiceover/scripts/lib.py
@@ -95,207 +95,44 @@ def env_float(name, default, *, minimum=None):
 # are optional and fall back to MIMO_API_KEY / MIMO_API_URL. Token-Plan keys (tp-*) auto-
 # route to the Token-Plan cluster base URL; pay-as-you-go keys use api.xiaomimimo.com.
 _mimo_api_key = os.environ.get("MIMO_API_KEY", "")
-_mimo_video_api_key = os.environ.get("MIMO_VIDEO_API_KEY", "") or _mimo_api_key
 _mimo_tts_api_key = os.environ.get("MIMO_TTS_API_KEY", "") or _mimo_api_key
-_mimo_asr_api_key = os.environ.get("MIMO_ASR_API_KEY", "") or _mimo_api_key
 _raw_api_url = os.environ.get("MIMO_API_URL") or default_mimo_api_url(_mimo_api_key)
-_raw_mimo_video_api_url = (
-    os.environ.get("MIMO_VIDEO_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_video_api_key)
-)
 _raw_mimo_tts_api_url = (
     os.environ.get("MIMO_TTS_API_URL")
     or os.environ.get("MIMO_API_URL")
     or default_mimo_api_url(_mimo_tts_api_key)
 )
-_raw_mimo_asr_api_url = (
-    os.environ.get("MIMO_ASR_API_URL")
-    or os.environ.get("MIMO_API_URL")
-    or default_mimo_api_url(_mimo_asr_api_key)
-)
 
 CONFIG = {
-    "api_provider": "mimo",
-    "api_provider_source": "default",
     "api_url": normalize_api_url(_raw_api_url),
-    "api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
     "api_key": _mimo_api_key,
     "api_key_source": "MIMO_API_KEY",
     "mimo_api_url": normalize_api_url(_raw_api_url),
-    "mimo_api_url_source": "env" if os.environ.get("MIMO_API_URL") else "default",
     "mimo_api_key": _mimo_api_key,
-    "mimo_api_key_source": "MIMO_API_KEY",
-    "mimo_video_api_url": normalize_api_url(_raw_mimo_video_api_url),
-    "mimo_video_api_url_source": "env" if (
-        os.environ.get("MIMO_VIDEO_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_video_api_key": _mimo_video_api_key,
-    "mimo_video_api_key_source": "MIMO_VIDEO_API_KEY" if os.environ.get("MIMO_VIDEO_API_KEY") else "MIMO_API_KEY",
     "mimo_tts_api_url": normalize_api_url(_raw_mimo_tts_api_url),
-    "mimo_tts_api_url_source": "env" if (
-        os.environ.get("MIMO_TTS_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
     "mimo_tts_api_key": _mimo_tts_api_key,
     "mimo_tts_api_key_source": "MIMO_TTS_API_KEY" if os.environ.get("MIMO_TTS_API_KEY") else "MIMO_API_KEY",
-    "mimo_asr_api_url": normalize_api_url(_raw_mimo_asr_api_url),
-    "mimo_asr_api_url_source": "env" if (
-        os.environ.get("MIMO_ASR_API_URL") or os.environ.get("MIMO_API_URL")
-    ) else "default",
-    "mimo_asr_api_key": _mimo_asr_api_key,
-    "mimo_asr_api_key_source": "MIMO_ASR_API_KEY" if os.environ.get("MIMO_ASR_API_KEY") else "MIMO_API_KEY",
-    "mimo_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
-    "mimo_video_model": os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "mimo_video_model_source": "env" if (
-        os.environ.get("MIMO_VIDEO_MODEL") or os.environ.get("MIMO_MODEL")
-    ) else "default",
-    "vlm_model": os.environ.get("MIMO_MODEL", DEFAULT_MIMO_MODEL),
-    "vlm_model_source": "env" if os.environ.get("MIMO_MODEL") else "default",
     "mimo_asr_model": os.environ.get("MIMO_ASR_MODEL", DEFAULT_MIMO_ASR_MODEL),
-    "mimo_asr_model_source": "env" if os.environ.get("MIMO_ASR_MODEL") else "default",
-    "mimo_asr_language": os.environ.get("MIMO_ASR_LANGUAGE", "auto"),  # auto | zh | en
-    "mimo_asr_base64_max_mb": env_float("MIMO_ASR_BASE64_MAX_MB", 10.0, minimum=1.0),
-    # ASR 分段窗口秒数。越小 → 长视频的对白时间戳越精细（默认 15s）。旧值 180s 会把 >3min
-    # 视频的对白塌缩成一个时间戳，既让 brief 无法定位对白，又触发 detect.py 的粗粒度跳过，
-    # 使 overlaps_speech/安静窗口判断失真。代价是更多 ASR 调用；ASR 慢时可调大。
-    "asr_segment_seconds": env_float("ASR_SEGMENT_SECONDS", 15.0, minimum=5.0),
-    "scene_threshold": 0.1,
-    "scene_threshold_source": "default",
     "mimo_tts_model": os.environ.get("MIMO_TTS_MODEL", DEFAULT_MIMO_TTS_MODEL),
-    "mimo_tts_model_source": "env" if os.environ.get("MIMO_TTS_MODEL") else "default",
     "mimo_tts_voice": os.environ.get("MIMO_TTS_VOICE", "冰糖"),
-    "mimo_tts_voice_source": "env" if os.environ.get("MIMO_TTS_VOICE") else "default",
     "voice_ref": os.environ.get("VOICE_REF", "").strip(),  # optional arbitrary reference audio for narration voice clone
     "mimo_tts_style": os.environ.get(
         "MIMO_TTS_STYLE",
         "自然、清晰、有感染力，像在给观众讲故事；随剧情起伏，该紧张时紧张、该动情时动情，不平铺直叙。",
     ),
-    "mimo_tts_style_source": "env" if os.environ.get("MIMO_TTS_STYLE") else "default",
-    "mimo_media_resolution": os.environ.get("MIMO_MEDIA_RESOLUTION", "default"),
-    "mimo_media_resolution_source": "env" if os.environ.get("MIMO_MEDIA_RESOLUTION") else "default",
-    "mimo_video_overview": env_bool("MIMO_VIDEO_OVERVIEW", False),  # opt-in (--mimo-video-overview / =1); when on it becomes the PRIMARY per-scene description, frames stay the anchor/fallback
-    "mimo_video_overview_source": "env" if os.environ.get("MIMO_VIDEO_OVERVIEW") else "default",
-    "mimo_video_fps": env_float("MIMO_VIDEO_FPS", 3.0, minimum=0.1),
-    "mimo_video_fps_source": "env" if os.environ.get("MIMO_VIDEO_FPS") else "default",
-    "mimo_video_chunk_max_seconds": env_float("MIMO_VIDEO_CHUNK_MAX_SECONDS", 20.0, minimum=1.0),
-    "mimo_video_chunk_min_seconds": env_float("MIMO_VIDEO_CHUNK_MIN_SECONDS", 1.0, minimum=0.2),
-    "mimo_video_chunk_timeout": env_int("MIMO_VIDEO_CHUNK_TIMEOUT", 180, minimum=1),
-    "mimo_video_base64_max_mb": env_float("MIMO_VIDEO_BASE64_MAX_MB", 45.0, minimum=1.0),
-    # Per-scene frame VLM sampling — scale frames with scene length instead of a hard cap of 6
-    "vlm_seconds_per_frame": env_float("VLM_SECONDS_PER_FRAME", 4.0, minimum=0.5),
-    "vlm_max_frames": env_int("VLM_MAX_FRAMES", 16, minimum=3),
-    "vlm_max_tokens": env_int("VLM_MAX_TOKENS", 1500, minimum=200),
-    "mimo_video_prompt": os.environ.get(
-        "MIMO_VIDEO_PROMPT",
-        "请用中文分析这个视频分片的主要人物、场景变化、关键动作、情绪走向和剧情冲突，"
-        "重点提取适合写短视频解说的故事线索。不要泛泛复述画面，要标出对后续写稿有用的信息。",
-    ),
     "mimo_disable_thinking": env_bool("MIMO_DISABLE_THINKING", True),
-    "mimo_disable_thinking_source": "env" if os.environ.get("MIMO_DISABLE_THINKING") else "default",
-    "fps": 0,  # 0 = 自动（≤60s→2fps, ≤5min→1.5fps, >5min→1fps）
-    # TTS 语速（字符/秒）。实测 mimo-tts 冰糖音色中位 ~3.9 字/秒，可用 SPEECH_RATE 覆盖
-    # 生成解说时使用 speech_rate * safety_margin 作为约束
-    "speech_rate": env_float("SPEECH_RATE", 3.9, minimum=0.5),  # 旧值 3.5 系统性偏低 ~10-17%
-    "speech_safety_margin": env_float("SPEECH_SAFETY_MARGIN", 0.85, minimum=0.1),  # 保守系数：TTS 实际语速有 ±20% 波动
-    # Block-coverage lint thresholds — promoted from inline .get() literals to real CONFIG keys (tunable; defaults unchanged)
-    "narration_coverage_target": 0.7,   # rough first-draft/diagnostic fallback; content-led audio decisions may differ (not a quota)
-    "narration_coverage_max": 0.85,     # above this coverage → no_original_blocks (narration is wall-to-wall)
-    "narration_coverage_min": 0.5,      # below this coverage → under_narrated
-    "narration_block_seconds": 9.0,     # block cadence used to derive target block count
-    "original_block_min_seconds": 2.5,  # a deliberate original-audio gap must be at least this long
-    "narration_block_min_chars": 16,    # below this avg block size → fragmented_beats
-    "fade_ms": 120,  # TTS fade-in/fade-out 时长(ms); keep in sync with assemble default
     "breath_ms": 250,  # 段间呼吸空间(ms)；block recap 块内连贯、块间留原声呼吸
-    # Legacy single-pass cut mapping density fields; current writing uses block coverage controls below.
-    "target_segments_per_minute": 9.6,   # legacy single-pass cut mapping report only; block recap uses narration_coverage_*
-    "min_segments_per_minute": 6.24,     # legacy single-pass cut mapping report only
-    "max_narration_gap_seconds": 11.0,   # legacy single-pass cut mapping report only
-    "ducking_mode": "fixed",  # fixed | sidechaincompress | none
-    "ducking_threshold": 0.15,
-    "ducking_ratio": 3,
-    "ducking_attack": 10,
-    "ducking_release": 300,
-    "ducking_level_sc": 2.0,
-    "ducking_makeup": 1.2,
-    "ducking_narr_weight": 1.5,
-    "ducking_orig_volume": env_float("DUCKING_ORIG_VOLUME", 0.3, minimum=0.0),  # 解说时原声基准音量
-    "zone_ducking_volume": 0.12,    # 解说时原声压低到的音量
-    "zone_fade_seconds": 0.5,      # 解说/原声切换的淡入淡出时长(秒)
-    "idle_orig_volume": env_float("IDLE_ORIG_VOLUME", 1.0, minimum=0.0),  # 解说间隙(无旁白)时的原声音量，铺底避免顿挫
-    "duck_fade_seconds": env_float("DUCK_FADE_SECONDS", 0.3, minimum=0.0),  # 原声 ducking 过渡淡入淡出(秒)
-    "bgm_path": os.environ.get("BGM_PATH", "").strip(),  # 背景音乐文件(可选)，留空则不加 BGM
-    "source_video": os.environ.get("SOURCE_VIDEO", "").strip(),  # 剪辑模式下的原始视频(可选)，用于时间线/剪映导出引用原片片段
-    "export_jianying": env_bool("EXPORT_JIANYING", False),  # 渲染后可选导出剪映草稿(默认关；与核心解耦)
-    "jianying_draft_dir": os.environ.get("JIANYING_DRAFT_DIR", "").strip(),  # 剪映草稿输出父目录(留空=work_dir)
-    "jianying_bundle_media": env_bool("JIANYING_BUNDLE_MEDIA", True),  # 默认开：macOS 剪映沙箱读不到外部路径，须把素材拷进草稿目录
-    "bgm_volume": env_float("BGM_VOLUME", 0.18, minimum=0.0),  # BGM 铺底音量
-    "bgm_ducking_volume": env_float("BGM_DUCKING_VOLUME", 0.10, minimum=0.0),  # 旁白时 BGM 压低到的音量
     "narration_speed": env_float("NARRATION_SPEED", 1.15, minimum=0.5),  # 解说整体提速(atempo)，默认回到可懂区间；长片可设 1.0
     "narration_cumulative_tempo_max": env_float("NARRATION_CUMULATIVE_TEMPO_MAX", 1.35, minimum=1.0),  # TTS rate × 全局 atempo × 段内 atempo 的累计上限
     "narration_cumulative_tempo_hard_max": env_float("NARRATION_CUMULATIVE_TEMPO_HARD_MAX", 1.40, minimum=1.0),  # QC/阻断硬上限
     "tts_segment_tempo_max": env_float("TTS_SEGMENT_TEMPO_MAX", 1.20, minimum=1.0),  # 兼容旧段内 atempo 上限；实际会被累计预算收紧
-    "mask_source_subtitles": env_bool("MASK_SOURCE_SUBTITLES", True),  # 遮挡原片烧录字幕（默认开；无烧录字幕素材设 false）
-    "source_subtitle_mask_ratio": env_float("SOURCE_SUBTITLE_MASK_RATIO", 0.14, minimum=0.0),  # 底部遮挡比例
-    "narration_delay_seconds": env_float("NARRATION_DELAY_SECONDS", 0.0, minimum=0.0),  # 默认严格采用 Agent 写入的 start；旧项目可显式恢复延迟
-    "narration_tail_pad_seconds": 0.1,  # 解说尾部最少留白；短 slot 会自动压低 delay 避免截断
-    "quiet_overlap_min_ratio": 0.8,  # 解说段至少多少比例落在安静窗口内才标记为非对白重叠
-    "visual_beat_max_seconds": 18.0,  # 单段解说超过该时长且跨多个帧锚点时给 lint 提醒
-    "visual_beat_max_facts": 3,  # 单段解说最多建议覆盖的 frame_facts 锚点数量
-    "asr_chunk_min_chars": env_int("ASR_CHUNK_MIN_CHARS", 500, minimum=1),  # brief 中 ASR 写作分块最小字数/词数
-    "asr_chunk_max_chars": env_int("ASR_CHUNK_MAX_CHARS", 800, minimum=1),  # brief 中 ASR 写作分块最大字数/词数
-    "speech_ducking_volume": env_float("SPEECH_DUCKING_VOLUME", 0.2, minimum=0.0),    # 解说与对白重叠时原声音量
-    "silence_noise_threshold": "-25dB",  # ffmpeg silencedetect 噪声阈值
-    "silence_min_duration": 0.3,     # 静音最短持续秒数
-    "quiet_window_min": 1.0,         # 可放解说的安静窗口最短秒数
-    "silence_merge_gap": 0.5,        # 相邻静音段间隔<此值时合并
-    "scene_merge_min": 4.0,         # 场景合并最短时长，<此值的场景合并到相邻场景
-    "scene_junk_filter": env_bool("SCENE_JUNK_FILTER", True),  # 过滤连续黑/白帧无效过渡场景
-    "scene_junk_dark_luma": env_float("SCENE_JUNK_DARK_LUMA", 8.0, minimum=0.0),
-    "scene_junk_bright_luma": env_float("SCENE_JUNK_BRIGHT_LUMA", 245.0, minimum=0.0),
-    "scene_junk_pixel_ratio": env_float("SCENE_JUNK_PIXEL_RATIO", 0.995, minimum=0.0),
-    "context_info": "",              # 额外上下文（节目名、角色名等）
-    "context_info_source": "default",
-    "fps_source": "default",
-    "style": "纪录片",               # 解说风格（resume 时随 run_settings 持久化/恢复）
-    "style_source": "default",
     "tts_dynamic_params": True,  # 启用动态语速调节
-    "vlm_workers": env_int("VLM_WORKERS", 8, minimum=1),  # VLM 并行分析线程数
     "tts_workers": env_int("TTS_WORKERS", 4, minimum=1),  # TTS 并行合成线程数
-    "tts_timeout": env_int("TTS_TIMEOUT", 90, minimum=1),  # 单段 TTS 命令超时秒数
     "tts_retries": env_int("TTS_RETRIES", 3, minimum=1),  # 单段 TTS 失败重试次数
     "allow_partial_tts": env_bool("ALLOW_PARTIAL_TTS", False),
     "tts_segment_normalize": env_bool("TTS_SEGMENT_NORMALIZE", True),  # 单段 TTS RMS 归一，降低段间忽大忽小
     "tts_segment_target_rms_dbfs": env_float("TTS_SEGMENT_TARGET_RMS_DBFS", -20.0),
     "tts_segment_peak_limit": env_float("TTS_SEGMENT_PEAK_LIMIT", 0.98, minimum=0.1),
-    "edit_mode": os.environ.get("EDIT_MODE", "full"),  # full | cut
-    "edit_mode_source": "env" if os.environ.get("EDIT_MODE") else "default",
-    "target_duration": os.environ.get("TARGET_DURATION", ""),  # cut 模式目标成片时长，如 10m
-    "target_duration_source": "env" if os.environ.get("TARGET_DURATION") else "default",
-    "clip_padding": env_float("CLIP_PADDING", 0.0, minimum=0.0),  # cut 模式片段两端扩展秒数
-    "clip_padding_source": "env" if os.environ.get("CLIP_PADDING") else "default",
-    "allow_clip_overlap": env_bool("ALLOW_CLIP_OVERLAP", False),  # cut 模式是否允许重复/重叠使用原片
-    "burn_subtitles": env_bool("BURN_SUBTITLES", True),  # 烧录解说字幕（默认开；遮挡原字幕后需自带字幕，否则字幕区空白）
-    "force_video_reencode": env_bool("FORCE_VIDEO_REENCODE", False),  # 组装时重编码视频，修复部分容器时间戳问题
-    # 成片末端整体响度归一（默认混音偏轻，归一后更接近常见短视频响度；样片约 -11.9，默认取更安全的 -14）
-    "final_loudnorm": env_bool("FINAL_LOUDNORM", True),  # 组装末端做一次整体响度归一
-    "target_lufs": env_float("TARGET_LUFS", -14.0),       # 目标综合响度 (LUFS)
-    "target_true_peak": env_float("TARGET_TRUE_PEAK", -1.0),  # 目标真峰值 (dBTP)
-    "target_lra": env_float("TARGET_LRA", 11.0),          # 目标响度范围 (LU)
-    "final_limiter_peak": env_float("FINAL_LIMITER_PEAK", 0.98, minimum=0.1),  # loudnorm 后峰值保护 limiter
-    "subtitle_font_name": os.environ.get("SUBTITLE_FONT_NAME", "Arial"),
-    "subtitle_font_size": env_int("SUBTITLE_FONT_SIZE", 42, minimum=8),
-    "subtitle_primary_color": os.environ.get("SUBTITLE_PRIMARY_COLOR", "&H00FFFFFF"),
-    "subtitle_outline_color": os.environ.get("SUBTITLE_OUTLINE_COLOR", "&H00000000"),
-    "subtitle_outline": env_float("SUBTITLE_OUTLINE", 2.0, minimum=0.0),
-    "subtitle_shadow": env_float("SUBTITLE_SHADOW", 1.0, minimum=0.0),
-    "subtitle_margin_v": env_int("SUBTITLE_MARGIN_V", 48, minimum=0),
-    "subtitle_margin_l": env_int("SUBTITLE_MARGIN_L", 40, minimum=0),
-    "subtitle_margin_r": env_int("SUBTITLE_MARGIN_R", 40, minimum=0),
-    "subtitle_alignment": env_int("SUBTITLE_ALIGNMENT", 2, minimum=1),
-    "subtitle_max_chars": env_int("SUBTITLE_MAX_CHARS", 20, minimum=6),
-    "subtitle_play_res_x": env_int("SUBTITLE_PLAY_RES_X", 1280, minimum=1),
-    "subtitle_play_res_y": env_int("SUBTITLE_PLAY_RES_Y", 720, minimum=1),
 }
 if isinstance(_EXISTING_CONFIG_REF, dict):
     _EXISTING_CONFIG_REF.clear()

--- a/tests/orchestrator/test_audio_policy_parity.py
+++ b/tests/orchestrator/test_audio_policy_parity.py
@@ -1,6 +1,16 @@
+"""Audio policy must agree wherever it is actually consumed.
+
+Previously every skill declared the full ~30-key audio policy and this file asserted all
+five copies matched. That parity was circular: the keys only needed to agree because
+lib.py had been copied, and most skills never read them. Now a skill declares a knob only
+if its own code reads it, so parity is asserted over the real overlap — which is where a
+divergence could actually change a rendered recap.
+"""
+import ast
 import importlib.util
 from pathlib import Path
 
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 LIBS = {
@@ -11,6 +21,46 @@ LIBS = {
     "understanding": ROOT / "skills/video-understanding/scripts/lib.py",
 }
 
+# Knobs that shape the rendered audio. A skill is held to these only if it declares them,
+# i.e. only if its own code reads them — see test_audio_policy_keys_are_declared_where_read.
+# Exactly the inputs narration_tempo_budget() reads. A skill that carries these must
+# compute the same cap from them, because voiceover and assemble both enforce it.
+TEMPO_KEYS = (
+    "narration_speed",
+    "narration_cumulative_tempo_max",
+    "narration_cumulative_tempo_hard_max",
+    "tts_segment_tempo_max",
+)
+MIX_KEYS = (
+    "fade_ms",
+    "ducking_mode",
+    "ducking_threshold",
+    "ducking_ratio",
+    "ducking_attack",
+    "ducking_release",
+    "ducking_level_sc",
+    "ducking_makeup",
+    "ducking_narr_weight",
+    "ducking_orig_volume",
+    "zone_ducking_volume",
+    # `zone_fade_seconds` used to sit here. It was declared in all five lib.py copies and
+    # read by nothing in the entire repository — kept alive only by the old blanket parity
+    # assertion, which proved the copies agreed without anyone consuming the value.
+    "idle_orig_volume",
+    "duck_fade_seconds",
+    "bgm_volume",
+    "bgm_ducking_volume",
+    "speech_ducking_volume",
+    "final_loudnorm",
+    "target_lufs",
+    "target_true_peak",
+    "target_lra",
+    "final_limiter_peak",
+    "tts_segment_normalize",
+    "tts_segment_target_rms_dbfs",
+    "tts_segment_peak_limit",
+)
+
 
 def _load_lib(name, path):
     spec = importlib.util.spec_from_file_location(f"audio_policy_{name}_lib", path)
@@ -19,65 +69,68 @@ def _load_lib(name, path):
     return module
 
 
-def test_audio_tempo_policy_config_and_helper_stay_in_sync():
-    libs = {name: _load_lib(name, path) for name, path in LIBS.items()}
-    keys = [
-        "narration_speed",
-        "narration_cumulative_tempo_max",
-        "narration_cumulative_tempo_hard_max",
-        "tts_segment_tempo_max",
-        "fade_ms",
+@pytest.fixture(scope="module")
+def libs():
+    return {name: _load_lib(name, path) for name, path in LIBS.items()}
+
+
+def _readable_source(path, *, include_lib=True):
+    """Everything in a skill that could read CONFIG, excluding the CONFIG literal itself."""
+    scripts = path.parent
+    parts = [
+        p.read_text(encoding="utf-8")
+        for p in sorted(scripts.glob("*.py"))
+        if p.name != "lib.py"
     ]
-    baseline = {key: libs["assemble"].CONFIG[key] for key in keys}
+    if include_lib:
+        lib_source = path.read_text(encoding="utf-8")
+        config_span = set()
+        for node in ast.walk(ast.parse(lib_source)):
+            if (
+                isinstance(node, ast.Assign)
+                and any(getattr(t, "id", "") == "CONFIG" for t in node.targets)
+                and isinstance(node.value, ast.Dict)
+            ):
+                config_span = set(range(node.lineno, node.end_lineno + 1))
+        parts.append(
+            "\n".join(
+                line
+                for number, line in enumerate(lib_source.splitlines(), start=1)
+                if number not in config_span
+            )
+        )
+    return "\n".join(parts)
 
-    for name, lib in libs.items():
-        assert {key: lib.CONFIG[key] for key in keys} == baseline, name
-        assert hasattr(lib, "narration_tempo_budget"), name
 
+@pytest.mark.parametrize("key", TEMPO_KEYS + MIX_KEYS)
+def test_audio_policy_value_agrees_across_every_skill_that_declares_it(libs, key):
+    declarers = {name: lib for name, lib in libs.items() if key in lib.CONFIG}
+    assert declarers, f"no skill declares {key!r} any more; drop it from this contract"
+    values = {name: lib.CONFIG[key] for name, lib in declarers.items()}
+    assert len(set(map(repr, values.values()))) == 1, f"{key} diverged: {values}"
+
+
+def test_tempo_budget_helper_agrees_wherever_the_tempo_knobs_are_declared(libs):
+    """narration_tempo_budget turns the tempo knobs into the cap voiceover and assemble both
+    enforce. Any skill carrying those knobs must compute the same budget from them."""
+    declarers = {
+        name: lib
+        for name, lib in libs.items()
+        if all(key in lib.CONFIG for key in TEMPO_KEYS)
+    }
+    assert {"assemble", "voiceover"} <= set(declarers), (
+        "assemble and voiceover both enforce the tempo budget and must declare its inputs"
+    )
     for offset in (-0.05, 0.0, 0.05, 0.08):
-        expected = libs["assemble"].narration_tempo_budget(offset)
-        for name, lib in libs.items():
+        expected = declarers["assemble"].narration_tempo_budget(offset)
+        for name, lib in declarers.items():
+            assert hasattr(lib, "narration_tempo_budget"), name
             assert lib.narration_tempo_budget(offset) == expected, name
 
 
-def test_audio_mix_and_normalization_policy_stay_in_sync():
-    libs = {name: _load_lib(name, path) for name, path in LIBS.items()}
-    keys = [
-        "ducking_mode",
-        "ducking_threshold",
-        "ducking_ratio",
-        "ducking_attack",
-        "ducking_release",
-        "ducking_level_sc",
-        "ducking_makeup",
-        "ducking_narr_weight",
-        "ducking_orig_volume",
-        "zone_ducking_volume",
-        "zone_fade_seconds",
-        "idle_orig_volume",
-        "duck_fade_seconds",
-        "bgm_volume",
-        "bgm_ducking_volume",
-        "speech_ducking_volume",
-        "final_loudnorm",
-        "target_lufs",
-        "target_true_peak",
-        "target_lra",
-        "final_limiter_peak",
-        "tts_segment_normalize",
-        "tts_segment_target_rms_dbfs",
-        "tts_segment_peak_limit",
-    ]
-    baseline = {key: libs["assemble"].CONFIG[key] for key in keys}
-
-    for name, lib in libs.items():
-        assert {key: lib.CONFIG[key] for key in keys} == baseline, name
-
-
-def test_visual_qc_delivery_boundary_fields_are_not_audio_policy_keys():
+def test_visual_qc_delivery_boundary_fields_are_not_audio_policy_keys(libs):
     """Delivery transparency fields are rollup/QC facts, not shared audio policy knobs;
     this guards against leaking visual-delivery contract fields into CONFIG parity."""
-    libs = {name: _load_lib(name, path) for name, path in LIBS.items()}
     delivery_fact_keys = {
         "video_encode_passes",
         "reencode_reason",
@@ -87,3 +140,33 @@ def test_visual_qc_delivery_boundary_fields_are_not_audio_policy_keys():
     }
     for name, lib in libs.items():
         assert not (delivery_fact_keys & set(lib.CONFIG)), name
+
+
+def test_no_skill_declares_config_it_never_reads(libs):
+    """The invariant that replaces blanket parity.
+
+    A key declared where nothing reads it is dead weight at best and a lie at worst:
+    CLIP_PADDING was declared in five CONFIGs, reported as active through
+    clip_padding_source, and read by none of them — including the one skill that
+    implements padding.
+    """
+    allowed_unread = {
+        # Derived report of a knob this skill implements: FOREIGN_SOURCE_AUDIO selects the
+        # ducking volumes below it, and this exposes which policy ended up in effect.
+        "assemble": {"foreign_source_audio"},
+    }
+    offenders = {}
+    for name, path in LIBS.items():
+        readable = _readable_source(path)
+        unread = {
+            key
+            for key in libs[name].CONFIG
+            if f'"{key}"' not in readable and f"'{key}'" not in readable
+        }
+        unread -= allowed_unread.get(name, set())
+        if unread:
+            offenders[name] = sorted(unread)
+    assert not offenders, (
+        f"CONFIG keys declared but read by nothing in their own skill: {offenders}. "
+        "Declare a knob in the skill that implements it, not in every copy of lib.py."
+    )


### PR DESCRIPTION
Stacked on #65 — review that first; this diff is only the config work.

Replaces #66, which I closed: that one introduced a `shared/` directory, which conflicts
with a rule this project set at the start. Nothing here adds shared code — every skill's
existing anti-drift mechanism (sibling byte-identity for the intentional local copies) is
untouched. This is deletion plus one invariant.

## What changed

Five of six `lib.py` copies carried the union of everyone's settings. `video-cut` was
already the counter-example: 8 keys, all used.

| skill | CONFIG keys |
| --- | --- |
| video-assemble | 181 → 78 |
| video-recap | 165 → 34 |
| video-script | 163 → 43 |
| video-understanding | 175 → 84 |
| video-voiceover | 170 → 41 |
| video-cut | 8 → 9 |

**583 dead declarations removed**, plus the module-level plumbing that only existed to feed
them. Only 5 keys were read by 4+ skills; 113 of 163 keys in use were read by exactly one.

## How the keep-sets were determined

Not by grepping. CONFIG was temporarily instrumented per skill to record every key access
during that skill's test run, with each read attributed to its calling frame so
parity-test reads did not count as production use. That found 29 keys in video-recap no
regex would have flagged, and it is how both defects below surfaced.

- **`zone_fade_seconds`** was declared in all five copies and read *nowhere in the
  repository*. It survived only because the old blanket parity test proved the copies
  agreed — without anyone consuming the value.
- **`CLIP_PADDING` still did nothing** even after #65 wired it: `video-cut/lib.py` never
  declared the key, so the lookup always hit its inline default. The test passed because
  it monkeypatched the key in, bypassing exactly the broken link. Fixed in #65's last
  commit so that PR does not land a claim it does not deliver.

## The parity test

`test_audio_policy_parity` asserted all five copies agreed on ~30 audio keys. That parity
was circular: the keys had to agree only *because* lib.py had been copied, and most skills
never read them. It now asserts agreement across the skills that actually declare a knob,
holds `narration_tempo_budget` to the four inputs it really reads, and adds the invariant
that replaces blanket parity:

> no skill may declare config that nothing in it reads

That is what makes the `CLIP_PADDING` / `narration_coverage_max` class of defect
impossible to reintroduce — and it is a rule each skill enforces on itself, with no shared
code involved.

## Testing

`python scripts/test.py` green: 149 / 63 / 68 / 287 / 104 / 225 / 24.
`ruff check skills tests scripts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)