### PR TITLE
security: declare validation workflow permissions

### DIFF
--- a/.github/workflows/skill-validate.yml
+++ b/.github/workflows/skill-validate.yml
@@ -4,6 +4,9 @@ on:
   # here would let docs-only PRs stall forever under branch protection.
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     strategy:


### PR DESCRIPTION
## Summary

Declare the validation workflow's token permissions explicitly and limit it to read-only repository contents.

## Validation

- parsed `.github/workflows/skill-validate.yml` as YAML
- `git diff --check`

No skill runtime code or dependency is changed.
