### PR TITLE
docs: migrate repository namespace to zenstory-ai

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "video-recap-skills",
       "source": "./",
       "description": "Turn any video into a Chinese-narration recap (understanding -> narration -> cut -> voiceover -> assemble) on ffmpeg + one Xiaomi MiMo API key. A bundle of independent skills + a thin orchestrator. macOS / Linux / Windows.",
-      "homepage": "https://github.com/worldwonderer/video-recap-skills",
+      "homepage": "https://github.com/zenstory-ai/video-recap-skills",
       "license": "MIT"
     }
   ]

--- a/README.en.md
+++ b/README.en.md
@@ -84,20 +84,20 @@ The default Fish model is `s2.1-pro-free`, with the built-in “娱乐扒妹” 
 Run inside Claude Code:
 
 ```text
-/plugin marketplace add worldwonderer/video-recap-skills
+/plugin marketplace add zenstory-ai/video-recap-skills
 /plugin install video-recap-skills@video-recap
 ```
 
 Or simply ask:
 
 ```text
-Install this plugin: https://github.com/worldwonderer/video-recap-skills
+Install this plugin: https://github.com/zenstory-ai/video-recap-skills
 ```
 
 #### Codex CLI
 
 ```bash
-codex plugin marketplace add worldwonderer/video-recap-skills
+codex plugin marketplace add zenstory-ai/video-recap-skills
 codex plugin add video-recap-skills@video-recap
 ```
 
@@ -108,7 +108,7 @@ For a local checkout, replace the marketplace source in the first command with i
 The official [OpenCode Agent Skills documentation](https://opencode.ai/docs/skills/) defines project skills under `.opencode/skills/<name>/SKILL.md`. Clone the repository and start OpenCode from that directory:
 
 ```bash
-git clone https://github.com/worldwonderer/video-recap-skills.git
+git clone https://github.com/zenstory-ai/video-recap-skills.git
 cd video-recap-skills
 mkdir -p .opencode
 ln -s ../skills .opencode/skills             # macOS / Linux

--- a/README.md
+++ b/README.md
@@ -84,20 +84,20 @@ export FISH_TTS_REFERENCE_ID=your-voice-model-id  # 可选；覆盖内置“娱�
 在 Claude Code 内执行：
 
 ```text
-/plugin marketplace add worldwonderer/video-recap-skills
+/plugin marketplace add zenstory-ai/video-recap-skills
 /plugin install video-recap-skills@video-recap
 ```
 
 也可以直接说：
 
 ```text
-安装这个插件：https://github.com/worldwonderer/video-recap-skills
+安装这个插件：https://github.com/zenstory-ai/video-recap-skills
 ```
 
 #### Codex CLI
 
 ```bash
-codex plugin marketplace add worldwonderer/video-recap-skills
+codex plugin marketplace add zenstory-ai/video-recap-skills
 codex plugin add video-recap-skills@video-recap
 ```
 
@@ -108,7 +108,7 @@ codex plugin add video-recap-skills@video-recap
 [OpenCode 官方 Agent Skills 文档](https://opencode.ai/docs/skills/)规定项目级技能放在 `.opencode/skills/<name>/SKILL.md`。克隆仓库后，从仓库目录启动 OpenCode：
 
 ```bash
-git clone https://github.com/worldwonderer/video-recap-skills.git
+git clone https://github.com/zenstory-ai/video-recap-skills.git
 cd video-recap-skills
 mkdir -p .opencode
 ln -s ../skills .opencode/skills             # macOS / Linux

--- a/tests/orchestrator/test_plugin_manifest.py
+++ b/tests/orchestrator/test_plugin_manifest.py
@@ -93,7 +93,7 @@ def test_public_readmes_are_skill_first_and_document_verified_hosts():
     }
 
     for language, text in readmes.items():
-        assert "codex plugin marketplace add worldwonderer/video-recap-skills" in text, language
+        assert "codex plugin marketplace add zenstory-ai/video-recap-skills" in text, language
         assert "codex plugin add video-recap-skills@video-recap" in text, language
         assert "https://opencode.ai/docs/skills/" in text, language
         assert "opencode debug skill" in text, language


### PR DESCRIPTION
## Summary
- update canonical repository and installation references to `zenstory-ai/video-recap-skills`
- update the marketplace homepage and its regression assertion
- preserve product behavior, attribution, and release artifacts

## Verification
- registered patch head: `76f29fde6000ebdba40778ebceacd0e5a51f42c2`
- `ruff check skills tests scripts` passed locally
- `python scripts/test.py` passed locally (295 + 104 + 244 + 24 tests)
