### PR TITLE
docs(changelog): 采用组织统一的发布标准

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-All notable changes to this project are documented here. This project adheres to
-[Semantic Versioning](https://semver.org/).
+All notable changes to this project are documented here.
+
+格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
+版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
+
+小节名统一使用 Keep a Changelog 的六个英文类别（`Added` / `Changed` / `Deprecated` /
+`Removed` / `Fixed` / `Security`），正文为中文。收紧到会拒绝旧输入的改动记入 `Changed`。
 
 ## [Unreleased]
 
@@ -264,3 +269,14 @@ recap feels like a recap, not captions over a clip.
 - Initial release: turn any video into a Chinese-narration recap on `ffmpeg` + one Xiaomi
   MiMo API key. Five independent skills (understanding, script, cut, voiceover, assemble)
   plus a thin orchestrator; optional 剪映 draft export.
+
+[Unreleased]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.3.3...v0.4.0
+[0.3.3]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.3.1...v0.3.2
+[0.3.0]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.2.3...v0.3.0
+[0.2.3]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/zenstory-ai/video-recap-skills/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/zenstory-ai/video-recap-skills/releases/tag/v0.1.0


### PR DESCRIPTION
按 [zenstory-ai/.github 的 `release-writing` skill](https://github.com/zenstory-ai/.github/tree/main/skills/release-writing) 把本仓库的 CHANGELOG 对齐到组织标准。

## 改了什么

**补上底部链接引用（本次主要修复）。** 本文件所有版本标题都写成 `## [0.4.0] - 2026-07-27` 这种方括号形式，但文件里**一条链接引用都没有**——那些方括号此前不指向任何东西。现已为 9 个版本各补一行 compare 链接。

**头部补上 Keep a Changelog 与分级说明。** 此前只提 Semantic Versioning。现在写明小节名用六个英文类别、正文用中文，以及「收紧到会拒绝旧输入的记入 `Changed`」——让下一次发版不用重新推断。

**不重写历史。** 既有小节保留中文标题，英文类别从下一次发版开始用。

## 一个需要单独处理的发现

`v0.3.1` **有 tag、有 release，但 CHANGELOG 里没有对应小节**。

因此本 PR 的 compare 区间是按**实际 tag 相邻关系**生成的，不是按标题相邻——否则 `[0.3.2]` 会写成 `v0.3.0...v0.3.2`，跨掉一个版本。已逐条校验，全部为相邻区间。

缺失的那一节我没有补——那属于补写历史，应该由知道 v0.3.1 实际内容的人来写（release notes 里有：英→中配音模式、语速校准、doctor 预检）。

## 验证

```
compare 区间非相邻数: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)